### PR TITLE
Fix MkDocs installation instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,11 +53,11 @@ The hooks enforce Markdown linting with `pre-commit`.
 
 ## Building the Docs
 
-Install Python packages and build the site with
+Install Python packages from `requirements.txt` and build the site with
 [MkDocs](https://www.mkdocs.org/):
 
 ```bash
-pip install mkdocs mkdocs-material mkdocs-monorepo-plugin
+pip install -r requirements.txt
 mkdocs serve
 ```
 


### PR DESCRIPTION
## Summary
- make docs use `pip install -r requirements.txt` for building the docs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887dbf1b91483268fc4a651c7b4123a