### PR TITLE
Add VectorDB querying ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ To fetch updates from all submodules later on, run:
 git submodule update --remote
 ```
 
-
 ## After Cloning
 
 Set up Git LFS and repository hooks after cloning:
@@ -90,4 +89,22 @@ called `d0tTino-import`. Merge that branch to incorporate the history:
 
 ```bash
 git merge d0tTino-import --allow-unrelated-histories
+```
+
+## Ingesting and Querying Markdown
+
+The `scripts/ingest.py` helper can store markdown chunks in a simple
+vector database and retrieve them later:
+
+```bash
+# Build the database
+python scripts/ingest.py docs/example.md --db vector_db.pkl
+
+# Query for similar text
+python - <<'EOF'
+from pathlib import Path
+from scripts.ingest import VectorDB
+db = VectorDB(Path('vector_db.pkl'))
+print(db.query('search text'))
+EOF
 ```

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -47,6 +47,21 @@ class VectorDB:
         with self.path.open("wb") as f:
             pickle.dump(self.data, f)
 
+    def query(self, text: str, top_k: int = 1) -> List[str]:
+        """Return the ``top_k`` most similar chunks to ``text``."""
+        if not self.data:
+            return []
+        target = embed(text)
+        scored = [
+            (
+                sum((e - t) ** 2 for e, t in zip(vec, target)) ** 0.5,
+                chunk,
+            )
+            for vec, chunk in self.data
+        ]
+        scored.sort(key=lambda x: x[0])
+        return [c for _, c in scored[:top_k]]
+
 
 def main() -> None:
     """CLI entry point for ingesting markdown into a vector database."""

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -63,3 +63,18 @@ def test_embed_deterministic():
     result1 = subprocess.check_output([sys.executable, "-c", script])
     result2 = subprocess.check_output([sys.executable, "-c", script])
     assert result1 == result2
+
+
+def test_vector_db_query(tmp_path):
+    text = "Alpha beta gamma delta epsilon"
+    md_file = tmp_path / "query.md"
+    md_file.write_text(text)
+
+    db_file = tmp_path / "db.pkl"
+    chunks = list(ingest_markdown(md_file, chunk_size=2))
+    db = VectorDB(db_file)
+    db.add_texts(chunks)
+
+    assert db.query("gamma delta") == ["gamma delta"]
+    results = db.query("some query", top_k=2)
+    assert len(results) == 2


### PR DESCRIPTION
## Summary
- implement `query` in `scripts/ingest.py`
- document ingest/query workflow in README
- add retrieval tests for `VectorDB`

## Testing
- `pytest -q`
- `npx markdownlint-cli "**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_6882e9e461088326b917cd01104551d1