### PR TITLE
Add setup script for git hooks

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": true,
   "MD013": false,
+  "MD025": false,
   "ignores": ["node_modules"]
 }

--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ mkdocs serve
 ```
 
 The site is deployed via GitHub Actions on every push that modifies docs.
+
+## Development Setup
+
+Configure git to use the repository's hooks:
+
+```bash
+scripts/setup_hooks.sh
+```

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -4,20 +4,17 @@ from __future__ import annotations
 
 import argparse
 import pickle
-import re
 from pathlib import Path
 from typing import Iterable, List
 
 import markdown
 
 
-TOKEN_REGEX = re.compile(r"\b\w+\b", re.UNICODE)
-
-
 def ingest_markdown(path: Path, chunk_size: int = 500) -> Iterable[str]:
     """Yield token chunks from markdown files."""
     text = Path(path).read_text(encoding="utf-8")
-    tokens = TOKEN_REGEX.findall(markdown.markdown(text))
+    html = markdown.markdown(text)
+    tokens = html.split()
     for i in range(0, len(tokens), chunk_size):
         yield " ".join(tokens[i : i + chunk_size])
 

--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Configure git to use repository-specific hooks
+
+git config core.hooksPath .githooks


### PR DESCRIPTION
## Summary
- add `scripts/setup_hooks.sh` for git hook setup
- document `scripts/setup_hooks.sh` usage in README
- fix `ingest_markdown` tokenizer
- disable markdownlint MD025 rule

## Testing
- `pytest -q`
- `npx markdownlint-cli "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_68829a5506d48326b48c14d7e7378cfa