### PR TITLE
Remove tmp dir on early exit

### DIFF
--- a/scripts/migrate_old_docs.sh
+++ b/scripts/migrate_old_docs.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 # Ensure git-filter-repo is installed before proceeding
 if ! command -v git-filter-repo >/dev/null; then


### PR DESCRIPTION
## Summary
- clean up temporary directory even if migrate_old_docs.sh exits early

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e6e4c22883268e022ea0874daf16