### PR TITLE
Add test for empty VectorDB query

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -81,3 +81,9 @@ def test_ingest_empty_file(tmp_path):
     md_file = tmp_path / "empty.md"
     md_file.write_text("")
     assert list(ingest_markdown(md_file)) == []
+
+
+def test_vector_db_query_empty(tmp_path):
+    db_file = tmp_path / "empty.pkl"
+    db = VectorDB(db_file)
+    assert db.query("anything") == []


### PR DESCRIPTION
## Summary
- ensure query on an empty VectorDB returns an empty list

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6887eadf39148326ae35294876f33ccf