### PR TITLE
Add initial ADR with numbering scheme

### DIFF
--- a/adr/0001-use-mkdocs.md
+++ b/adr/0001-use-mkdocs.md
@@ -1,0 +1,23 @@
+# 0001: Use MkDocs for Documentation
+
+## Status
+
+Accepted
+
+## Context
+
+We need a static site generator for publishing project documentation. The
+team is familiar with Markdown and wants a simple workflow for hosting docs
+on GitHub Pages.
+
+## Decision
+
+We will build the documentation site using [MkDocs](https://www.mkdocs.org/).
+The `mkdocs-material` theme and `mkdocs-monorepo-plugin` plugin are included
+for styling and multi-repository support.
+
+## Consequences
+
+Documentation can be built locally with `mkdocs serve` and deployed via the
+existing GitHub Actions workflow. Contributors must have Python installed to
+build the site.

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records
+
+This directory contains architecture decision records (ADRs) for the project.
+
+ADRs are numbered sequentially starting at 0001. Files use a zero-padded
+four-digit prefix followed by a short name, for example:
+
+```
+0001-use-mkdocs.md
+0002-add-search-plugin.md
+```
+
+Numbers are never reused. Once an ADR is written, its file name and number
+remain stable even if the decision is superseded.


### PR DESCRIPTION
## Summary
- document how to number Architecture Decision Records
- capture decision to build documentation using MkDocs

No tests were run since this change only adds documentation.


------
https://chatgpt.com/codex/tasks/task_e_6887a40258408326a48d74ff8308111e