### PR TITLE
Add git-filter-repo check in migration script

### DIFF
--- a/scripts/migrate_old_docs.sh
+++ b/scripts/migrate_old_docs.sh
@@ -12,6 +12,12 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 TMP_DIR=$(mktemp -d)
 
+# Ensure git-filter-repo is installed before proceeding
+if ! command -v git-filter-repo >/dev/null; then
+    echo "git-filter-repo is required. Install it and retry." >&2
+    exit 1
+fi
+
 # Clone the legacy repo
 git clone https://github.com/d0tTino/d0tTino.git "$TMP_DIR"
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -34,6 +34,11 @@ def test_migrate_old_docs_git_commands(tmp_path):
     )
     fake_git.chmod(0o755)
 
+    # Provide a dummy git-filter-repo command for the script check
+    fake_filter_repo = tmp_path / "git-filter-repo"
+    fake_filter_repo.write_text("#!/bin/sh\nexit 0\n")
+    fake_filter_repo.chmod(0o755)
+
     env = os.environ.copy()
     env.update({
         "PATH": f"{tmp_path}:{env['PATH']}",
@@ -49,4 +54,3 @@ def test_migrate_old_docs_git_commands(tmp_path):
     assert commands[1].startswith("clone https://github.com/d0tTino/d0tTino.git")
     assert commands[2].startswith("-C") and "filter-repo" in commands[2]
     assert commands[3].startswith("-C") and commands[3].endswith("+HEAD:d0tTino-import")
-


### PR DESCRIPTION
## Summary
- fail fast if `git-filter-repo` isn't installed when migrating old docs
- fix `test_scripts.py` flake8 warning and mock `git-filter-repo`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d2e3dcfc8326b162d2d19fa51b4b