### PR TITLE
Ensure deterministic embeddings

### DIFF
--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -7,7 +7,7 @@ import pickle
 import re
 from pathlib import Path
 from typing import Iterable, List
-import re
+import hashlib
 
 import markdown
 
@@ -25,7 +25,9 @@ def ingest_markdown(path: Path, chunk_size: int = 500) -> Iterable[str]:
 
 def embed(text: str) -> List[float]:
     """Return a simple numeric embedding for ``text``."""
-    return [float(hash(text) % 1000000)]
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    value = int(digest, 16) % 1000000
+    return [float(value)]
 
 
 class VectorDB:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -7,7 +7,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from scripts.ingest import ingest_markdown, VectorDB
+from scripts.ingest import ingest_markdown, VectorDB, embed
 
 
 def test_ingest_chunking(tmp_path):
@@ -51,3 +51,15 @@ def test_cli_chunk_size_and_persistence(tmp_path):
 
     reloaded = VectorDB(db_file)
     assert reloaded.data == db.data
+
+
+def test_embed_deterministic():
+    script = (
+        "import sys; "
+        f"sys.path.append('{str(ROOT)}'); "
+        "from scripts.ingest import embed; "
+        "print(embed('deterministic'))"
+    )
+    result1 = subprocess.check_output([sys.executable, "-c", script])
+    result2 = subprocess.check_output([sys.executable, "-c", script])
+    assert result1 == result2


### PR DESCRIPTION
## Summary
- remove duplicate `import re`
- add `hashlib` usage to make embeddings deterministic
- test that embeddings remain consistent across runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e5b32ac08326b8c6f784d7488434