### PR TITLE
Fix pre-commit markdownlint command

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
-npx markdownlint-cli "**/*.md"
+npx -y markdownlint-cli "**/*.md"
 flake8 --exclude node_modules


### PR DESCRIPTION
## Summary
- update `.githooks/pre-commit` to supply `-y` to `npx` so markdownlint runs without prompts

## Testing
- `flake8 --exclude node_modules`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c95bd2308326af64e4206ed4fa95