### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,5 +12,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install mkdocs-material mkdocs-monorepo-plugin
+      - run: pip install -r requirements.txt
+      - run: mkdocs build
       - run: mkdocs gh-deploy --force

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -49,4 +49,3 @@ def test_migrate_old_docs_git_commands(tmp_path):
     assert commands[1].startswith("clone https://github.com/d0tTino/d0tTino.git")
     assert commands[2].startswith("-C") and "filter-repo" in commands[2]
     assert commands[3].startswith("-C") and commands[3].endswith("+HEAD:d0tTino-import")
-


### PR DESCRIPTION
## Summary
- use requirements.txt for Python dependencies in docs workflow
- build docs before deploying them
- clean up trailing newline in test file so flake8 passes

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883d2e549548326b4944e38a4b50626