### PR TITLE
Update markdownlintignore for external docs

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,3 @@
 node_modules
+
+_project-docs/


### PR DESCRIPTION
## Summary
- ignore `_project-docs/` in Markdown linting

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c95cbc488326a315d65da50c4b94