### PR TITLE
Fix markdownlint MD012 violation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,6 @@ To fetch updates from all submodules later on, run:
 git submodule update --remote
 ```
 
-
 ## After Cloning
 
 Set up Git LFS and repository hooks after cloning:


### PR DESCRIPTION
## Summary
- remove an extra blank line in `docs/index.md`
- ensure markdownlint passes with no MD012 errors

## Testing
- `npx -y markdownlint-cli "**/*.md" | head`

------
https://chatgpt.com/codex/tasks/task_e_6883d1ab29a48326b4954d39410ae364