### PR TITLE
Add plain text ingestion with chunk-size CLI

### DIFF
--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -6,15 +6,17 @@ import argparse
 import pickle
 from pathlib import Path
 from typing import Iterable, List
+import re
 
 import markdown
 
 
 def ingest_markdown(path: Path, chunk_size: int = 500) -> Iterable[str]:
-    """Yield token chunks from markdown files."""
+    """Yield token chunks from a markdown file converted to plain text."""
     text = Path(path).read_text(encoding="utf-8")
     html = markdown.markdown(text)
-    tokens = html.split()
+    plain_text = re.sub(r"<[^>]+>", "", html)
+    tokens = plain_text.split()
     for i in range(0, len(tokens), chunk_size):
         yield " ".join(tokens[i : i + chunk_size])
 
@@ -43,8 +45,9 @@ class VectorDB:
 
 
 def main() -> None:
+    """CLI entry point for ingesting markdown into a vector database."""
     parser = argparse.ArgumentParser(
-        description="Ingest markdown into a vector database"
+        description="Ingest markdown into a vector database",
     )
     parser.add_argument("input", type=Path, help="Markdown file to ingest")
     parser.add_argument(
@@ -54,9 +57,16 @@ def main() -> None:
         default=Path("vector_db.pkl"),
         help="Database file",
     )
+    parser.add_argument(
+        "--chunk-size",
+        dest="chunk_size",
+        type=int,
+        default=500,
+        help="Number of tokens per chunk",
+    )
     args = parser.parse_args()
 
-    chunks = list(ingest_markdown(args.input))
+    chunks = list(ingest_markdown(args.input, chunk_size=args.chunk_size))
     db = VectorDB(args.db)
     db.add_texts(chunks)
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -17,11 +17,11 @@ def test_ingest_chunking(tmp_path):
     chunks = list(ingest_markdown(md_file, chunk_size=3))
 
     assert chunks == [
-        "<p>This is a",
+        "This is a",
         "simple test file",
         "with enough words",
         "to form multiple",
-        "chunks.</p>",
+        "chunks.",
     ]
 
 
@@ -39,7 +39,7 @@ def test_db_upload_stub(tmp_path):
         upload_stub(chunk)
 
     assert uploaded == [
-        "<p>Alpha beta",
+        "Alpha beta",
         "gamma delta",
-        "epsilon zeta</p>",
+        "epsilon zeta",
     ]


### PR DESCRIPTION
## Summary
- tokenize Markdown by stripping HTML tags first
- expose `--chunk-size` option for ingestion script
- update ingest docstrings
- adjust tests for new behavior

## Testing
- `npx markdownlint-cli "**/*.md"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d3e17b5c8326991640544283b8fc