### PR TITLE
Add empty markdown ingestion test

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -75,3 +75,9 @@ def test_vector_db_query(tmp_path):
     assert db.query("gamma delta") == ["gamma delta"]
     results = db.query("some query", top_k=2)
     assert len(results) == 2
+
+
+def test_ingest_empty_file(tmp_path):
+    md_file = tmp_path / "empty.md"
+    md_file.write_text("")
+    assert list(ingest_markdown(md_file)) == []


### PR DESCRIPTION
## Summary
- ensure ingest_markdown handles empty files

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e4962fac8326bf69b72014f9862a