### PR TITLE
Fix MD051 link fragments in cyberpunk cookbook

### DIFF
--- a/docs/cyberpunk-cookbook.md
+++ b/docs/cyberpunk-cookbook.md
@@ -10,12 +10,12 @@ updated: 2025-07-28
 
 - [Wave 1: Foundations](#wave-1-foundations)
 - [Wave 2: Threat Mapping](#wave-2-threat-mapping)
-- [Wave 3: Privacy & OPSEC](#wave-3-privacy-opsec)
-- [Wave 3: Legal Countermeasures & Rights Navigation](#wave-3-legal-countermeasures-rights-navigation)
+- [Wave 3: Privacy & OPSEC](#wave-3-privacy--opsec)
+- [Wave 3: Legal Countermeasures & Rights Navigation](#wave-3-legal-countermeasures--rights-navigation)
 - [Wave 3: Decentralized Infrastructure](#wave-3-decentralized-infrastructure)
 - [Wave 4: Hands-On Hardening](#wave-4-hands-on-hardening)
-- [Wave 4: Reconnaissance & Open-Source Intelligence](#wave-4-reconnaissance-open-source-intelligence)
-- [Wave 5: Cognitive Security & Influence Defense](#wave-5-cognitive-security-influence-defense)
+- [Wave 4: Reconnaissance & Open-Source Intelligence](#wave-4-reconnaissance--open-source-intelligence)
+- [Wave 5: Cognitive Security & Influence Defense](#wave-5-cognitive-security--influence-defense)
 - [Wave 6: Futures](#wave-6-futures)
 - [References](#references)
 


### PR DESCRIPTION
## Summary
- update TOC anchors in `cyberpunk-cookbook.md` to match generated heading slugs

## Testing
- `npx markdownlint docs/cyberpunk-cookbook.md`


------
https://chatgpt.com/codex/tasks/task_e_6888e6ed4dec8326b0037c1941d3e212