### PR TITLE
Update setup_hooks to resolve repo root

### DIFF
--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 # Configure git to use repository-specific hooks
 
-git config core.hooksPath .githooks
+# Resolve the repository root in case the script is run from a subdirectory.
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Configure git to look for hooks in the .githooks directory at the repo root.
+git config core.hooksPath "$REPO_ROOT/.githooks"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -16,7 +16,8 @@ def test_setup_hooks_sets_hooks_path(tmp_path):
     result = subprocess.check_output(
         ["git", "config", "--get", "core.hooksPath"], cwd=repo
     ).decode().strip()
-    assert result == ".githooks"
+    expected = str(repo / ".githooks")
+    assert result == expected
 
 
 def test_migrate_old_docs_git_commands(tmp_path):


### PR DESCRIPTION
## Summary
- resolve the repo root in `scripts/setup_hooks.sh` before configuring hook path
- adjust tests for the new absolute hook path

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888e6e636ac832692c0d5add4c4dcae