### PR TITLE
Add research doc on energy-efficient LLM swarms

### DIFF
--- a/docs/ai-research/energy-efficient-swarm.md
+++ b/docs/ai-research/energy-efficient-swarm.md
@@ -1,0 +1,644 @@
+---
+title: "The Energy-Efficient Swarm: A Playbook for High-Density, Multi-Agent LLM Deployment on Consumer GPUs"
+tags: [ai-research, llm, energy, multi-agent]
+project: ai-research
+updated: 2025-07-28
+---
+# The Energy-Efficient Swarm: A Playbook for High-Density, Multi-Agent LLM Deployment on Consumer GPUs
+
+## Section 1: The Foundation - Model Quantization for VRAM-Constrained Environments
+
+The fundamental challenge in deploying a multi-agent system on a single consumer-grade GPU is
+managing the finite video random-access memory (VRAM). The target hardware, an NVIDIA RTX 4080
+SUPER, is equipped with 16 GB of VRAM. A standard 7-billion parameter Large Language Model (LLM) in
+its native 16-bit floating-point (FP16) precision requires approximately 14 GB of VRAM for its
+weights alone, making the deployment of even a single agent model, let alone a swarm of five or
+more, an impossibility. Consequently, model quantization---the process of reducing the numerical
+precision of a model's weights and potentially its activations---is not merely an optimization but a
+foundational requirement. This section provides a rigorous analysis of the leading quantization
+techniques, evaluates their impact on model reasoning capabilities, and culminates in a definitive
+recommendation for the optimal format to enable a high-density swarm of 4-7B parameter class models
+within the 16 GB VRAM envelope. 1.1 A Comparative Analysis: GGUF, AWQ, and the State of 4-Bit
+Quantization The landscape of 4-bit quantization is dominated by several competing formats and
+methodologies, each with distinct trade-offs in terms of performance, flexibility, and VRAM
+footprint. An understanding of these trade-offs is critical to selecting the correct foundation for
+the system architecture. GGUF (GPT-Generated Unified Format): GGUF has emerged as a de facto
+standard in the local LLM community, primarily due to its exceptional flexibility. Its core design
+principle is to be backend-agnostic, enabling execution on both CPUs and GPUs. The most critical
+feature for this project is its native support for layer-splitting, a technique where a model's
+layers can be strategically divided between GPU VRAM and system RAM.1 This allows for a granular
+trade-off between performance and memory usage; the most frequently used and performance-critical
+layers (e.g., attention layers) can be loaded into VRAM for maximum speed, while less critical
+layers are offloaded to the much larger, albeit slower, system RAM. This capability is expertly
+leveraged by inference engines like llama.cpp, making GGUF the premier format for environments with
+severe VRAM constraints.1 AWQ (Activation-Aware Weight Quantization): AWQ is a sophisticated
+post-training quantization (PTQ) method that operates on the principle that not all weights are
+equally important. By analyzing the activation magnitudes during a calibration pass, AWQ identifies
+and preserves the precision of "salient" weights that are most critical to the model's performance,
+while more aggressively quantizing less important ones.1 This activation-aware approach has proven
+particularly effective for instruction-tuned and multi-modal LLMs, often yielding superior
+performance preservation compared to more naive quantization schemes. AWQ is heavily optimized for
+GPU-only inference and is well-supported by high-performance runtimes such as NVIDIA's TensorRT-LLM
+and LMDeploy.3 GPTQ (Generalized Post-Training Quantization): GPTQ is another widely adopted PTQ
+method that focuses on GPU inference. It employs a layer-wise quantization approach that uses
+approximate second-order Hessian information to minimize quantization error, achieving a strong
+balance between compression and accuracy.1 Like AWQ, GPTQ is designed for scenarios where the entire
+model can reside within GPU VRAM and is supported by a wide range of GPU hardware and inference
+backends. QLoRA and FlexGen: It is important to distinguish between quantization formats and the
+techniques or engines that use them. QLoRA is a parameter-efficient fine-tuning (PEFT) method, not
+an inference format. It involves quantizing a base model to 4-bits (using a format called NF4) and
+then training small, low-rank adapters on top of it.6 While highly effective for reducing memory
+during training, the output is a set of adapter weights, not a standalone quantized model for
+deployment. FlexGen is an inference engine designed for high-throughput generation on severely
+resource-constrained hardware, such as a single 16 GB GPU running a 175-billion parameter model.8 It
+achieves this through an aggressive offloading strategy that pages model tensors (weights,
+activations, and the KV cache) not just to CPU RAM but also to disk storage (e.g., NVMe SSDs).
+FlexGen internally uses 4-bit group-wise quantization to compress these tensors and minimize I/O
+overhead.10 While a powerful demonstration of VRAM optimization, its reliance on disk I/O introduces
+significant latency, making it unsuitable for the project's target of ≤800 ms per agent turn.
+However, it remains a valuable tool for risk mitigation and non-interactive, batch-processing tasks.
+
+1.2 Preserving Intelligence: Mitigating Reasoning Degradation on MMLU & GSM8K The primary risk of
+aggressive 4-bit quantization is not a subtle drop in perplexity but a catastrophic degradation of a
+model's complex reasoning abilities. This is the single greatest threat to the viability of a
+multi-agent system, where agents are often tasked with specialized reasoning. Empirical studies have
+quantified this degradation starkly: one analysis reported an average quality drop of 12% across
+multiple benchmarks, with performance on the Grade School Math (GSM8K) benchmark plummeting by
+28%.12 Another recent study on mathematical reasoning found that quantization can degrade accuracy
+by as much as 69.81% on complex benchmarks like MATH and AIME.13 An agent that cannot reason is
+ineffective, regardless of how efficiently it runs. Recent research has not only identified the
+cause of this degradation but has also proposed actionable mitigation strategies. The Root Cause:
+Activation Outliers: The performance collapse is not due to a uniform loss of information. Instead,
+it is primarily caused by the emergence of extreme outliers in the activation tensors during
+inference.15 These outliers, which can be orders of magnitude larger than typical activation values,
+force the quantization algorithm to use a very large scaling factor. This "stretches" the
+quantization grid to accommodate the outlier, leaving very few discrete quantization levels for the
+vast majority of normal-value activations, resulting in a massive loss of information and
+precision.16 Critically, these outliers are now understood to be a byproduct of standard LLM
+pre-training methodologies, particularly the use of adaptive optimizers like Adam and certain
+normalization schemes, rather than an inherent property of the Transformer architecture itself.15
+Mitigation Strategy 1: Outlier-Safe Pre-Training (OSP): The most fundamental solution is to prevent
+outliers from forming in the first place. The "Outlier-Safe Pre-Training" (OSP) framework proposes a
+set of practical guidelines for training quantization-friendly LLMs from scratch.15 By replacing the
+Adam optimizer with alternatives like Muon and using techniques such as Single-Scale RMSNorm, OSP
+produces models that are inherently free of activation outliers. An OSP-trained model, when
+subjected to aggressive 4-bit quantization, demonstrates dramatically superior performance
+preservation compared to a traditionally trained model.18 This provides a clear directive for model
+selection: to maximize post-quantization quality, George should prioritize models that are
+explicitly advertised as being trained using OSP or similar quantization-aware techniques.
+Mitigation Strategy 2: In-situ Correction with "Silver Bullet" Datasets (InfiJanice): For existing
+models that were not trained with OSP and suffer from quantization-induced degradation, a post-hoc
+repair mechanism has been developed. The "InfiJanice" methodology involves a three-step process 13:
+Identify Failures: The quantized model is run on a reasoning benchmark (e.g., GSM8K), and its
+incorrect reasoning traces are collected. Curate "Silver Bullet" Data: An automated pipeline, often
+using a more powerful "expert" model, analyzes the failure cases to identify the specific reasoning
+steps where errors occur. It then generates correct reasoning paths for these specific problems,
+creating a small, highly targeted dataset of "correct/incorrect" preference pairs. Rapid
+Fine-Tuning: The degraded, quantized model is then fine-tuned for a very short period (e.g., 3-5
+minutes on a single GPU) on this "Silver Bullet" dataset using a technique like Direct Preference
+Optimization (DPO). This process has been shown to be remarkably effective, restoring the
+mathematical reasoning accuracy of a 4-bit model to the level of its full-precision counterpart
+without harming its general capabilities. This transforms the problem of poor quantization
+performance from an immutable fact into a solvable engineering challenge, providing an actionable
+recipe to repair and enhance the chosen agent models.
+
+1.3 Recommendation: The Optimal Format for a 4-7B Parameter Swarm on 16GB VRAM Based on the analysis
+of the project's core constraints, GGUF is the recommended quantization format for the multi-agent
+system. The justification for this choice is not based on a single metric like raw speed but on the
+holistic requirements of the system architecture. The primary, non-negotiable constraint is fitting
+at least five 7-billion parameter models onto a single 16 GB GPU. A 4-bit quantized 7B model
+requires approximately 4.5 GB of VRAM for its weights. Loading five such models would require
+5×4.5 GB=22.5 GB, which exceeds the available 16 GB budget, even before accounting for the KV cache,
+activations, and framework overhead. This calculation reveals a critical architectural insight: some
+form of memory offloading from VRAM to system RAM is not an optional optimization but a fundamental
+necessity. The system cannot function without it. This necessity dictates the choice of format and
+runtime. While AWQ and GPTQ are highly performant when a model fits entirely in VRAM, their support
+for flexible, granular layer-offloading to system RAM is less mature and not a primary design
+feature. In contrast, the GGUF format, in conjunction with the llama.cpp inference engine, is built
+around this concept. It provides a simple, robust, and widely-supported mechanism (n_gpu_layers
+parameter) to precisely control the VRAM/RAM split for each model. This allows for the creation of a
+stable, co-resident swarm of agents by allocating a specific VRAM "budget" to each one, ensuring the
+total VRAM usage remains under the 16 GB limit. The performance penalty incurred by accessing some
+layers from system RAM over the PCIe bus is an acceptable trade-off for achieving the required model
+density. Quantization Method (7B Model) Est. VRAM (Weights) Est. Throughput (tok/s) MMLU Score (%
+Drop) GSM8K Score (% Drop) Key Feature for Multi-Agent System FP16 (Baseline) ∼14 GB ∼400% 0% Not
+Viable (OOM) AWQ (4-bit) ∼4.5 GB \>120 ∼1−3% ∼5−15% High performance for fully VRAM-resident models
+GGUF (Q4_K_M) Variable (user-set) ∼106 (full GPU) ∼2−5% ∼10−28% Flexible CPU/GPU layer offloading
+for VRAM management FlexGen (4-bit) Variable (user-set) ∼1 (for 175B) Low Low Extreme offloading to
+CPU/Disk (high latency) Table 1.1: A comparative analysis of quantization methods for a 7B model on
+an RTX 4080 SUPER. Throughput for GGUF is based on benchmarks with full GPU offload.23 Performance
+drops are representative estimates based on community reports and benchmarks.12 The key feature
+column highlights the architectural relevance of each method.
+
+## Section 2: The Engine Room - Benchmarking and Selecting an Inference Runtime
+
+With GGUF established as the optimal model format for its memory flexibility, the next critical
+decision is the choice of inference runtime. The runtime is the software engine that loads the
+quantized model, manages the GPU, and executes inference requests. Its efficiency directly impacts
+both latency and throughput. This section benchmarks the leading open-source runtimes on the target
+RTX 4080 SUPER hardware and provides a recommendation tailored to the specific demands of a
+high-density, offloading-heavy multi-agent system.
+
+2.1 Throughput vs. Latency: vLLM, TensorRT-LLM, and LMDeploy on the RTX 4080 SUPER While numerous
+inference engines exist, a few stand out for their performance and feature sets on NVIDIA hardware.
+TensorRT-LLM: This is NVIDIA's open-source library for high-performance LLM inference, built on top
+of the TensorRT deep learning compiler.26 Its primary advantage is raw speed. By compiling a model
+into a highly optimized engine specifically for a target GPU architecture (e.g., Ada Lovelace for
+the RTX 4080 SUPER), it can achieve significant performance gains. Benchmarks on an RTX 4090 show
+TensorRT-LLM can be 30-70% faster than llama.cpp for single-stream throughput.3 This performance
+comes at the cost of increased complexity---each model must be explicitly compiled for the target
+GPU---and reduced flexibility, as it is tightly coupled to the NVIDIA ecosystem.27 vLLM: Developed
+at UC Berkeley, vLLM's key innovation is PagedAttention, a novel memory management algorithm for the
+KV cache that dramatically improves throughput for concurrent requests.28 Combined with Continuous
+Batching, vLLM excels in high-throughput serving scenarios, often outperforming other frameworks by
+a significant margin when serving many simultaneous users to a single model.31 It strikes an
+excellent balance between high performance and ease of use, often requiring just a pip install.27
+LMDeploy: From the creators of MMRazor, LMDeploy features the TurboMind inference engine, which is
+heavily optimized for quantized models. It claims substantial speedups for 4-bit inference,
+potentially 2.4x faster than FP16 execution.27 It incorporates advanced features like persistent
+batching (another term for continuous batching) and a blocked KV cache, making it a strong
+competitor to vLLM, particularly in high-concurrency throughput benchmarks.4 llama.cpp: This
+C++-based engine is the canonical runtime for the GGUF format. Its primary strengths are not raw,
+single-stream speed but its unparalleled versatility, portability, and, most importantly, its
+first-class support for CPU/GPU hybrid execution via layer offloading.1 It is extremely memory
+efficient and has a minimal dependency footprint. While benchmarks show it is slower than
+specialized engines like TensorRT-LLM, its performance on modern GPUs is still formidable. For
+example, a Llama 3 8B Q4_K_M model can achieve over 100 tokens/second on an RTX 4080.23 Other
+Runtimes (MLC-LLM, Petals): The landscape includes other notable projects. MLC-LLM is a machine
+learning compiler that can deploy LLMs to a wide array of backends, including NVIDIA (CUDA/Vulkan),
+AMD, Apple Metal, and even web browsers via WebGPU, prioritizing universality.35 Petals is a unique
+engine for running extremely large models (100B+ parameters) by distributing layers across a
+peer-to-peer network of consumer GPUs, BitTorrent-style.37 While innovative, these are not directly
+applicable to the project's goal of a self-contained, single-GPU system.
+
+2.2 Deep Dive into Core Optimizations The performance of modern inference engines is driven by a
+handful of key algorithmic and systems-level optimizations. PagedAttention (vLLM): The KV cache is a
+major consumer of VRAM during inference, and its size grows with every generated token. Traditional
+systems allocate a contiguous block of memory for each sequence's cache, leading to significant
+internal and external fragmentation and wasted memory.38 PagedAttention solves this by borrowing
+concepts from operating system virtual memory.29 It partitions the KV cache into fixed-size "blocks"
+(analogous to memory pages) that are stored non-contiguously. A "block table" maps logical token
+positions to these physical blocks. This approach nearly eliminates memory waste (reducing it to
+\<4%), allows for flexible memory sharing between different requests, and dramatically increases the
+effective batch size the GPU can handle, boosting throughput by 2-4x.29 Continuous Batching (vLLM,
+LMDeploy): In contrast to static batching (where the server waits for a full batch before starting)
+or dynamic batching (which uses a timeout), continuous batching operates at the token level.39 The
+server processes the entire batch for a single token generation step. As soon as any sequence in the
+batch completes, it is evicted, and a new sequence from the waiting queue is immediately added to
+the batch for the very next step. This ensures the GPU is always operating at maximum capacity,
+eliminating the idle "bubbles" that occur in other batching strategies and maximizing hardware
+utilization.28 This is an ideal scheduling strategy for an event-driven system with many
+asynchronous agent requests. Speculative Decoding (TensorRT-LLM): This is a latency optimization
+technique that is particularly effective for low-batch-size or single-stream inference. It works by
+using a small, fast "draft model" to generate a candidate sequence of several tokens (e.g., 4-5
+tokens). This cheap speculation is then passed to the large, powerful "target model" for
+verification in a single forward pass.40 The target model accepts the draft tokens up to the first
+incorrect one. Since a single forward pass of the large model can validate multiple tokens, the
+average time per token is significantly reduced.41 This, however, adds the complexity of running and
+managing two models simultaneously. CUDA Graphs: Launching CUDA kernels from the CPU incurs a small
+but non-trivial overhead. In the token generation (decode) phase of an LLM, the sequence of kernel
+launches is identical for every step. CUDA Graphs exploit this by allowing the runtime to "capture"
+the entire sequence of operations for one step into a single graph object. This graph can then be
+"replayed" in subsequent steps with a single command, dramatically reducing CPU overhead and the
+latency between kernel executions.44 This optimization is now implemented in several engines,
+including recent versions of llama.cpp.22.3 Recommendation: The Optimal Runtime Configuration for
+Multi-Model Serving While frameworks like vLLM and TensorRT-LLM demonstrate superior performance in
+scenarios where models fit comfortably within VRAM, the architectural constraints of this project
+lead to a different conclusion. The optimal runtime configuration is a hybrid approach centered on
+llama.cpp (via its llama-cpp-python server binding) as the core inference server. The rationale is a
+direct continuation of the logic from Section 1. The primary challenge is not achieving the absolute
+maximum tokens/second for a single model, but rather enabling the stable co-residency of five or
+more models within a 16 GB VRAM budget. This makes efficient and controllable memory offloading the
+single most critical feature of the inference engine. llama.cpp is designed from the ground up to
+support the GGUF format and its CPU/GPU layer-splitting capability. This feature is mature, robust,
+and provides the necessary granular control to manage the VRAM budget across multiple,
+simultaneously loaded models. While vLLM does have mechanisms for using CPU memory as swap space, it
+is less explicit and controllable than llama.cpp's layer-based offloading.45 For this specific
+high-density use case, the architectural requirement for offloading outweighs the raw speed benefits
+of other engines. The performance of llama.cpp on an RTX 4080 SUPER is more than sufficient to meet
+the ≤800 ms latency target for typical agent interactions, which usually involve generating a few
+dozen tokens, not thousands. Engine Throughput (tok/s) Latency (ms/tok) VRAM (Model+Cache) Avg.
+Power (W) Key Feature for Multi-Agent TensorRT-LLM \~170 \~5.9 \~7.2 GB High Lowest latency via
+model compilation & speculative decoding vLLM \~130 \~7.7 \~7.0 GB High PagedAttention for
+high-throughput KV cache management LMDeploy \~140 \~7.1 \~6.8 GB High TurboMind engine optimized
+for 4-bit inference llama.cpp \~106 \~9.4 Variable Moderate Mature GGUF offloading for VRAM budget
+management Table 2.1: Representative benchmark data for a single Llama 3 8B 4-bit model on an RTX
+4090/4080 class GPU. TensorRT-LLM vs. llama.cpp data from.3 Other figures are derived from various
+benchmarks.23 Power is a qualitative estimate. The "Key Feature" column highlights the most relevant
+capability for George's specific high-density, VRAM-constrained use case, justifying the selection
+of llama.cpp.
+
+## Section 3: The Conductor - Scheduling and Routing for a Multi-Agent Collective
+
+Having established the foundational components---GGUF models executed by a llama.cpp server---this
+section addresses the system-level orchestration. A successful multi-agent system requires more than
+just efficient models; it needs an intelligent conductor to manage workloads, route tasks, and
+handle the complexities of shared resource management. Here, we design the scheduling and routing
+logic that will transform the collection of individual models into a cohesive, intelligent swarm.
+3.1 The Cost of Cognition: Quantifying and Mitigating GPU Context-Switching Overhead A naive
+approach to managing multiple models on one GPU might be to load each agent's model into VRAM only
+when it's needed---a "load-on-demand" strategy. This approach is fundamentally non-viable due to the
+prohibitive cost of GPU context switching. Unlike CPU context switching, which is a highly
+optimized, microsecond-level operation, swapping gigabytes of model data in and out of GPU VRAM is a
+heavyweight process dominated by PCIe bus transfer speeds.47 For a 4.5 GB quantized model on a PCIe
+4.0 x16 bus with a theoretical maximum bandwidth of \~32 GB/s, the transfer time alone would be in
+the hundreds of milliseconds, even before accounting for kernel launch overhead and memory
+allocation. Real-world experiments show that snapshot-loading a 13B model can take 2-5 seconds.48
+Research into pipelined context switching for deep learning models confirms that the overhead of
+transmitting model parameters is a significant performance bottleneck.49 The recent Prism multi-LLM
+serving system, which does employ model swapping for idle models, is designed for data center
+environments with different SLOs and still highlights the challenge of model activation latency.50
+For a system with a strict latency budget of ≤800 ms per agent turn, a multi-second loading delay
+for each turn is an immediate violation. This leads to a critical design principle: the system must
+avoid VRAM swapping of model weights at all costs during active operation. The only viable strategy
+is to ensure all active agent models are co-resident, with their layers pre-allocated between VRAM
+and system RAM at startup. The scheduler's role is therefore not to manage the physical loading of
+models, but to manage the logical flow of requests to these already-loaded models.
+
+3.2 Architecting the Router: Implementing "Cheapest Competent Model" Selection With multiple
+specialized agents co-resident, the system needs a mechanism to route incoming tasks to the correct
+agent. This routing decision is itself a complex task that can be handled by an LLM. The goal is to
+implement a "cheapest competent model" strategy: use the most resource-efficient model capable of
+making the routing decision, thereby preserving the computational power of the larger, specialized
+models for the tasks they are designed for. A comparison of agentic frameworks reveals the best tool
+for this purpose: CrewAI: A high-level framework that excels at orchestrating agents with predefined
+roles in a structured, often sequential, process.51 While it can connect to local models 54, its
+abstractions are less suited for building the kind of complex, conditional, low-level routing logic
+required here.56 DSPy: A powerful framework for programming with LLMs, focusing on algorithmic
+optimization of prompts and model parameters.57 It is not an agent orchestration framework. However,
+its ability to define and optimize modules with swappable LMs makes it an excellent tool for
+building the components of the router---for example, creating a highly optimized classification
+module that forms the core of the routing logic.59 LangGraph: This framework is the ideal choice for
+implementing the router. It represents workflows as explicit, stateful graphs where nodes are agents
+or tools and edges represent conditional logic.52 This provides the necessary low-level control to
+build a sophisticated, dynamic routing system. Its concepts of a "Supervisor" node and "Conditional
+Edges" are perfectly suited for implementing the desired architecture.51 The recommended router
+implementation strategy using LangGraph is as follows: The Supervisor Pattern: The entire workflow
+will be encapsulated in a LangGraph StateGraph. A central "supervisor" node will serve as the entry
+point for all incoming tasks.62 The Router LLM: The supervisor node will be powered by a very small
+and fast "router" LLM (e.g., a highly quantized 3B model like Phi-3-mini). Its sole purpose is to
+analyze the incoming task and output a classification indicating which specialized agent should
+handle it (e.g., {"next_agent": "code_generator"}). This embodies the "cheapest competent model"
+principle by offloading the high-frequency, low-complexity routing task to an efficient model.
+Conditional Edges: The supervisor node will be connected to all the specialized agent nodes via a
+conditional edge. This edge will execute a Python function that reads the next_agent field from the
+supervisor's output and directs the graph's execution flow to the corresponding agent node.66 Each
+agent node is a simple function that formats a request and calls its designated model endpoint on
+the llama.cpp server.
+
+3.3 Blueprint: A NATS-Integrated, Event-Driven Agent Scheduler The LangGraph router will be
+integrated into George's existing NATS-based, event-driven architecture. This ensures a decoupled,
+scalable system. Sequence of Operations: Task Ingestion: An external process publishes a task
+message to a NATS topic, e.g., tasks.new. The message payload contains the user prompt and any
+relevant metadata. Scheduler Service: A dedicated Python service subscribes to the tasks.new topic.
+Upon receiving a message, it instantiates and invokes the LangGraph router with the task payload as
+the initial state. Routing: The LangGraph supervisor node is executed. It calls the small router LLM
+to determine the appropriate destination agent. Conditional Handoff: The graph's conditional edge
+fires, routing the state to the selected agent node (e.g., code_agent). Inference Request: The
+code_agent node's function executes. It constructs an OpenAI-compatible API request and sends it to
+the llama.cpp server endpoint, specifying the particular model file it requires (e.g.,
+codellama-7b.Q4_K_M.gguf). Inference Execution: The llama.cpp server, which has all models
+pre-loaded with their respective VRAM/RAM layer splits, processes the request on the specified model
+and returns the result. Result Publication: The agent node receives the response, updates the
+graph's final state, and the graph execution concludes. The scheduler service then publishes the
+final result to an output topic, e.g., results.completed. Pseudocode for the LangGraph Router:
+
+``` python
+from typing import TypedDict, Annotated, Literal
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from langchain_core.messages import BaseMessage
+
+# 1. Define the shared state for the graph
+class AgentState(TypedDict):
+    messages: Annotated, add_messages]
+    next_agent: str
+
+# 2. Define the LLM clients (pointing to the llama.cpp server)
+router_llm = ChatOpenAI(model="phi-3-mini.Q4_K_M.gguf",...)
+coder_llm = ChatOpenAI(model="codellama-7b.Q4_K_M.gguf",...)
+writer_llm = ChatOpenAI(model="mistral-7b-instruct.Q4_K_M.gguf",...)
+
+# 3. Define the supervisor node (the router)
+def supervisor_node(state: AgentState):
+    # Use the small router_llm to decide the next step
+    response = router_llm.invoke(state['messages'])
+    return {"next_agent": response.content} # e.g., "coder" or "writer"
+
+# 4. Define the worker agent nodes
+def coder_node(state: AgentState):
+    response = coder_llm.invoke(state['messages'])
+    return {"messages": [response]}
+
+def writer_node(state: AgentState):
+    response = writer_llm.invoke(state['messages'])
+    return {"messages": [response]}
+
+# 5. Define the conditional routing logic
+def router_edge(state: AgentState) -> Literal["coder", "writer", "__end__"]:
+    if state["next_agent"] == "coder":
+        return "coder"
+    elif state["next_agent"] == "writer":
+        return "writer"
+    else:
+        return END
+
+# 6. Construct the graph
+workflow = StateGraph(AgentState)
+workflow.add_node("supervisor", supervisor_node)
+workflow.add_node("coder", coder_node)
+workflow.add_node("writer", writer_node)
+
+workflow.add_edge(START, "supervisor")
+workflow.add_conditional_edges(
+    "supervisor",
+    router_edge,
+    {"coder": "coder", "writer": "writer", "__end__": END}
+)
+workflow.add_edge("coder", END)
+workflow.add_edge("writer", END)
+
+# 7. Compile the graph
+app = workflow.compile()
+
+# The NATS subscriber would then call app.invoke(...)
+```
+
+
+## Section 4: The Power Profile - Achieving Sub-220W Operation
+
+Meeting the stringent average power draw target of ≤220 W for the GPU requires moving beyond default
+hardware settings and implementing a deliberate power management strategy. For a high-end card like
+the RTX 4080 SUPER, which has a Total Graphics Power (TGP) of 320W, this represents a significant
+reduction. This section provides a practical methodology for hardware tuning, efficiency
+measurement, and active power management to operate the agent swarm within this power budget. 4.1
+Hardware Tuning: A Practical Guide to Undervolting the RTX 4080 SUPER for AI Workloads
+
+The single most effective technique for reducing GPU power consumption is undervolting. GPUs are
+typically shipped with a conservative voltage-frequency curve designed to ensure stability across a
+wide range of silicon quality. However, most individual chips can operate at the same clock speeds
+using significantly less voltage, which quadratically reduces power consumption (P∝V2). This process
+yields substantial reductions in power draw and heat output with minimal, and often zero, impact on
+performance.68 Tooling: The recommended tool for this process is MSI Afterburner, a widely used
+utility for GPU overclocking, monitoring, and tuning.70 Step-by-Step Undervolting Process: Establish
+a Baseline: Before making any changes, run the multi-agent benchmark and use monitoring tools to
+record the stock performance, clock speed, voltage, and power draw. Open the Curve Editor: In MSI
+Afterburner, press Ctrl+F to open the Voltage/Frequency curve editor. This graph plots the GPU's
+core clock frequency (Y-axis) against its operating voltage (X-axis).69 Select a Target Point: Based
+on community testing for the RTX 4080 SUPER, a good starting point for an efficiency-focused
+undervolt is around 900-950mV.68 Select the point on the curve corresponding to your target voltage
+(e.g., 925mV). Set the Clock Speed: Drag this single point vertically to set the desired clock
+speed. A good starting point is to aim for a clock speed slightly below the stock boost clock
+observed in the baseline test (e.g., 2580 MHz at 925mV).68 Flatten the Curve: After setting the
+target point, press L to lock the voltage at that point. This creates a flat line on the curve
+editor, ensuring the GPU never exceeds the target voltage, regardless of load. Click the "Apply"
+checkmark in the main Afterburner window. Memory Overclock: The GDDR6X memory on the RTX 4080 SUPER
+is often underclocked from the factory.68 A moderate memory overclock (e.g., +500 to +1300 MHz in
+Afterburner) can reclaim some of the performance lost from the core undervolt and is considered a
+"free" performance boost. This should be tested for stability independently. Stability Testing for
+AI Workloads: It is crucial to understand that an undervolt stable for gaming may not be stable for
+AI inference. Gaming workloads heavily stress the CUDA cores and 3D rendering pipeline. In contrast,
+LLM inference places a sustained, heavy load on the Tensor Cores and the memory subsystem. Some
+users report that undervolts which pass gaming stress tests can crash when features that utilize
+Tensor Cores are activated.68 Therefore, the ultimate stability test must be running the actual
+5-agent workload for several hours to ensure the system is robust under its specific operational
+load.
+
+4.2 Measuring Efficiency: Profiling Watt-Hours per Million Tokens with pyNVML
+
+To empirically validate the effectiveness of undervolting and other power management strategies, a
+precise measurement methodology is required. The pyNVML Library: The nvidia-ml-py library provides
+Python bindings for the NVIDIA Management Library (NVML), which is the C API that underpins the
+nvidia-smi command-line tool.72 This allows for programmatic access to a rich set of GPU metrics,
+including real-time power consumption. Energy Profiling Notebook (Deliverable D4): A Jupyter
+notebook will be provided to automate the measurement process. The core of this notebook is a Python
+script that performs the following actions: Initialization: Imports the pynvml library and
+initializes it with nvmlInit(). It then gets a handle to the GPU device (e.g., device index 0).
+Monitoring Thread: It launches a background thread that enters a loop. Inside the loop, it calls
+nvmlDeviceGetPowerUsage(handle) at a fixed interval (e.g., every 1 second). This function returns
+the current power draw in milliwatts.72 Data Logging: Each power reading is converted to Watts and
+logged to a list along with a timestamp. Calculation and Visualization: When the main workload (the
+multi-agent benchmark) finishes, the monitoring thread is stopped. The script then uses the logged
+power data to: Calculate the average power draw over the entire run. Integrate the power readings
+over time to compute the total energy consumed in Watt-seconds, which is then converted to
+Watt-hours. Calculate the final efficiency metric: Watt-hours per 1 Million Tokens Generated, by
+dividing the total energy by the total number of tokens produced by the benchmark. Use matplotlib to
+generate a plot of power consumption over time, allowing for visual analysis of the power profile.
+
+4.3 Active Power Management Strategies
+
+Beyond static hardware tuning, the system's software can also contribute to power efficiency. Idle
+State Management: When the NATS message bus is quiet and no agents are processing tasks, the GPU
+should automatically enter a low-power idle state (P-State P8). Modern NVIDIA drivers manage this
+transition effectively. The energy profiling notebook can be used to verify that the GPU's idle
+power draw drops to a low level (typically 15-30W) during periods of inactivity. Consolidating
+Inference via Batching: The llama.cpp server supports batching requests. If multiple agent tasks
+arrive on the NATS bus within a short time window (e.g., 100ms), the scheduler service can be
+designed to group these requests and send them to the llama.cpp server as a single batch. Processing
+a batch of requests is more power-efficient than processing them sequentially, as it allows the GPU
+to reach a high-utilization state and complete the work more quickly, returning to idle sooner. This
+increases the overall computational density and reduces the total time spent in high-power states.
+Profile Name V/F Setting (mV/MHz) Avg. Power (5-agent load) Throughput vs. Stock W-h per 1M Tokens
+Stock Default Curve ∼285 W 100% ∼150 Efficiency Undervolt 925mV / 2580MHz ∼215 W 98% ∼115
+Performance Undervolt 975mV / 2700MHz ∼250 W 101% ∼130 Table 4.1: Projected power and efficiency
+profiles for an RTX 4080 SUPER under a simulated 5-agent LLM inference load. Settings are based on
+community reports.68 The "Efficiency Undervolt" profile is designed to meet the ≤220 W target with
+minimal performance loss, resulting in the best energy efficiency.
+
+## Section 5: The Integrated Stack - A Reproducible Build Recipe
+
+This section consolidates the preceding analysis into a concrete, deployable system. It provides the
+architectural blueprint and the necessary configuration files to replicate the entire multi-agent
+runtime environment, ensuring a seamless setup process from a fresh operating system installation.
+5.1 System Architecture Diagram The integrated system is composed of several loosely coupled
+services communicating via a central message bus. The architecture is designed for modularity and
+resilience. (A diagram would be included here, illustrating the following flow): NATS Message Bus:
+The central nervous system of the architecture. External clients publish tasks to topics like
+tasks.new. Agent Supervisor Service: A Python application that subscribes to task topics. It
+contains the LangGraph router, which uses a small "router" LLM to classify tasks. llama.cpp Server:
+A dedicated inference server that exposes an OpenAI-compatible API. It is configured at startup to
+load all five (or more) specialized agent models in GGUF format, with layer offloading
+(n_gpu_layers) set for each to manage the VRAM budget. GPU (RTX 4080 SUPER): The hardware executing
+the inference. A portion of its VRAM holds the GPU layers of all co-resident models. CPU/System RAM:
+The CPU runs the NATS server and the Agent Supervisor. System RAM holds the offloaded layers of the
+GGUF models. Monitoring Service: A separate process running the Python/pyNVML script to log GPU
+power, temperature, and utilization metrics to a CSV file for analysis. This event-driven,
+service-oriented architecture ensures that components can be developed, deployed, and scaled
+independently. 5.2 The Docker Compose Configuration (Deliverable D2) To ensure maximum
+reproducibility and eliminate dependency conflicts, the entire stack is defined within a
+docker-compose.yml file. This allows the complete environment to be instantiated with a single
+docker compose up command. \# docker-compose.yml configuration
+
+``` yaml
+# docker-compose.yml
+# A reproducible runtime stack for a multi-agent, multi-LLM system.
+
+version: '3.8'
+
+services:
+  # 1. The NATS Message Bus
+  nats:
+    image: nats:2.10
+    ports:
+      - "4222:4222" # Client port
+      - "8222:8222" # Monitoring port
+    command: "-js -m 8222" # Enable JetStream and HTTP monitoring
+
+  # 2. The llama.cpp Python Inference Server
+  inference:
+    build:
+      context:./llama_cpp_docker
+      # Dockerfile will clone and build llama.cpp with CUDA support
+    runtime: nvidia # Expose NVIDIA GPUs to the container
+    volumes:
+      -./models:/models # Mount local models directory into the container
+    ports:
+      - "8000:8000"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - MODEL_PATH=/models/codellama-7b.Q4_K_M.gguf # Example default model
+      - N_GPU_LAYERS=25 # Default GPU layers, can be overridden per request
+      - N_CTX=4096
+    command: >
+      python3 -m llama_cpp.server
+      --model /models/router-phi-3-mini.Q4_K_M.gguf # Load router model by default
+      --n_gpu_layers 33 # Keep small router model fully in VRAM
+      --host 0.0.0.0
+      --port 8000
+      --n_ctx 4096
+      --chat_format chatml
+      --model_alias router_model
+      # The server can load other models on-the-fly via API requests
+
+  # 3. The LangGraph Agent Supervisor Service
+  supervisor:
+    build:
+      context:./supervisor_app
+      # Dockerfile will install Python, pynats, langgraph, langchain-openai, etc.
+    depends_on:
+      - nats
+      - inference
+    environment:
+      - NATS_URL=nats://nats:4222
+      - LLM_API_BASE=http://inference:8000/v1
+      - ROUTER_MODEL_NAME=router_model
+      # Environment variables for each worker model alias
+      - CODER_MODEL_PATH=/models/codellama-7b.Q4_K_M.gguf
+      - WRITER_MODEL_PATH=/models/mistral-7b-instruct.Q4_K_M.gguf
+    # The supervisor app will contain the LangGraph logic and NATS subscriber loop
+
+  # 4. The Monitoring Service (for Deliverable D4)
+  monitoring:
+    build:
+      context:./monitoring_app
+      # Dockerfile with Python, pyNVML, pandas, matplotlib
+    runtime: nvidia
+    volumes:
+      -./reports:/reports # Output CSV and graphs to a local directory
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      command: python3 profile.py --duration 600 --output /reports/power_profile.csv
+```
+
+Configuration Walkthrough: nats service: A standard NATS server with JetStream persistence enabled
+for reliable messaging. inference service: This is the core llama.cpp server. The Dockerfile in
+llama_cpp_docker is responsible for compiling llama.cpp with the correct CUDA flags. It mounts a
+local ./models directory, where George will place his GGUF files. The command pre-loads the small
+router model fully into VRAM for fast routing decisions. Other, larger models are loaded by the
+server as needed when the supervisor makes an API call specifying a different model path. The
+llama-cpp-python server intelligently caches models in memory according to their usage. supervisor
+service: This container runs the Python application containing the LangGraph router. It connects to
+the NATS server to receive tasks and to the inference service to make LLM calls. Environment
+variables are used to configure the endpoints and model names, decoupling the logic from the
+infrastructure. monitoring service: This service runs the energy profiling script (Deliverable D4),
+logging power data to a mounted volume for easy access and analysis on the host machine. 5.3
+Verification: A Guide to Running the Benchmark Suite To validate that the deployed stack meets all
+performance and efficiency targets, a verification script and procedure are provided. Prerequisites:
+Ensure Docker is installed with NVIDIA container runtime support, and the ./models directory is
+populated with the required GGUF model files. Launch the Stack: From the project's root directory,
+run docker compose up -d. This will build the images and start all services in the background. Run
+the Benchmark: A benchmark.py script will be provided. This script connects to the NATS server and
+simulates a concurrent 5-agent workload by publishing 100 task messages to the tasks.new topic at a
+controlled rate. It will also subscribe to the results.completed topic to measure the end-to-end
+latency for each task. Monitor and Collect Data: While the benchmark is running, execute the
+monitoring service: docker compose run --rm monitoring. This will start the power profiling script,
+which will run for a specified duration (e.g., 10 minutes) and save the results to
+./reports/power_profile.csv. Simultaneously, use watch nvidia-smi on the host machine to observe the
+VRAM usage. Analyze Results: Latency: The benchmark.py script will output the average, P95, and P99
+end-to-end latency. Verify this is ≤800 ms. VRAM: The nvidia-smi output should show that total VRAM
+usage remains consistently below the 16 GB limit. Power: Analyze the generated power_profile.csv
+using the provided Jupyter notebook (D4). Verify that the average power draw is ≤220 W. This
+comprehensive verification process provides empirical proof that the system design and configuration
+successfully meet all of George's specified success criteria.
+
+## Section 6: Future-Proofing and Contingency Planning
+
+A robust system is not only performant on day one but is also designed for extensibility and
+resilience. This final section provides guidance on expanding the agent swarm with new modalities,
+analyzes future hardware bottlenecks, and outlines a clear plan for mitigating common failure modes.
+6.1 Extending the Swarm: Integrating Lightweight Vision and Audio Models The LangGraph-based router
+architecture is inherently extensible. Adding new capabilities, such as vision or audio processing,
+is a matter of defining new agent nodes and updating the router's logic. Audio Transcription: To add
+an audio processing agent, whisper.cpp is the ideal choice. It is built upon the same ggml tensor
+library as llama.cpp, ensuring high performance and efficiency on both CPU and GPU.2 A new
+"transcription" agent node can be created in LangGraph. This node would take an audio file path as
+input, invoke a whisper.cpp process or library call to perform transcription, and return the
+resulting text. The supervisor's router LLM would be fine-tuned or prompted to recognize tasks like
+"transcribe this meeting" and route them to this new node. Vision-Language Processing: For image
+understanding, a lightweight Vision-Language Model (VLM) can be integrated. Models like VILA or
+Llava are available in GGUF format and can be served by llama.cpp. A new "vision" agent node would
+be added to the graph. The supervisor would route tasks containing image inputs (e.g., "describe
+this image") to the vision agent, which would then call the llama.cpp server with the appropriate
+VLM model specified. Managing the additional VRAM for the VLM would require careful adjustment of
+the n_gpu_layers for all co-resident models to stay within the 16 GB budget. 6.2 Bottleneck
+Analysis: PCIe 5.0 vs. System RAM for Next-Gen Workloads The recommended architecture relies heavily
+on offloading model layers to system RAM. In this configuration, the primary performance bottleneck
+for the offloaded portion of the model is not the speed of the CPU or the RAM itself, but the
+bandwidth of the Peripheral Component Interconnect Express (PCIe) bus that connects the CPU/RAM to
+the GPU. The RTX 4080 SUPER uses a PCIe 4.0 x16 interface, which has a theoretical maximum bandwidth
+of approximately 32 GB/s. When an agent invokes a model and requires a layer that resides in system
+RAM, that layer's weights must be transferred over the PCIe bus to the GPU for computation. This
+transfer latency is the dominant cost for offloaded layers. Future motherboard and CPU platforms
+supporting PCIe 5.0 will double this bandwidth to \~64 GB/s. For this specific offloading-heavy
+architecture, an upgrade to a PCIe 5.0 compatible system would yield a near-linear performance
+improvement for the offloaded layers. This would directly reduce the latency of each agent turn, or
+alternatively, allow for more layers to be offloaded to RAM while maintaining the same latency
+budget, thereby freeing up VRAM to accommodate even more agents or larger models. 6.3 Risk &
+Mitigation Brief (Deliverable D5) A 24/7 autonomous system must be designed to anticipate and handle
+failures gracefully. Failure Mode: Out of Memory (OOM) Errors Cause: The combined VRAM requirements
+of model weights (GPU layers), the KV cache for all active requests, and framework overhead exceed
+the 16 GB capacity. This can happen if the context length of requests grows unexpectedly large or if
+too many agents are processing requests simultaneously. Mitigation Strategy: Proactive: Carefully
+tune the n_gpu_layers for each model in the llama.cpp server configuration at startup to leave a
+generous headroom (e.g., 2-3 GB) for the dynamic KV cache. Reactive: If OOM errors still occur, the
+primary response is to further reduce the n_gpu_layers for one or more of the larger models,
+offloading more to system RAM. Advanced (Non-interactive tasks): For background tasks that are not
+latency-sensitive, the system can be configured to use an engine like FlexGen.8 The LangGraph router
+could identify these tasks and route them to a separate FlexGen instance that offloads entirely to
+CPU/disk, preserving precious VRAM for the interactive agents. Failure Mode: Thermal Throttling
+Cause: Sustained 24/7 inference, even with an efficient undervolt, can lead to heat buildup within
+the PC case if airflow is inadequate. This will cause the GPU to automatically reduce its clock
+speeds to protect itself, leading to increased latency and degraded performance. Mitigation
+Strategy: Monitoring: The pyNVML monitoring script (D4) should be configured to log GPU temperature
+(nvmlDeviceGetTemperature) alongside power draw. Set up alerts if the temperature consistently
+exceeds a safe threshold (e.g., 80°C). Hardware: Ensure the workstation has excellent case airflow
+with a proper intake/exhaust fan configuration. Tuning: Use MSI Afterburner to set a more aggressive
+custom fan curve that increases fan speed earlier as temperatures rise, preventing the GPU from
+reaching its throttle point. Failure Mode: Driver Bugs / CUDA Incompatibilities Cause: A mismatch
+between the NVIDIA driver version, the CUDA toolkit version used to compile llama.cpp, the PyTorch
+version, and other dependencies. This is a common source of instability and difficult-to-debug
+errors. Mitigation Strategy: Containerization: This risk is almost entirely mitigated by using the
+provided Docker Compose environment (D2). The Dockerfile for each service locks in a specific,
+known-good version of the base image, CUDA toolkit, Python libraries, and compilation flags. This
+creates a hermetic, reproducible environment that is insulated from the host system's configuration.
+Failure Mode: Agent Hallucination / Degraded Reasoning Performance Cause: A 4-bit quantized model,
+even if generally capable, may fail on a specific, complex reasoning task, providing an incorrect or
+nonsensical answer. Mitigation Strategy: Post-Hoc Repair: If a particular agent model is found to be
+consistently underperforming on its specialized task, apply the "InfiJanice" methodology described
+in Section 1.2.13 Create a "Silver Bullet" dataset from its failures and perform a quick fine-tuning
+run to restore its reasoning capabilities. Hierarchical Fallback: The LangGraph supervisor can be
+programmed with a fallback mechanism. If an agent's output fails a validation check (e.g., the code
+it generated doesn't compile, or its summary is flagged as nonsensical by another model), the
+supervisor can re-route the original task to a more powerful, but more resource-intensive, model
+(e.g., a larger model with more layers on the GPU) or flag the task for human review. This creates a
+resilient, self-correcting loop.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Reverse Engineering Codex: ai-research/reverse-engineering-codex.md
       - DeepThought-ReThought Roadmap: ai-research/strategic-roadmap-deepthought.md
       - Friend or Foe PRD: ai-research/discord-friend-foe-prd.md
+      - Energy-Efficient Swarm: ai-research/energy-efficient-swarm.md
   - Arduino: arduino/index.md
   - Terminal Workflow: terminal-workflow/index.md
   - Culture Project: culture-project/index.md


### PR DESCRIPTION
## Summary
- create `energy-efficient-swarm.md` detailing multi-agent LLM deployment
- link the page in mkdocs navigation with consistent indenting
- rewrap the new research doc at ~100 columns for easier diffs on GitHub
- add section headings for clearer structure

## Testing
- no tests needed for documentation changes

------
https://chatgpt.com/codex/tasks/task_e_68881b3122408326a109e129f4ba994e