### PR TITLE
Add flake8 linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,3 @@
 #!/bin/sh
 npx markdownlint-cli "**/*.md"
+flake8

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,25 @@
+name: Python Lint
+
+on:
+  push:
+    paths:
+      - '**/*.py'
+  pull_request:
+    paths:
+      - '**/*.py'
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run flake8
+        run: flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs
 mkdocs-material
 mkdocs-monorepo-plugin
 pytest
+flake8

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -20,7 +20,7 @@ def ingest_markdown(path: Path, chunk_size: int = 500) -> Iterable[str]:
     tokens = plain.split()
 
     for i in range(0, len(tokens), chunk_size):
-        yield " ".join(tokens[i : i + chunk_size])
+        yield " ".join(tokens[i:i + chunk_size])
 
 
 def embed(text: str) -> List[float]:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2,12 +2,9 @@ from pathlib import Path
 import subprocess
 import sys
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
-
-from scripts.ingest import ingest_markdown, VectorDB, embed
+from scripts.ingest import ingest_markdown, VectorDB  # noqa: E402
 
 
 def test_ingest_chunking(tmp_path):


### PR DESCRIPTION
## Summary
- run `flake8` in git hooks and CI
- configure flake8
- require flake8 in requirements
- fix lint issues

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f2168c8483269143f54bfd958b95