### PR TITLE
Add markdown ingestion CLI

### DIFF
--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,18 +1,68 @@
-"""Simple markdown ingest script."""
+"""Utilities for ingesting markdown files into a local vector database."""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+import re
 from pathlib import Path
+from typing import Iterable, List
 
 import markdown
 
 
-def ingest_markdown(path: Path, chunk_size: int = 500):
-    """Yield text chunks from markdown files."""
-    text = Path(path).read_text()
-    html = markdown.markdown(text)
-    words = html.split()
-    for i in range(0, len(words), chunk_size):
-        yield " ".join(words[i : i + chunk_size])
+TOKEN_REGEX = re.compile(r"\b\w+\b", re.UNICODE)
+
+
+def ingest_markdown(path: Path, chunk_size: int = 500) -> Iterable[str]:
+    """Yield token chunks from markdown files."""
+    text = Path(path).read_text(encoding="utf-8")
+    tokens = TOKEN_REGEX.findall(markdown.markdown(text))
+    for i in range(0, len(tokens), chunk_size):
+        yield " ".join(tokens[i : i + chunk_size])
+
+
+def embed(text: str) -> List[float]:
+    """Return a simple numeric embedding for ``text``."""
+    return [float(hash(text) % 1000000)]
+
+
+class VectorDB:
+    """Very small local vector database stub."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        if path.exists():
+            with path.open("rb") as f:
+                self.data = pickle.load(f)
+        else:
+            self.data = []
+
+    def add_texts(self, texts: Iterable[str]):
+        embeddings = [embed(t) for t in texts]
+        self.data.extend(zip(embeddings, texts))
+        with self.path.open("wb") as f:
+            pickle.dump(self.data, f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Ingest markdown into a vector database"
+    )
+    parser.add_argument("input", type=Path, help="Markdown file to ingest")
+    parser.add_argument(
+        "--db",
+        dest="db",
+        type=Path,
+        default=Path("vector_db.pkl"),
+        help="Database file",
+    )
+    args = parser.parse_args()
+
+    chunks = list(ingest_markdown(args.input))
+    db = VectorDB(args.db)
+    db.add_texts(chunks)
 
 
 if __name__ == "__main__":
-    for chunk in ingest_markdown(Path("../ai-research/logical-chunking.md")):
-        print(len(chunk.split()))
+    main()


### PR DESCRIPTION
## Summary
- ingest 500-token markdown chunks with a stub vector DB
- expose command-line interface to specify input file and DB path

## Testing
- `black --check scripts/ingest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882963a3d2c8326ae2ac90b002f5ca2