### PR TITLE
Add playbook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository aggregates documentation and research across multiple projects.
 - `culture-project/` – organizational culture project
 - `_project-docs/` – submodule mounts for individual projects
 - `scripts/` – helper scripts including ingest utilities
+- `playbooks/` – workflow and container playbooks
 
 ## Project Documentation Submodules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ This repository aggregates documentation and research across multiple projects.
 - `culture-project/` – organizational culture project
 - `_project-docs/` – submodule mounts for individual projects
 - `scripts/` – helper scripts including ingest utilities
+- `playbooks/` – workflow and container playbooks
 
 ## Project Documentation Submodules
 

--- a/playbooks/github-actions-workflows.md
+++ b/playbooks/github-actions-workflows.md
@@ -1,0 +1,19 @@
+# GitHub Actions Workflows
+
+This playbook summarizes the automated workflows that run in this repository.
+
+## Docs Deployment
+
+- Defined in `.github/workflows/docs.yml`.
+- Builds the MkDocs site and deploys it to GitHub Pages on every push that updates markdown files.
+
+## Linting
+
+- `markdownlint.yml` checks all Markdown files using `markdownlint-cli`.
+- `python-lint.yml` runs `flake8` against Python sources.
+
+## Tests
+
+- `tests.yml` executes the test suite with `pytest` when Python files change.
+
+These workflows keep the documentation site and helper scripts healthy.

--- a/playbooks/local-docker-build.md
+++ b/playbooks/local-docker-build.md
@@ -1,0 +1,16 @@
+# Local Docker Build
+
+Follow these steps to build and preview the documentation site inside a container.
+
+1. Ensure Docker is installed on your system.
+2. Build the image from the repository root:
+   ```bash
+   docker build -t docs-site -f Dockerfile .
+   ```
+3. Run the container and expose port 8000:
+   ```bash
+   docker run --rm -p 8000:8000 docs-site
+   ```
+4. Open `http://localhost:8000` to preview the site served by MkDocs.
+
+The Dockerfile installs dependencies and invokes `mkdocs serve` so you can iterate locally without affecting your host environment.


### PR DESCRIPTION
## Summary
- document GitHub Actions workflows
- document steps to build docs locally in Docker
- reference new `playbooks/` directory in the doc index and README

## Testing
- [no tests due to documentation changes](https://openai.com)

------
https://chatgpt.com/codex/tasks/task_e_6887a4090e088326824f88a59c504f86