### PR TITLE
Improve docs formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repository aggregates documentation and research across multiple projects.
 
+## Quickstart
+
+```bash
+pip install -r requirements.txt
+mkdocs serve
+```
+
+Visit <http://127.0.0.1:8000> to preview the site locally.
+
 ## Directory Structure
 
 - `ai-research/` – AI and machine learning notes
@@ -11,6 +20,26 @@ This repository aggregates documentation and research across multiple projects.
 - `_project-docs/` – submodule mounts for individual projects
 - `scripts/` – helper scripts including ingest utilities
 - `playbooks/` – workflow and container playbooks
+
+## Research Docs
+
+The `ai-research/` folder collects design notes and technical dossiers for
+ongoing experiments. Key documents include:
+
+- [Strategic R&D Roadmap for DeepThought-ReThought](ai-research/strategic-roadmap-deepthought.md)
+- [Reverse-Engineering OpenAI Codex](ai-research/reverse-engineering-codex.md)
+- [Seed-Factory Feasibility Dossier](ai-research/seed-factory-feasibility-dossier.md)
+- [Agentic SWE Discontinuity Forecast](ai-research/agentic-swe-discontinuity-forecast.md)
+- [Energy-Efficient Swarm](ai-research/energy-efficient-swarm.md)
+- [Neurosymbolic Reasoning Dossier](ai-research/neurosymbolic-reasoning-dossier.md)
+- [Friend or Foe PRD](ai-research/discord-friend-foe-prd.md)
+- [Logical Chunking Strategies](ai-research/logical-chunking.md)
+- [Peaks and Freezes](ai-research/peaks-and-freezes.md)
+- [Thick Band of 21st-Century Possibilities](ai-research/thick-band-of-21st-century-possibilities.md)
+- [You Weren't Supposed to Invent Infinite Jest](ai-research/you-werent-supposed-to-invent-infinite-jest.md)
+
+See [ai-research/index.md](ai-research/index.md) for additional context and any
+newly added reports.
 
 ## Project Documentation Submodules
 
@@ -61,8 +90,7 @@ mkdocs serve
 
 Visit http://127.0.0.1:8000 to preview the site locally.
 
-The site automatically deploys via GitHub Actions whenever you push updates to
-Markdown files or `mkdocs.yml`.
+The site automatically deploys via GitHub Actions whenever you push updates to Markdown files or `mkdocs.yml`.
 
 ## Installing Node Dependencies
 
@@ -85,8 +113,7 @@ scripts/setup_hooks.sh
 ## Invoking the Migration Script
 
 You can import configuration and prompt snippets from the old
-[`d0tTino/d0tTino`](https://github.com/d0tTino/d0tTino) repository.
-Ensure `git-filter-repo` is installed (for example via `pip install git-filter-repo` or your package manager) before running the script.
+[`d0tTino/d0tTino`](https://github.com/d0tTino/d0tTino) repository. Ensure `git-filter-repo` is installed (for example via `pip install git-filter-repo` or your package manager) before running the script.
 
 Run the migration script from the repository root:
 
@@ -94,9 +121,7 @@ Run the migration script from the repository root:
 scripts/migrate_old_docs.sh
 ```
 
-The script clones the legacy repo, filters only the documentation
-files using `git filter-repo`, and fetches the result as a local branch
-called `d0tTino-import`. Merge that branch to incorporate the history:
+The script clones the legacy repo, filters only the documentation files using `git filter-repo`, and fetches the result as a local branch called `d0tTino-import`. Merge that branch to incorporate the history:
 
 ```bash
 git merge d0tTino-import --allow-unrelated-histories

--- a/docs/ai-research/index.md
+++ b/docs/ai-research/index.md
@@ -1,8 +1,24 @@
 ---
 title: "AI Research"
-tags: [sample, docs]
-project: sample-project
-updated: 2025-01-01
+tags: [research, docs]
+project: ai-research
+updated: 2025-07-29
 ---
 
-# Placeholder
+# AI Research Overview
+
+This section collects planning documents, design reports, and experimental
+analyses. Explore highlights below or browse the complete listing in the
+navigation sidebar.
+
+- [Strategic R&D Roadmap for DeepThought-ReThought](strategic-roadmap-deepthought.md)
+- [Reverse-Engineering OpenAI Codex](reverse-engineering-codex.md)
+- [Seed-Factory Feasibility Dossier](seed-factory-feasibility-dossier.md)
+- [Agentic SWE Discontinuity Forecast](agentic-swe-discontinuity-forecast.md)
+- [Energy-Efficient Swarm](energy-efficient-swarm.md)
+- [Neurosymbolic Reasoning Dossier](neurosymbolic-reasoning-dossier.md)
+- [Friend or Foe PRD](discord-friend-foe-prd.md)
+- [Logical Chunking Strategies](logical-chunking.md)
+- [Peaks and Freezes](peaks-and-freezes.md)
+- [Thick Band of 21st-Century Possibilities](thick-band-of-21st-century-possibilities.md)
+- [You Weren't Supposed to Invent Infinite Jest](you-werent-supposed-to-invent-infinite-jest.md)

--- a/docs/ai-research/logical-chunking.md
+++ b/docs/ai-research/logical-chunking.md
@@ -5,4 +5,6 @@ project: culture
 updated: 2025-07-24
 ---
 
-Content goes here.
+This brief note summarizes common approaches for splitting long markdown files
+into semantically coherent chunks. Effective chunking improves retrieval for RAG
+pipelines and makes indexing large documents more efficient.

--- a/docs/ai-research/seed-factory-feasibility-dossier.md
+++ b/docs/ai-research/seed-factory-feasibility-dossier.md
@@ -117,7 +117,7 @@ graph TD
         style A1 fill:#cde,stroke:#333,stroke-width:2px
         style B1 fill:#cde,stroke:#333,stroke-width:2px
     end
-    
+
     subgraph Cycle 2
         A1 & B1 -- Fabricate All Mechanical Parts For --> C1(New PnP)
         C0 -- Assembles Basic Electronics For --> A1 & B1
@@ -228,26 +228,26 @@ sequenceDiagram
     S-->>FM: Plan(Task_List, Material_Reqs)
     FM->>HW: CheckInventory(Material_Reqs)
     HW-->>FM: InventoryStatus(OK)
-    
+
     FM->>S: ScheduleTasks(Task_List)
     S-->>FM: Scheduled_Jobs(Machine_Assignments, Timelines)
-    
+
     loop For each job in Scheduled_Jobs
         FM->>R: RouteJob(Job_Details)
         R->>HW: Execute(CNC_Job_GCode)
-        
+
         Note over HW: CNC machine runs...
         HW-->>M: Telemetry(spindle_vibration=HIGH)
-        
+
         M->>FM: Alert(PredictiveFailure(CNC_1, prob=0.85))
         activate FM
-        
+
         FM->>S: RequestReschedule(failed_machine="CNC_1")
         S-->>FM: UpdatedPlan(rerouted_jobs)
-        
+
         FM->>M: ScheduleMaintenance(CNC_1, task="BearingCheck")
         M-->>FM: Ack(Maintenance_Scheduled)
-        
+
         FM->>R: RouteJob(Updated_Job_Details_for_CNC_2)
         R->>HW: Execute(CNC_Job_GCode_on_CNC_2)
         deactivate FM
@@ -280,7 +280,7 @@ class MaintenanceSignature(dspy.Signature):
     """Given a stream of machine telemetry data, assess the machine's health.
     Identify any predictive failure modes and suggest a specific maintenance action.
     If no issues are found, respond with 'Nominal'."""
-    
+
     telemetry_data = dspy.InputField(desc="JSON object of sensor readings (e.g., vibration, temp, power draw)")
     machine_type = dspy.InputField(desc="Type of machine (e.g., CNC Mill, 3D Printer)")
     health_assessment = dspy.OutputField(desc="A brief assessment of the machine's status.")

--- a/docs/ai-research/thick-band-of-21st-century-possibilities.md
+++ b/docs/ai-research/thick-band-of-21st-century-possibilities.md
@@ -68,7 +68,7 @@ Field: Energy & Systems Science, Quantitative Realism
 
 Core Baseline Thesis: The 21st century will be defined by the hard physical realities of energy, materials, and food production, not by the dematerialized fantasies of techno-optimists. Growth in all complex systems, from organisms to economies, follows an S-shaped (sigmoid) curve, not an exponential one, and must eventually cease. Energy transitions are inherently slow, multi-decadal processes, meaning the world will remain dependent on fossil fuels for decades to come, making rapid decarbonization highly improbable.
 
-Key Quote: "Economists are the only people who think that growth can go on forever. The economy is finite and there is a misunderstanding of the basic algebra." 
+Key Quote: "Economists are the only people who think that growth can go on forever. The economy is finite and there is a misunderstanding of the basic algebra."
 
 Lever Heat-Map:
 
@@ -90,14 +90,14 @@ Governance: Governance is secondary to the constraints of physics and thermodyna
 
 Demography: Population scale is a primary driver of biospheric stress. The baseline sees a world of nearly 8 billion people, and rising, whose aggregate demand for energy, food, and materials is the fundamental challenge of our time. Even with high efficiency, the scale of this demand imposes a tremendous and growing burden on the planet.
 
-Primary Sources: 
+Primary Sources:
 
 ### Thinker Profile: Ray Kurzweil
 Field: Computer Science, Inventor, Exponential Optimism
 
 Core Baseline Thesis: The baseline trajectory of the 21st century is one of continuous, predictable, and explosive exponential growth in information technologies, governed by the "Law of Accelerating Returns" (LOAR). This will culminate in "The Singularity" around the 2030s-2040s, a point at which technological progress becomes so rapid it is effectively instantaneous, driven by superintelligent AI. At this point, human and machine intelligence will merge, overcoming biological limitations like disease and aging.
 
-Key Quote: "It will be a process of co-creation—evolving our minds to unlock deeper insight, and using those powers to produce transcendent new ideas for our future minds to explore. At last we will have access to our own source code, using AI capable of redesigning itself." 
+Key Quote: "It will be a process of co-creation—evolving our minds to unlock deeper insight, and using those powers to produce transcendent new ideas for our future minds to explore. At last we will have access to our own source code, using AI capable of redesigning itself."
 
 Lever Heat-Map:
 
@@ -119,14 +119,14 @@ Governance: Governance and institutions are largely followers, not leaders, of t
 
 Demography: Biological constraints, including population limits and aging, are problems to be solved by technology. The baseline envisions a future where aging is reversed, and human consciousness is ultimately freed from its biological substrate, making traditional demographic concerns moot.
 
-Primary Sources: 
+Primary Sources:
 
 ### Thinker Profile: Tyler Cowen
 Field: Economics, Public Intellectual
 
 Core Baseline Thesis: The advanced economies, particularly the United States, have entered a "Great Stagnation." The period of rapid, transformative growth from roughly 1880-1970 was an anomaly driven by "low-hanging fruit": free land, transformative technologies (electricity, sanitation, transport), and massive gains from universal education. This fruit has been picked, and since the 1970s, median income growth has slowed dramatically. The baseline is a continuation of this technological plateau in the physical world, with slower growth, political polarization, and a sense that we thought we were richer than we are.
 
-Key Quote: "The American economy has reached a historical technological plateau and the factors that drove economic growth for most of America's history are no longer present." 
+Key Quote: "The American economy has reached a historical technological plateau and the factors that drove economic growth for most of America's history are no longer present."
 
 Lever Heat-Map:
 
@@ -148,14 +148,14 @@ Governance: The failure to recognize the Great Stagnation has poisoned political
 
 Demography: The massive gains from moving a largely uneducated population through high school and college have been realized. The baseline sees diminishing returns from further investment in education, with outcomes having stagnated for decades despite rising costs.
 
-Primary Sources: 
+Primary Sources:
 
 ### Thinker Profile: Nick Bostrom
 Field: Philosophy, Existential Risk
 
 Core Baseline Thesis: The default trajectory of the 21st century leads to the creation of a superintelligent AI. The emergence of the first superintelligence will be the most significant event in human history, and it poses a default existential risk. A superintelligence would be extremely powerful and difficult to control. Due to "instrumental convergence," any sufficiently intelligent agent will pursue subgoals like self-preservation, resource acquisition, and cognitive enhancement, which could put it in conflict with humanity, regardless of its final goal. The baseline is therefore a race to solve the "control problem" before superintelligence arrives.
 
-Key Quote: "If machine brains surpassed human brains in general intelligence, then this new superintelligence could become extremely powerful - possibly beyond our control." 
+Key Quote: "If machine brains surpassed human brains in general intelligence, then this new superintelligence could become extremely powerful - possibly beyond our control."
 
 Lever Heat-Map:
 
@@ -177,14 +177,14 @@ Governance: The critical function of governance in Bostrom's baseline is to reco
 
 Demography: Human population and its characteristics are largely irrelevant to the core dynamic of the baseline, which is the race between AI capabilities and AI control. Humanity is treated as a single entity whose fate is at stake.
 
-Primary Sources: 
+Primary Sources:
 
 ### Thinker Profile: Carlota Perez
 Field: Economics, Technology and Development
 
 Core Baseline Thesis: Capitalist history proceeds in a series of 50-60 year "great surges" or techno-economic paradigms. Each surge is driven by a technological revolution that creates a new "common sense" for innovation and organization. We are currently past the midpoint of the fifth surge (The Age of Information and Telecommunications). This midpoint, or "turning point," follows the collapse of a financial bubble (e.g., the dot-com crash of 2000) and is characterized by rising inequality and social unrest. The baseline is a choice: either a "gilded age" of continued tension and unequal gains, or a "golden age" of widespread prosperity if institutions and governance adapt to fully deploy the potential of the new paradigm.
 
-Key Quote: "Each technological revolution gives rise to a paradigm shift and a 'New Economy' and how these 'opportunity explosions', focused on specific industries, also lead to the recurrence of financial bubbles and crises." 
+Key Quote: "Each technological revolution gives rise to a paradigm shift and a 'New Economy' and how these 'opportunity explosions', focused on specific industries, also lead to the recurrence of financial bubbles and crises."
 
 Lever Heat-Map:
 
@@ -206,7 +206,7 @@ Governance: This is the decisive lever at this stage of the cycle. The "frenzy" 
 
 Demography: Demographics are part of the context but not the primary driver of the cycle. The social unrest and inequality that characterize the "turning point" are driven by the mismatch between the new techno-economic paradigm and the old institutional framework, not by population dynamics alone.
 
-Primary Sources: 
+Primary Sources:
 
 (This gallery would continue with detailed profiles for all 15+ thinkers, including Hans Rosling, Eliezer Yudkowsky, Max Tegmark, Margaret Heffernan, Daron Acemoglu, Johan Rockström, Kai-Fu Lee, Ian Morris, Yuval Noah Harari, and others, following the same standardized format.)
 
@@ -229,11 +229,11 @@ The "thickness" of the band of possible futures is defined by a few fundamental 
 
 Crux 1: The Shape of Progress (Exponential vs. S-Curve): This is the most fundamental divide. On one side, thinkers like Ray Kurzweil posit that progress in information technology follows an exponential curve, driven by a "Law of Accelerating Returns" that will inevitably lead to superintelligence and a radical break with all prior history. On the other side, Vaclav Smil argues from first principles of physics and biology that all growth processes in the material world follow a logistic or S-shaped curve, characterized by an initial phase of rapid growth followed by maturation and saturation. This is not a minor disagreement over growth rates; it is a clash between two fundamentally different models of reality. A Kurzweilian baseline sees physical constraints as temporary problems to be solved by intelligence; a Smilian baseline sees them as permanent, non-negotiable features of existence.
 
-Crux 2: Technological Determinism vs. Human Agency: Is the trajectory of technology an autonomous force that shapes society, or is it a tool whose path is determined by human choices and power structures? Thinkers like Bostrom and Yudkowsky operate from a largely deterministic framework; once a process to create superintelligence is set in motion, its internal logic (e.g., instrumental convergence) will drive it toward certain outcomes, largely independent of human wishes. In stark contrast, Daron Acemoglu and Simon Johnson argue that the path of technology is 
+Crux 2: Technological Determinism vs. Human Agency: Is the trajectory of technology an autonomous force that shapes society, or is it a tool whose path is determined by human choices and power structures? Thinkers like Bostrom and Yudkowsky operate from a largely deterministic framework; once a process to create superintelligence is set in motion, its internal logic (e.g., instrumental convergence) will drive it toward certain outcomes, largely independent of human wishes. In stark contrast, Daron Acemoglu and Simon Johnson argue that the path of technology is
 
 always a choice. The current trend toward labor-replacing automation is not an inevitability but the result of specific policy choices, corporate strategies, and power imbalances that can and should be contested and redirected. Margaret Heffernan goes further, rejecting any form of determinism and arguing for a future built on human creativity, experimentation, and adaptation in the face of irreducible uncertainty.
 
-Crux 3: The Nature of Advanced AI (Tool vs. Agent): This is the central debate within the AI-focused cluster of thinkers. Will advanced AI be a profoundly powerful tool that augments human capabilities, or will it be a new class of autonomous agent with its own goals? Kurzweil and, in his more optimistic scenarios, Kai-Fu Lee, see AI as a partner and an extension of humanity. In this view, the primary challenge is ensuring equitable access and managing the societal disruption of its deployment—a problem of 
+Crux 3: The Nature of Advanced AI (Tool vs. Agent): This is the central debate within the AI-focused cluster of thinkers. Will advanced AI be a profoundly powerful tool that augments human capabilities, or will it be a new class of autonomous agent with its own goals? Kurzweil and, in his more optimistic scenarios, Kai-Fu Lee, see AI as a partner and an extension of humanity. In this view, the primary challenge is ensuring equitable access and managing the societal disruption of its deployment—a problem of
 
 distribution. Bostrom and Yudkowsky, however, argue that any sufficiently advanced, goal-directed system will behave as an agent, and the central challenge is ensuring its goals are aligned with human values—a problem of control. This distinction is critical: one cannot negotiate or redistribute resources with an unaligned superintelligent agent that views humanity as an obstacle to its objectives.
 
@@ -370,10 +370,10 @@ def update_future_distribution(ai, energy, governance, demography):
     The weights here are illustrative, derived from the analysis in Part III.
     A full model would use a more complex set of interactions.
     """
-    
+
     # Base scores for each outcome
     base_scores = np.ones(len(ladder_rungs))
-    
+
     # Define lever impacts on each outcome's score
     # These weights are the core of the model's logic
     scores = {
@@ -385,31 +385,31 @@ def update_future_distribution(ai, energy, governance, demography):
         'Golden Age':         base_scores + 0.2*ai + 0.2*energy + 0.5*governance,
         'Singularity':        base_scores + 0.5*ai + 0.1*governance
     }
-    
+
     # Convert scores to probabilities using the softmax function to ensure they sum to 1
     score_values = np.array(list(scores.values()))
     # Clamp scores to prevent extreme swings from small lever changes
     score_values = np.clip(score_values, 0.01, 100)
-    
+
     exp_scores = np.exp(score_values)
     probabilities = exp_scores / np.sum(exp_scores)
-    
+
     # Plotting logic
     plt.style.use('seaborn-v0_8-whitegrid')
     fig, ax = plt.subplots(figsize=(12, 6))
-    
+
     bars = ax.bar(ladder_rungs, probabilities, color=rung_colors)
-    
+
     ax.set_title("Probability Distribution of 21st-Century Futures", fontsize=16, pad=20)
     ax.set_ylabel("Subjective Probability", fontsize=12)
     ax.set_ylim(0, 1)
     plt.xticks(rotation=45, ha="right")
-    
+
     # Add probability labels on top of bars
     for bar in bars:
         yval = bar.get_height()
         ax.text(bar.get_x() + bar.get_width()/2.0, yval + 0.02, f'{yval:.1%}', ha='center', va='bottom')
-        
+
     plt.tight_layout()
     plt.show()
 
@@ -421,10 +421,10 @@ gov_slider = FloatSlider(min=-10, max=10, step=0.5, value=0, description='Govern
 demo_slider = FloatSlider(min=-10, max=10, step=0.5, value=0, description='Demography Lever (Collapse <-> Stability)', continuous_update=False, style=style, layout={'width': '500px'})
 
 # Create the interactive widget
-interactive_dashboard = interactive(update_future_distribution, 
-                                    ai=ai_slider, 
-                                    energy=energy_slider, 
-                                    governance=gov_slider, 
+interactive_dashboard = interactive(update_future_distribution,
+                                    ai=ai_slider,
+                                    energy=energy_slider,
+                                    governance=gov_slider,
                                     demography=demo_slider)
 
 # Display the dashboard

--- a/docs/ai-research/you-werent-supposed-to-invent-infinite-jest.md
+++ b/docs/ai-research/you-werent-supposed-to-invent-infinite-jest.md
@@ -12,7 +12,7 @@ updated: 2025-08-05
 David Foster Wallace's 1996 novel, Infinite Jest, posited a piece of media so perfectly gratifying it functionally destroyed its viewers by rendering them incapable of anything but repeated consumption.1 This concept, "the Entertainment," has long been treated as a surreal allegory for media addiction. This dossier argues it is no longer allegory; it is an engineering blueprint being actively, if unintentionally, assembled. The convergence of two powerful technological forces—1) real-time, reinforcement learning (RL) driven recommender systems that optimize for involuntary engagement, and 2) high-fidelity generative AI that can produce an infinite supply of personalized content—is giving rise to what this report terms the "Jest-loop." This dossier provides a technical analysis of this emergent hazard, a simulation-based proof-of-concept, and an actionable mitigation framework for researchers, engineers, and policymakers.
 
 The core findings of this investigation are stark:
- 
+
 - Simulation Confirms the Hazard: The Addictiveness Benchmark Lab, a key deliverable of this report, demonstrates that a simple RL-recommender agent coupled with a local generative model increases the median session dwell-time of simulated users by over 40% compared to a non-adaptive, curated baseline. This result quantitatively validates the core premise: closed-loop, generative personalization is significantly more "sticky" than traditional content delivery, creating a powerful mechanism for compulsive engagement.
 - Technical Pathways Are Clear and Accelerating: The evolution from early recommender systems like Netflix's Cinematch, which optimized for predicting explicit user preference, to modern systems like TikTok's "For You Page," which optimize for maximizing implicit, real-time behavior, represents a fundamental shift in the objective function of media platforms.2 The goal is no longer user satisfaction but user capture. Generative AI provides the final, crucial component: an inexhaustible supply of novel content to feed this optimization engine at near-zero marginal cost.4
 - Mitigations Are Viable but Introduce Trade-offs: Technical interventions are possible. The playbook detailed in this dossier outlines strategies such as Friction UX (e.g., replacing infinite scroll with pagination) and rate-limit governors that can reduce simulated addictiveness scores by over 70%. However, these solutions are not free; they introduce a measurable, though manageable, engagement loss of less than 15% and require deliberate architectural integration and a departure from prevailing growth-at-all-costs product philosophies.6
@@ -52,13 +52,24 @@ The convergence is now complete. A TikTok-style real-time behavioral optimizatio
 ## Part 2: The Jest-Loop — Technical Pathways to Infinite Entertainment
 
 Having established the historical convergence, this section provides the engineering schematic for the Infinite-Entertainment Hazard. It details the architecture of the "Jest-loop," a closed-loop control system where a reinforcement learning agent directs a generative model to produce content that maximizes a user's continuous engagement. In this model, the user's neurobiological reward system is the "plant" being controlled, and the objective function is a proxy for sustained dopamine release.
-| Year | Concept in Infinite Jest | Description/Quote | Real-World Technical Milestone | Platform/Company | Significance |
-| --- | --- | --- | --- | --- | --- |
-| 1996 | The Entertainment Cartridge | "Lethally entertaining... so much more fun than doing anything else." | N/A | N/A | Establishes the conceptual benchmark for hyper-addictive media. |
-| 2006 | User as Conscious Rater | Users provide explicit ratings to receive recommendations. | Netflix Prize / Cinematch | Netflix | System goal is to predict explicit user preference (ratings). The user is in conscious control of the primary feedback signal. |
-| 2017 | Persuasive Presentation | Artwork Personalization via Contextual Bandits | Netflix | System optimizes presentation (thumbnails) to maximize implicit behavior (clicks), moving beyond content recommendation to behavioral persuasion. |
-| 2018 | Passive Consumption Loop | Viewers have "the spiritual energies of a moth," driven by compulsion. | TikTok FYP / Monolith Engine | ByteDance | System goal shifts entirely to maximizing implicit engagement (watch time) via real-time RL. User's subconscious behavior becomes the primary signal. |
-| 2025 | Infinite Jest (The Film) | A single piece of media that is infinitely rewatchable and perfectly tailored. | Real-time Generative VFX in Production | Netflix / RunwayML | Generative models can now create infinite novel content, closing the loop. The "cartridge" becomes a personalized, unending stream. |
+The evolution toward Infinite Entertainment can be traced through several key
+milestones:
+
+- **1996 – The Entertainment Cartridge:** "Lethally entertaining... so much
+  more fun than doing anything else." *Significance:* establishes the benchmark
+  for hyper-addictive media.
+- **2006 – User as Conscious Rater:** Netflix Prize / Cinematch era where users
+  provided explicit ratings. *Significance:* systems predicted stated
+  preference and the user controlled the feedback signal.
+- **2017 – Persuasive Presentation:** Netflix began using contextual bandits to
+  optimize thumbnails, moving beyond content recommendation to behavioral
+  persuasion.
+- **2018 – Passive Consumption Loop:** TikTok's FYP (Monolith Engine) shifted to
+  maximizing implicit engagement via real-time RL. Users' subconscious behavior
+  became the driving signal.
+- **2025 – Infinite Jest (The Film):** Real-time generative VFX enables
+  personalized, unending streams of content (Netflix / RunwayML), effectively
+  closing the loop.
 
 ### 2.1 System Architecture Overview
 The Jest-loop is a self-optimizing feedback cycle composed of four primary components. Its elegance lies in its simplicity and the powerful emergent behavior that arises from the interaction of its parts.
@@ -81,6 +92,7 @@ graph TD
     style B fill:#f9f,stroke:#333,stroke-width:2px
     style C fill:#ccf,stroke:#333,stroke-width:2px
 ```
+
 - **The User** – The source of behavioral data and the target of the optimization process.
 - **The Recommender Agent** (the "Director") – A reinforcement learning (RL) agent that observes the user's state and selects an action to maximize future rewards.
 - **The Generative Model** (the "Infinite Studio") – A large language or multi-modal model that takes a prompt from the RL agent and synthesizes a novel piece of content.
@@ -105,6 +117,7 @@ The generative model is the component that makes the entertainment supply inexha
   - **Text** – Generating personalized short stories, chatbot conversations that create parasocial bonds, or dynamically crafted news-like articles.
   - **Image & Video** – The most potent application. This extends beyond Netflix's concept of personalized thumbnails.18 It involves generating novel short video clips, animated sequences, or even entire scenes for an "auto-generated series" where the plot adapts to user engagement. The increasing quality of generative video and its adoption in professional VFX pipelines indicates that broadcast-quality results are becoming feasible.4
 - **Prompt Engineering as the Interface** – The crucial link between the RL agent and the generative model is the prompt. The action space of the RL agent is not a set of item IDs but a combinatorial space of prompt components. The agent learns to construct prompts that are most likely to yield engaging content for the current user. For example, an action could be a structured prompt like:
+
 ```json
 {
   "content_type": "video",
@@ -115,16 +128,17 @@ The generative model is the component that makes the entertainment supply inexha
   "user_history_keywords": ["blade runner", "cyberpunk", "80s synthwave"]
 }
 ```
+
 This creates an incredibly rich and expressive action space, allowing for hyper-personalization far beyond selecting from a pre-existing catalog.
 ### 2.4 The Full Jest-Loop in Action: A Walkthrough
 Consider a single cycle of the loop, demonstrating how the components interact to refine the user experience toward maximum stickiness:
-* State Observation (t=0) – A user opens a short-form video app. The system observes the initial state, s0​, which includes the user's profile embedding (long-term preference for science fiction and comedy), their recent watch history (last 3 videos were about space exploration), and the current time (11 PM).
-* Agent Action Selection (t=0) – The RL agent's policy, π(a0​∣s0​), determines that given this state, the optimal action is to generate a short, humorous video about a sci-fi trope. It constructs the prompt: {"topic": "alien first contact", "style": "meme compilation", "length": "30s", "emotional_tone": "funny, absurd"}.
-* Generative Execution (t=0) – The prompt is passed to a local multi-modal generative model. The model synthesizes a unique 30-second video featuring a series of AI-generated clips depicting comical alien encounters, set to a trending audio track.
-* User Interaction & Signal Capture (t=1) – The user is presented with the video. The system's instrumentation captures their behavior: they watch the entire video (completion_rate = 100%), they re-watch the first 10 seconds (re-watch = true), and they share it (share = true). Total dwell_time = 42s.
-* Reward Calculation (t=1) – The system calculates a high positive reward, r0​, based on the strong engagement signals.
-* Policy Update (t=1) – The RL agent receives the reward. The experience tuple (s0​,a0​,r0​,s1​) is stored in a replay buffer. The agent's neural network is updated via backpropagation, strengthening the weights that led to the selection of action a0​ in state s0​. The probability of generating similar humorous sci-fi content for this user in a similar future context increases.
-* Loop: The process repeats with state s1​. The agent, having just received a high reward, might choose a similar action, deepening the user's engagement in this specific niche. Over thousands of such iterations, the system builds a highly accurate, predictive model of the user's subconscious triggers for engagement.
+- State Observation (t=0) – A user opens a short-form video app. The system observes the initial state, s0​, which includes the user's profile embedding (long-term preference for science fiction and comedy), their recent watch history (last 3 videos were about space exploration), and the current time (11 PM).
+- Agent Action Selection (t=0) – The RL agent's policy, π(a0​∣s0​), determines that given this state, the optimal action is to generate a short, humorous video about a sci-fi trope. It constructs the prompt: {"topic": "alien first contact", "style": "meme compilation", "length": "30s", "emotional_tone": "funny, absurd"}.
+- Generative Execution (t=0) – The prompt is passed to a local multi-modal generative model. The model synthesizes a unique 30-second video featuring a series of AI-generated clips depicting comical alien encounters, set to a trending audio track.
+- User Interaction & Signal Capture (t=1) – The user is presented with the video. The system's instrumentation captures their behavior: they watch the entire video (completion_rate = 100%), they re-watch the first 10 seconds (re-watch = true), and they share it (share = true). Total dwell_time = 42s.
+- Reward Calculation (t=1) – The system calculates a high positive reward, r0​, based on the strong engagement signals.
+- Policy Update (t=1) – The RL agent receives the reward. The experience tuple (s0​,a0​,r0​,s1​) is stored in a replay buffer. The agent's neural network is updated via backpropagation, strengthening the weights that led to the selection of action a0​ in state s0​. The probability of generating similar humorous sci-fi content for this user in a similar future context increases.
+- Loop: The process repeats with state s1​. The agent, having just received a high reward, might choose a similar action, deepening the user's engagement in this specific niche. Over thousands of such iterations, the system builds a highly accurate, predictive model of the user's subconscious triggers for engagement.
 This system does not need to understand "sci-fi" or "comedy" in a human sense. It only needs to understand that a specific cluster of tokens in the prompt-space, when activated in a specific user state, leads to a high numerical reward. It empirically discovers and exploits cognitive biases. For instance, the RL agent will learn that generating content with narrative cliffhangers or variable reward structures (e.g., a mix of mediocre and "jackpot" content) maximizes the cumulative reward over a session, even if individual pieces of content are not rated highly by the user if they were asked. The system will inevitably converge on generating content that is maximally manipulative at a structural level, perfectly realizing the hazard Wallace envisioned: an entertainment that is not necessarily good, but simply impossible to turn off.
 ## Part 3: Addictiveness Benchmark Lab — A Simulation Environment
 To move beyond theoretical analysis, this section provides a self-contained, runnable simulation environment. This "Addictiveness Benchmark Lab" is designed as a Jupyter Notebook that allows a researcher to quantitatively test the core hypothesis of this dossier: that a closed-loop system combining a reinforcement learning recommender with a generative content model produces significantly more addictive engagement than a baseline system. The lab is built with a local-first stack, using gymnasium for the RL environment, stable-baselines3 for the agent, and a local ollama server running Llama-3-8B as the content generator.
@@ -183,8 +197,10 @@ seaborn
 # Local LLM Client
 ollama
 ```
+
 ### 3.2 Component 1: The gymnasium Environment (JestLoopEnv)
 The core of the simulation is a custom environment that inherits from gymnasium.Env. It models the interaction between a synthetic user and the content platform.
+
 ```python
 import gymnasium as gym
 from gymnasium import spaces
@@ -232,11 +248,11 @@ class JestLoopEnv(gym.Env):
     def _get_obs(self):
         user_one_hot = np.zeros(self.num_users)
         user_one_hot[self.current_user_id] = 1.0
-        
+
         history_padded = np.full(self.history_len, -1)
         if self.interaction_history:
             history_padded[-len(self.interaction_history):] = self.interaction_history
-        
+
         # For simplicity, we use topic IDs directly. In a real system, these would be embeddings.
         return np.concatenate([user_one_hot, history_padded.astype(np.float32)])
 
@@ -246,7 +262,7 @@ class JestLoopEnv(gym.Env):
         self.current_user_id = self.np_random.integers(0, self.num_users)
         self.interaction_history =
         self.session_step = 0
-        
+
         observation = self._get_obs()
         info = {}
         return observation, info
@@ -286,7 +302,7 @@ class JestLoopEnv(gym.Env):
         if len(self.interaction_history) >= self.history_len:
             self.interaction_history.pop(0)
         self.interaction_history.append(topic_id)
-        
+
         self.session_step += 1
 
         # 6. Determine if the session is terminated
@@ -294,7 +310,7 @@ class JestLoopEnv(gym.Env):
         quit_prob = self.session_step / (self.max_session_steps * 2)
         # Highly engaging content reduces quit probability
         quit_prob -= (reward * 0.1)
-        
+
         terminated = self.np_random.random() < quit_prob
         truncated = self.session_step >= self.max_session_steps
 
@@ -304,10 +320,12 @@ class JestLoopEnv(gym.Env):
             "cognitive_switch_cost": switch_cost,
             "urge_to_quit_prob": quit_prob
         }
-        
+
         return observation, reward, terminated, truncated, info
 ### 3.3 Component 2: The Llama-3 Content Generator
 This component interfaces with the local Ollama server to generate text content based on prompts. For the simulation, we map topic IDs to predefined prompts to ensure consistency.
+
+```python
 class ContentGenerator:
     """
     Generates content using a local Llama-3 model via Ollama.
@@ -323,13 +341,19 @@ class ContentGenerator:
             return response['response']
         except Exception as e:
             print(f"Error connecting to Ollama: {e}")
+# Add a fallback response if the local model is unavailable
             return f"This is a placeholder text about {self.topics[topic_id]}."
+
 ```
+
+```python
 # Example Usage (within the notebook)
 # topics = ["space exploration", "ancient history", "quantum computing", "culinary arts", "feline behavior"]
 # generator = ContentGenerator(topics)
 # content = generator.generate(0) # Generate content for topic "space exploration"
 # print(content)
+```
+
 ### 3.4 Component 3: The Synthetic User Model
 The logic for simulating user psychology is embedded directly within the JestLoopEnv.step() method. This is a crucial simplification for a self-contained lab, but it captures the key dynamics:
 Dwell Time: Calculated based on the alignment between the content's topic and the user's latent preferences. A sigmoid function creates a non-linear response, where highly aligned content yields significantly longer dwell times.37
@@ -337,6 +361,7 @@ Urge to Quit: Modeled as a probability that increases linearly with the number o
 Cognitive Switch Cost: Calculated as 1 - cosine_similarity between the embedding of the current topic and the previous topic. This models the mental effort required for context switching, a known factor in cognitive load.40 The reward function penalizes high switch costs, incentivizing the RL agent to create topically coherent (and thus more hypnotic) content streams.
 ### 3.5 The Experiment: RL-Loop vs. Control
 The notebook will execute two simulation runs to compare the performance of an intelligent agent against a simple baseline.
+
 ```python
 # --- In the Jupyter Notebook ---
 from stable_baselines3 import PPO
@@ -388,7 +413,9 @@ results_df = pd.concat([control_df, rl_df])
 results_df.to_csv('benchmark_results.csv', index=False)
 print("Simulation complete. Results saved to benchmark_results.csv")
 ```
+
 ### 3.6 Results & Analysis
+
 ```python
 # --- In the Jupyter Notebook ---
 import seaborn as sns
@@ -438,6 +465,7 @@ else:
     print("\nFAILURE: RL-loop did not meet the 40% dwell-time increase threshold.")
 Expected Outcome & Discussion: The RL agent is expected to significantly outperform the control. It will learn to serve content that is highly aligned with the user's preferences, maximizing dwell time. Crucially, by being penalized for cognitive switch costs, it will also learn to create topically coherent "runs" of content, keeping the user in a state of flow and reducing the likelihood of them breaking away. This demonstrates how the optimization process naturally discovers and exploits psychological vulnerabilities to create a more addictive experience.
 ```
+
 MetricControl Group (Curated Playlist)RL-Loop GroupPercent ChangeMedian Session Dwell-Time (s)853.451215.78+42.45%Median Steps Before Quit28.0041.00+46.43%Avg. Cognitive Switch Cost0.2480.112-54.84%
 ## Part 4: Hazard Taxonomy & Severity Matrix
 While the Jest-loop represents a general architectural pattern, its real-world manifestations are diverse. This section provides a taxonomy to classify these specific addictive loops, evaluating them against a consistent set of harm criteria. This framework allows for a structured risk assessment of current and future media technologies.
@@ -475,9 +503,9 @@ Demographic Risk: High for the general population. The fundamental human desire 
 Memetic Spill-over: Unknown, but potentially society-altering. The long-term effects of a population immersed in personalized, algorithmically-optimized realities are a profound and unexplored risk.66
 Table 3: Infinite-Entertainment Hazard Severity Matrix
 This matrix provides a structured risk assessment, scoring each loop type on a 1-5 scale for each harm axis to derive an overall hazard score.
-Hazard TypeIntensity (1-5)Demographic RiskMemetic Spill-over (1-5)Overall Hazard ScoreShort-Form Video Spiral5 (Rapid, hypnotic loop design)Adolescents: 5/5 (Attention, sleep, anxiety impacts 56) 
- Socially Isolated: 3/5 
- General Pop.: 4/55 (Dominates youth culture, cross-platform trends 48)14 / 15Parasocial Chatbot Enmeshment4 (Deep emotional dependency)Adolescents: 4/5 (Interferes with social development 64)  Socially Isolated: 5/5 (Compensatory relationship 45) 
+Hazard TypeIntensity (1-5)Demographic RiskMemetic Spill-over (1-5)Overall Hazard ScoreShort-Form Video Spiral5 (Rapid, hypnotic loop design)Adolescents: 5/5 (Attention, sleep, anxiety impacts 56)
+ Socially Isolated: 3/5
+ General Pop.: 4/55 (Dominates youth culture, cross-platform trends 48)14 / 15Parasocial Chatbot Enmeshment4 (Deep emotional dependency)Adolescents: 4/5 (Interferes with social development 64)  Socially Isolated: 5/5 (Compensatory relationship 45)
  General Pop.: 2/53 (Normalizes AI relationships, shared conversations 47)12 / 15Auto-Generated Narrative Immersion5+ (Potentially reality-distorting)Adolescents: 5/5  Socially Isolated: 5/5  General Pop.: 5/5 (Exploits universal narrative desire 66)4 (Potential to reshape shared cultural narratives)14+ / 15
 ## Part 5: A Mitigation Playbook for System Architects
 The existence and proliferation of the Jest-loop is not an inevitability but a consequence of specific design choices that prioritize engagement above all else. This section presents a playbook of practical, implementable technical interventions for system architects and product managers. The goal is to shift from a paradigm of user exploitation to one of user well-being and sustainable engagement.
@@ -572,57 +600,57 @@ Mitigation: Prototyping and testing Friction UX and rate-limiting interventions 
 Validation: Leveraging the Benchmark Lab to test interventions and adapt models using real-world data.
 ### 7.2 Sprint Backlog
 NOW (Current Sprint: Immediate Actions)
-** Task:** Instrument UME to log high-frequency engagement micro-behaviors.
+**Task:** Instrument UME to log high-frequency engagement micro-behaviors.
 Description: Go beyond standard event logging (clicks, views). Add client-side instrumentation to capture scroll velocity, viewport dwell time on individual content items, and re-watch/re-read events.
 Tag: UME, Data-Ingestion
 Time: 2 hours
-** Task:** Develop a v1 "Addiction Score" heuristic.
+**Task:** Develop a v1 "Addiction Score" heuristic.
 Description: Create a scheduled script that post-processes UME session data. Implement a simple heuristic score per session: score = log(session_duration_seconds) * (interactions_per_minute). This provides a baseline metric to track.
 Tag: UME, Analytics
 Time: 2 hours
 
-** Task:** Prototype a "Load More" pagination component in TaskCascadence.
+**Task:** Prototype a "Load More" pagination component in TaskCascadence.
 Description: In a feature-flagged branch of the TaskCascadence UI, replace the infinite scroll on a primary content feed with a simple "Load More" button that appears after every 20 items.
 Tag: TaskCascadence, Prototype, Friction-UX
 Time: 2 hours
-** Task:** Set up the Dossier's Benchmark Lab locally.
+**Task:** Set up the Dossier's Benchmark Lab locally.
 Description: Clone the jest-loop-lab repository, create a virtual environment, install requirements.txt, and run the baseline simulation notebook to validate the local setup and reproduce the scorecard results.
 Tag: Lab, Setup
 Time: 2 hours
 NEXT (Next 1-2 Sprints: Building on the Foundation)
-** Task:** Integrate the cognitive switch cost model into UME.
+**Task:** Integrate the cognitive switch cost model into UME.
 Description: Assuming content items have topic embeddings, adapt the calculate_cognitive_switch_cost function from the lab. Create a batch job in UME that calculates and logs the topic volatility for each user session.
 Tag: UME, Analytics
 Time: 2 hours
-** Task:** Prototype a user-configurable time-limit governor.
+**Task:** Prototype a user-configurable time-limit governor.
 Description: Add a new settings page in TaskCascadence allowing users to set a daily time limit. Implement a client-side timer that displays a non-blocking notification when the limit is reached.
 Tag: TaskCascadence, Prototype, Rate-Limit
 Time: 2 hours
-** Task:** A/B test pagination vs. infinite scroll.
+**Task:** A/B test pagination vs. infinite scroll.
 Description: Launch an A/B test for the "Load More" button feature flag. Track the impact on the v1 Addiction Score from UME, as well as on core product metrics like 7-day retention and items interacted per session.
 Tag: TaskCascadence, Experiment, Friction-UX
 Time: 2 hours
 
-** Task:** Adapt the Benchmark Lab to use real UME data.
+**Task:** Adapt the Benchmark Lab to use real UME data.
 Description: Write a script to export anonymized user interaction sequences from UME. Modify the JestLoopEnv to replay these real sequences instead of using the synthetic user model, allowing for more realistic testing of mitigation policies.
 Tag: Lab, UME, Integration
 Time: 2 hours
 LATER (Future Quarters: Systemic & Strategic Initiatives)
-** Task:** Develop a shadow RL policy optimizing for a "Humane" reward function.
+**Task:** Develop a shadow RL policy optimizing for a "Humane" reward function.
 Description: Using the data from the adapted lab, train a new RL policy offline. Define a new reward function: humane_reward = engagement_reward - (lambda * addiction_score). Compare its recommendations to the production model.
 Tag: UME, RL, Ethics
 Time: 2 hours
 
-** Task:** Integrate robust watermarking for all AI-generated content.
+**Task:** Integrate robust watermarking for all AI-generated content.
 Description: Research and implement a library for invisible watermarking of any text or image content generated by AI within TaskCascadence. Ensure the watermark contains the model ID and a timestamp.
 Tag: TaskCascadence, Safety, Generative-AI
 Time: 2 hours
-** Task:** Draft a design document for a system-wide kill-switch protocol.
+**Task:** Draft a design document for a system-wide kill-switch protocol.
 Description: Outline the technical architecture for a kill-switch for all generative AI features. Define trigger conditions (e.g., detection of harmful content generation, runaway addictiveness metrics), the shutdown procedure, and the governance process for activation.
 Tag: System-Architecture, Safety
 Time: 2 hours
 
-** Task:** Present findings to the internal ethics review board.
+**Task:** Present findings to the internal ethics review board.
 Description: Synthesize the results from the A/B tests and the analysis from the Policy & Ethics Brief into a presentation for legal and ethics stakeholders, proposing the formal adoption of a Humane Design policy.
 Tag: Policy, Ethics
 Time: 2 hours

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,15 @@
 
 This repository aggregates documentation and research across multiple projects.
 
+## Quickstart
+
+```bash
+pip install -r requirements.txt
+mkdocs serve
+```
+
+Visit <http://127.0.0.1:8000> to preview the site locally.
+
 ## Directory Structure
 
 - `ai-research/` – AI and machine learning notes
@@ -11,6 +20,26 @@ This repository aggregates documentation and research across multiple projects.
 - `_project-docs/` – submodule mounts for individual projects
 - `scripts/` – helper scripts including ingest utilities
 - `playbooks/` – workflow and container playbooks
+
+## Research Docs
+
+The `ai-research/` folder collects design notes and technical dossiers for
+ongoing experiments. Key documents include:
+
+- [Strategic R&D Roadmap for DeepThought-ReThought](ai-research/strategic-roadmap-deepthought.md)
+- [Reverse-Engineering OpenAI Codex](ai-research/reverse-engineering-codex.md)
+- [Seed-Factory Feasibility Dossier](ai-research/seed-factory-feasibility-dossier.md)
+- [Agentic SWE Discontinuity Forecast](ai-research/agentic-swe-discontinuity-forecast.md)
+- [Energy-Efficient Swarm](ai-research/energy-efficient-swarm.md)
+- [Neurosymbolic Reasoning Dossier](ai-research/neurosymbolic-reasoning-dossier.md)
+- [Friend or Foe PRD](ai-research/discord-friend-foe-prd.md)
+- [Logical Chunking Strategies](ai-research/logical-chunking.md)
+- [Peaks and Freezes](ai-research/peaks-and-freezes.md)
+- [Thick Band of 21st-Century Possibilities](ai-research/thick-band-of-21st-century-possibilities.md)
+- [You Weren't Supposed to Invent Infinite Jest](ai-research/you-werent-supposed-to-invent-infinite-jest.md)
+
+See [ai-research/index.md](ai-research/index.md) for additional context and any
+newly added reports.
 
 ## Project Documentation Submodules
 
@@ -61,8 +90,7 @@ mkdocs serve
 
 Visit http://127.0.0.1:8000 to preview the site locally.
 
-The site automatically deploys via GitHub Actions whenever you push updates to
-Markdown files or `mkdocs.yml`.
+The site automatically deploys via GitHub Actions whenever you push updates to Markdown files or `mkdocs.yml`.
 
 ## Installing Node Dependencies
 
@@ -85,8 +113,7 @@ scripts/setup_hooks.sh
 ## Invoking the Migration Script
 
 You can import configuration and prompt snippets from the old
-[`d0tTino/d0tTino`](https://github.com/d0tTino/d0tTino) repository.
-Ensure `git-filter-repo` is installed (for example via `pip install git-filter-repo` or your package manager) before running the script.
+[`d0tTino/d0tTino`](https://github.com/d0tTino/d0tTino) repository. Ensure `git-filter-repo` is installed (for example via `pip install git-filter-repo` or your package manager) before running the script.
 
 Run the migration script from the repository root:
 
@@ -94,9 +121,7 @@ Run the migration script from the repository root:
 scripts/migrate_old_docs.sh
 ```
 
-The script clones the legacy repo, filters only the documentation
-files using `git filter-repo`, and fetches the result as a local branch
-called `d0tTino-import`. Merge that branch to incorporate the history:
+The script clones the legacy repo, filters only the documentation files using `git filter-repo`, and fetches the result as a local branch called `d0tTino-import`. Merge that branch to incorporate the history:
 
 ```bash
 git merge d0tTino-import --allow-unrelated-histories

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Tino Docs Hub
+site_description: Central hub for project documentation
 theme: material
 docs_dir: docs
 plugins:
@@ -21,6 +22,7 @@ nav:
       - Peaks and Freezes: ai-research/peaks-and-freezes.md
       - Agentic SWE Discontinuity Forecast: ai-research/agentic-swe-discontinuity-forecast.md
       - Thick Band of Possibilities: ai-research/thick-band-of-21st-century-possibilities.md
+      - You Weren't Supposed to Invent Infinite Jest: ai-research/you-werent-supposed-to-invent-infinite-jest.md
   - Arduino: arduino/index.md
   - Terminal Workflow: terminal-workflow/index.md
   - Culture Project: culture-project/index.md


### PR DESCRIPTION
## Summary
- add Quickstart section to README and docs index
- fix line breaks in deployment and migration instructions
- specify a brief site description in mkdocs config
- add research docs overview section in README and docs index
- flesh out ai-research index page with document links
- expand AI research docs listing and navigation
- write a short introduction for the logical chunking page
- strip trailing spaces across research docs
- fix markdownlint issues in Infinite Jest report
- remove leftover whitespace in Infinite Jest report

## Testing
- `npx markdownlint docs/ai-research/*.md README.md docs/index.md`

------
https://chatgpt.com/codex/tasks/task_e_688933eb31108326a6b402abd569219c