### PR TITLE
Add doc migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,21 @@ Configure git to use the repository's hooks:
 ```bash
 scripts/setup_hooks.sh
 ```
+
+## Importing Legacy Docs
+
+You can import configuration and prompt snippets from the old
+[`d0tTino/d0tTino`](https://github.com/d0tTino/d0tTino) repository.
+Run the migration script from the repository root:
+
+```bash
+scripts/migrate_old_docs.sh
+```
+
+The script clones the legacy repo, filters only the documentation
+files using `git filter-repo`, and fetches the result as a local branch
+called `d0tTino-import`. Merge that branch to incorporate the history:
+
+```bash
+git merge d0tTino-import --allow-unrelated-histories
+```

--- a/scripts/migrate_old_docs.sh
+++ b/scripts/migrate_old_docs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Migrate documentation from the old d0tTino repository.
+#
+# This script clones the old repo and uses git filter-repo to keep only
+# documentation related paths. The filtered history is then fetched into the
+# current repository as the branch `d0tTino-import`.
+#
+# Usage: ./scripts/migrate_old_docs.sh
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TMP_DIR=$(mktemp -d)
+
+# Clone the legacy repo
+git clone https://github.com/d0tTino/d0tTino.git "$TMP_DIR"
+
+# Filter to just documentation paths and rewrite under old_docs/d0tTino/
+git -C "$TMP_DIR" filter-repo --force \
+  --path README.md \
+  --path dotfiles \
+  --path llm \
+  --path oh-my-posh \
+  --path vscode \
+  --path windows-terminal \
+  --to-subdirectory-filter old_docs/d0tTino
+
+# Import the filtered history as a local branch
+git -C "$REPO_ROOT" fetch "$TMP_DIR" +HEAD:d0tTino-import
+
+echo "Filtered history available on branch 'd0tTino-import'." >&2
+echo "Merge it with: git merge d0tTino-import --allow-unrelated-histories" >&2
+
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
## Summary
- migrate old docs with a new script using `git filter-repo`
- document how to fetch legacy docs from `d0tTino/d0tTino`

## Testing
- `pytest -q`
- `npx markdownlint-cli "**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_6882c8e6db588326ba051046fe718c53