### PR TITLE
Add Grok 4 Heavy reverse engineering report

### DIFF
--- a/docs/ai-research/index.md
+++ b/docs/ai-research/index.md
@@ -13,6 +13,7 @@ navigation sidebar.
 
 - [Strategic R&D Roadmap for DeepThought-ReThought](strategic-roadmap-deepthought.md)
 - [Reverse-Engineering OpenAI Codex](reverse-engineering-codex.md)
+- [Reverse-Engineering Grok 4 Heavy](reverse-engineering-grok4-heavy.md)
 - [Seed-Factory Feasibility Dossier](seed-factory-feasibility-dossier.md)
 - [Agentic SWE Discontinuity Forecast](agentic-swe-discontinuity-forecast.md)
 - [Energy-Efficient Swarm](energy-efficient-swarm.md)

--- a/docs/ai-research/reverse-engineering-grok4-heavy.md
+++ b/docs/ai-research/reverse-engineering-grok4-heavy.md
@@ -1,0 +1,580 @@
+---
+title: "Reverse-Engineering Grok 4 Heavy"
+tags: [reverse-engineering, ai-research, xai]
+project: ai-research
+updated: 2025-07-10
+---
+
+# Reverse-Engineering Design Report: Grok 4 Heavy Multi-Agent Framework
+
+## 1.0 Executive Summary
+
+### 1.1 Overview of Findings
+
+This report presents a detailed reverse-engineering analysis of the multi-agent framework that constitutes the core technological differentiator of xAI's Grok 4 Heavy model. The analysis concludes that Grok 4 Heavy is not a monolithic Large Language Model (LLM) but a sophisticated, supervised multi-agent system. The "Heavy" designation refers to a collaborative framework architected to orchestrate multiple specialized agent instances, which are themselves powerful models, to solve complex problems that exceed the capabilities of a single agent.
+
+The system's primary operational modality involves decomposing complex user prompts into a structured graph of sub-tasks. These tasks are then distributed among a pool of specialized agents that work in parallel and collaboratively, sharing information to build upon each other's work. Public statements describe this as being analogous to a "study group" where agents can "solve a problem in parallel and compare answers," a mechanism designed to enhance reasoning and reduce errors. This collaborative approach is credited with significant performance gains, including a reported 40% faster problem-solving time on complex tasks and a reduction in model hallucination through cross-checking.
+
+### 1.2 Inferred Architecture at a Glance
+
+The inferred architecture of the Grok 4 Heavy framework is a hierarchical, multi-component system designed for parallelism, specialization, and high-bandwidth coordination. The primary components are:
+
+- **The Orchestrator Agent**: A supervisor or router agent that serves as the system's central nervous system. It receives the user prompt, performs task decomposition to generate a dependency graph of sub-tasks, and routes these tasks to the most suitable expert agents. It also manages a consensus loop, assigning results to a critique agent for verification and initiating refinement cycles.
+
+- **Specialized Expert Agents**: A pool of subordinate agents, each a specialized, fine-tuned version of the base Grok 4 model. These agents are tailored for specific domains, such as the CodeGen agent for software development tasks, a MathProver for mathematical reasoning, a DataSynthesizer for retrieving and structuring information, and a CritiqueAgent for evaluating the work of other agents. The foundation of these agents is likely a Mixture-of-Experts (MoE) architecture, creating a "nested MoE" system that provides two layers of sparse activation for computational efficiency.
+
+- **Implicit Coordination Subsystem**: A high-throughput, low-latency communication bus that enables implicit coordination among agents. This subsystem is likely modeled on a Shared Recurrent Memory Transformer (SRMT) architecture. In this model, each agent contributes its internal state to a global shared memory, which all other agents can read via a cross-attention mechanism. This allows for near-instantaneous sharing of context and intentions without the overhead of explicit messaging protocols, facilitating the dynamic collaboration described as a key feature.
+
+### 1.3 Re-implementation Strategy
+
+A functionally equivalent, open-core implementation is technically feasible using existing open-source technologies. The proposed blueprint avoids direct cloning of proprietary models and instead focuses on recreating the architectural patterns and interaction logic of the framework. The strategy involves a hybrid approach, leveraging the strengths of multiple open-source multi-agent frameworks. CrewAI is recommended for its high-level, role-based abstractions to define the Orchestrator and Expert Agent roles, providing a structured and manageable workflow. The underlying agent-to-agent communication fabric would be implemented using 
+
+AutoGen for its flexible, event-driven, and conversational capabilities, which better model the dynamic "study group" interaction.
+
+The base agents will be built upon open-weight MoE models such as Mixtral 8x22B or Llama 3, which can be fine-tuned for specialized tasks. The implicit coordination subsystem can be functionally emulated using a high-performance message bus like Redis Pub/Sub to broadcast agent state updates.
+
+### 1.4 Legal & Feasibility Assessment
+
+The re-implementation project is assessed as technically feasible and can be conducted within the legal framework of the Digital Millennium Copyright Act (DMCA), specifically under the reverse engineering for interoperability exemption provided by 17 U.S.C. \u00a7 1201(f). This legal safe harbor permits the analysis of a program to identify the elements necessary to create an independent program that can interoperate with it. In this context, "interoperability" is interpreted as the ability of an independently created system to process the same class of complex problems and data formats as the target system.
+
+To ensure compliance, the project must adhere to a strict "clean room" protocol, where the analysis team that produces this report is completely firewalled from the development team that builds the new system. The objective is not to replicate the proprietary Grok 4 model weights or code verbatim but to understand and re-implement the architectural methods of multi-agent collaboration. This approach, supported by legal precedents such as Sega Enterprises v. Accolade, provides a sound legal basis for the project.
+
+## 2.0 Scope & Legal Constraints
+
+### 2.1 Project Scope
+
+The scope of this reverse-engineering endeavor is precisely defined and strictly limited. The primary target of analysis is the multi-agent orchestration and collaboration framework that distinguishes Grok 4 Heavy from the base Grok 4 model. The project will not, under any circumstances, attempt to reverse-engineer, extract, or replicate the proprietary weights of the underlying Grok 4 foundation model.
+
+The analysis focuses on identifying and documenting the following functional components and their interactions:
+
+The logic of the Orchestrator Agent, including its methods for task decomposition and agent routing.
+
+The architecture of the Expert Agents, specifically their specialization and how they are managed within a pool.
+
+The mechanisms for inter-agent communication, including both the high-bandwidth implicit coordination subsystem and any explicit messaging protocols.
+
+The system's approach to task state management, consensus, and result synthesis.
+
+The final deliverable of this analysis is this Reverse-Engineering Design Report (REDR), which will serve as the complete specification for an independent implementation.
+
+### 2.2 Legal Framework: DMCA \u00a71201(f) Analysis
+
+The entire project is predicated on the legal protections afforded by the Digital Millennium Copyright Act (DMCA), specifically the exception for reverse engineering for the purpose of interoperability, codified in 17 U.S.C. \u00a7 1201(f). A thorough understanding of this statute is critical to ensure the project remains legally compliant.
+
+The statute permits a person who has lawfully obtained a copy of a computer program to circumvent technological protection measures for the sole purpose of identifying and analyzing the elements of that program necessary to achieve interoperability with an independently created computer program. This right is contingent on the necessary interface information not having been previously made readily available. The information and tools developed through this process may be shared with others, but only for the purpose of enabling such interoperability.
+
+Key legal precedents, particularly Sega Enterprises v. Accolade and Atari Games Corp. v. Nintendo, have established a robust interpretation of this principle. In Sega, the court ruled that disassembly of Sega's game console code was a "fair use" because it was the only way for Accolade to discover the functional requirements for making their independently created games compatible with the Sega Genesis console. The court recognized that prohibiting such analysis would "stifle the free flow of ideas" and grant a de facto monopoly over the market, which was not the intent of copyright law.
+
+This project applies the same logic. The goal is not to create a clone of Grok 4 Heavy, but to build an independent multi-agent system that is "compatible" with the same class of complex, multi-step reasoning problems. To achieve this functional interoperability, it is necessary to understand the methods of collaboration, task decomposition, and inter-agent communication\u2014the unprotected functional elements of the system. Reverse engineering the framework is therefore a necessary step to enable the creation of a new, competitive, and independently developed program that operates in the same problem domain.
+
+### 2.3 Operational Constraints & Clean Room Protocol
+
+To maintain a strict legal boundary between permissible analysis and impermissible infringement, this project must be conducted under a "clean room" protocol. This protocol establishes an organizational and procedural firewall between two distinct teams:
+
+The Analysis Team: This team (the author of this report) has access to the target software (hypothetically) and is responsible for performing all reverse-engineering activities. The sole output of this team is this REDR, which documents the functional specifications, architectural patterns, and interface requirements of the Grok 4 Heavy framework. This report must not contain any verbatim proprietary code or data.
+
+The Implementation Team: This team is responsible for developing the new, open-core multi-agent system. This team is firewalled from the Analysis Team and has no access to the original Grok 4 Heavy software. Their development work will be based exclusively on the specifications provided in this REDR.
+
+This separation ensures that the final product is an independent creation, derived from a functional specification rather than from direct copying of the original work's expression. Adherence to this protocol is paramount for operating within the safe harbor of DMCA \u00a71201(f).
+
+## 3.0 Environment Baseline
+
+To ensure the reproducibility and technical grounding of this analysis, a specific, albeit hypothetical, environment is defined. This baseline provides a concrete foundation for the methodologies described and allows for the theoretical verification of the findings.
+
+Table 3.1: Analysis Toolchain
+The following table specifies the software toolchain used for this analysis. The selection of these tools directly informs the methods and potential findings of the reverse-engineering process. For example, the choice of Ghidra provides powerful decompilation and collaborative analysis features, while Frida enables sophisticated dynamic instrumentation and API hooking.
+
+Tool Name\tVersion\tSHA-256 Hash (Tool Binary)\tPurpose
+Ghidra\t11.1.2_PUBLIC\te3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\t\nStatic Analysis, Decompilation, Sleigh Processor Definition 
+
+Frida Toolkit\t16.3.3\ta1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2\t\nDynamic Analysis, API Hooking, Memory Inspection 
+
+Wireshark\t4.2.5\tf5e6d7c8b9a0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6\tNetwork Protocol Analysis (for API interactions)
+QEMU\t8.2.2\tb9a8c7d6e5f4d3c2b1a09f8e7d6c5b4a3d2c1b0a9f8e7d6c5b4a3d2c1b0a9f8e\tSystem Emulation (for sandboxed dynamic analysis)
+Python 3.11\t3.11.8\tc3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4\tScripting for Automation (Frida scripts, data parsing)
+Table 3.2: Target System Artifacts (Hypothetical)
+The analysis targets a set of hypothetical binary artifacts that would constitute a client-side implementation of the Grok 4 Heavy system. These artifacts represent the attack surface for reverse engineering.
+
+Artifact Name\tType\tSHA-256 Hash (Hypothetical)\tDescription
+grok_heavy_client.exe\tPE64 Executable\tdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tMain client application, presumed to contain the high-level orchestration logic and user interface components.
+libgrok_agent.dll\tPE64 DLL\tcafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe\tShared library containing the core agent execution runtime, task management, and communication stubs.
+grok_mem_coord.sys\tKernel Driver\tbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d\tA hypothetical kernel-mode driver to facilitate high-speed, cross-process shared memory for the implicit coordination subsystem.
+
+
+## 4.0 Methodology
+
+The reconstruction of the Grok 4 Heavy framework's architecture is achieved through a multi-pronged methodology that combines static analysis, dynamic instrumentation, and an iterative process of architectural modeling. This approach allows for the cross-validation of findings and the development of a comprehensive system model, from low-level code constructs to high-level component interactions.
+
+### 4.1 Static Analysis
+
+Static analysis involves examining the binary artifacts without executing them, providing a foundational understanding of the software's structure, logic, and data.
+
+Disassembly & Decompilation: Using Ghidra, the target binaries (grok_heavy_client.exe and libgrok_agent.dll) are disassembled into assembly language and then decompiled into a C-like pseudocode. This process is fundamental for identifying function boundaries, data structures, and string literals that may hint at agent roles (e.g., "CodeGen", "CritiqueAgent") or communication protocols.
+
+Control Flow Graphing (CFG): Ghidra's CFG capabilities are used to visualize the logical flow within key functions. This analysis focuses on identifying complex decision points, such as loops that iterate over an agent pool or conditional branches that determine task routing based on specific criteria. These graphs are instrumental in reverse-engineering the core logic of the Orchestrator Agent.
+
+Symbolic Execution: Where control flow is highly complex or obfuscated, symbolic execution tools like angr or Manticore are employed. By replacing concrete inputs with symbolic variables, these tools can explore multiple execution paths simultaneously to determine the conditions required to reach specific code blocks, such as those responsible for initializing the shared memory bus or dispatching a task.
+
+### 4.2 Dynamic Analysis (Instrumentation)
+
+Dynamic analysis involves observing the software during execution to understand its runtime behavior, data flows, and interactions with the operating system and network.
+
+API Hooking with Frida: The Frida toolkit is the primary tool for dynamic analysis. Scripts are developed to inject into the running 
+
+grok_heavy_client.exe process and hook key functions within libgrok_agent.dll. This allows for the interception of function calls in real-time to inspect arguments (e.g., serialized task objects), return values (e.g., agent results), and the flow of data between the orchestrator and the agent runtime.
+
+System Call Tracing: Standard OS utilities (strace on Linux, or equivalent Windows tools) are used to monitor system calls made by the process. This is particularly useful for identifying inter-process communication (IPC) mechanisms, file I/O related to configuration or logging, and the creation of child processes or threads for each agent.
+
+Network Traffic Analysis: Wireshark is used to capture and analyze network packets originating from the client. This is crucial for distinguishing between client-side logic and server-side operations. By correlating API hooks from Frida with observed network traffic, it is possible to map internal function calls to specific REST API endpoints, revealing the schema of the data being exchanged with xAI's backend servers.
+
+### 4.3 Architecture Reconstruction
+
+The findings from static and dynamic analysis are synthesized in an iterative process to reconstruct the system's architecture. This process follows the C4 model, starting at a high level and progressively adding detail.
+
+Context & Container Model: Initial dynamic analysis provides a black-box view, identifying the main process (grok_heavy_client.exe), its libraries (libgrok_agent.dll), and its external communications (API endpoints, file system). This forms the initial C4 context and container diagram.
+
+Component Model: Static analysis and API hooking are then used to look inside the containers. Functions are grouped into logical components based on their roles (e.g., TaskDecomposer, AgentRouter, SharedMemoryManager). This step refines the model by identifying the internal building blocks of the framework.
+
+A key challenge in this phase is differentiating between logic executed locally and logic that serves as a proxy for remote, server-side functionality. The methodology explicitly focuses on finding the "seam" between the client and server. The correlation of internal function calls with outbound network requests is the primary technique used to map the client-side architectural components to their corresponding backend services, ensuring the reconstructed architecture accurately reflects the division of labor in the distributed system.
+
+## 5.0 System Overview Diagram
+
+The following diagram illustrates the inferred high-level "Container" view of the Grok 4 Heavy multi-agent framework. It depicts the primary logical components and the flow of data and control from the initial user prompt to the final synthesized response. The architecture is centered around an Orchestrator Agent that manages a workflow executed by a pool of Specialized Agents, who collaborate implicitly via a Shared Memory Bus.
+
+```mermaid
+graph TD
+    subgraph User Interaction Layer
+        A[User Prompt]
+    end
+
+    subgraph Grok 4 Heavy Framework
+        B(Orchestrator Agent)
+        C(Task Graph)
+        D{Implicit Coordination Subsystem <br> (Shared Memory Bus)}
+        E[Agent Pool]
+    end
+
+    subgraph Specialized Agents
+        F1(Agent 1: CodeGen)
+        F2(Agent 2: MathProof)
+        F3(Agent 3: DataSynth)
+        F4(Agent 4: Critique)
+    end
+
+    subgraph External Services
+        G
+        H
+    end
+
+    A -- "1. User submits complex query" --> B;
+    B -- "2. Decomposes prompt into structured plan" --> C;
+    B -- "3. Assigns sub-tasks to agents" --> E;
+    E -- "Contains specialized agents" --> F1;
+    E -- " " --> F2;
+    E -- " " --> F3;
+    E -- " " --> F4;
+    F1 -- "4a. Writes state/partial results" --> D;
+    F2 -- "4a. Writes state/partial results" --> D;
+    F3 -- "4a. Writes state/partial results" --> D;
+    F4 -- "4a. Writes state/partial results" --> D;
+    D -- "4b. Broadcasts global context to all agents" --> F1;
+    D -- " " --> F2;
+    D -- " " --> F3;
+    D -- " " --> F4;
+    F1 -- "5. Uses external tools if needed" --> G;
+    F3 -- "5. Uses external tools if needed" --> H;
+    B -- "7. Aggregates results & synthesizes final response" --> Final_Response;
+    F1 -- "6. Sends completed sub-task result" --> B;
+    F2 -- "6. Sends completed sub-task result" --> B;
+    F3 -- "6. Sends completed sub-task result" --> B;
+    F4 -- "6. Sends critique for peer review" --> B;
+
+    style B fill:#f9f,stroke:#333,stroke-width:2px
+    style D fill:#ccf,stroke:#333,stroke-width:2px
+    style F1 fill:#bbf,stroke:#333,stroke-width:1px
+    style F2 fill:#bbf,stroke:#333,stroke-width:1px
+    style F3 fill:#bbf,stroke:#333,stroke-width:1px
+    style F4 fill:#bbf,stroke:#333,stroke-width:1px
+```
+
+## 6.0 Detailed Findings
+
+This section provides a detailed analysis of the core components of the Grok 4 Heavy framework, as reverse-engineered through the methodology outlined in Section 4.0.
+
+### 6.1 Component: The Orchestrator Agent (Supervisor/Router)
+
+The Orchestrator is the central coordinating intelligence of the framework. It does not perform the primary reasoning itself but instead manages the workflow of the specialized agents. Its functions are inferred from public descriptions of "problem decomposition" and standard multi-agent system design patterns.
+
+Function: The Orchestrator's primary role is to act as a supervisor and router. It receives the initial, often complex and ambiguous, user prompt. Its first action is to analyze the prompt's intent and break it down into a structured series of smaller, more manageable sub-tasks. This process is critical for enabling parallel execution and specialization.
+
+Task Decomposition Algorithm: The decomposition process is likely implemented via a high-level call to a general-purpose LLM. The Orchestrator would use a meta-prompt to instruct the model to generate a formal plan, likely in a structured format like JSON or YAML. This plan would represent a task graph, defining the individual tasks, their dependencies, and the required inputs/outputs for each. This approach mirrors modern agentic frameworks that treat planning as a first-class step, avoiding the "single prompt failure mode" where a single agent gets lost in a complex workflow.
+
+Agent Routing: Once the task graph is created, the Orchestrator routes each sub-task to the most appropriate agent in the pool. This routing decision is likely based on metadata associated with each agent (e.g., {'agent_id': 'agent_001', 'specialization': 'python_code_generation', 'version': '1.2'}). This aligns with the "supervisor/router" pattern where a coordinator directs requests to specialized agents.
+
+Consensus Management: A key feature of Grok 4 Heavy is its ability to "compare answers" and perform "error checking". This implies the Orchestrator manages a peer-review or consensus loop. After an agent (e.g., 
+
+CodeGen) completes a task, the Orchestrator would assign its output to a CritiqueAgent. The CritiqueAgent's role is to evaluate the result for correctness, coherence, and adherence to constraints. If the critique is negative or suggests improvements, the Orchestrator can loop back, assigning a new refinement task to the original agent or a different one. This iterative refinement process is key to improving accuracy and reducing hallucinations.
+
+### 6.2 Component: The Expert Agent Architecture
+
+The power of the Grok 4 Heavy framework stems not just from its orchestration but from the capability of its individual agents. Analysis suggests these are not simple LLM instances but highly specialized and powerful models in their own right.
+
+Foundation: The publicly released Grok-1 model is a 314 billion parameter Mixture-of-Experts (MoE) model, where only 25% of weights are active for any given token. Grok 4 is an evolution of this architecture.
+
+Architectural Hypothesis: Each "expert agent" within the Grok 4 Heavy framework is a fine-tuned, specialized version of the base Grok 4 MoE model. For instance, the specialized coding model planned for release is likely the CodeGen agent within this framework. This agent would be the base Grok 4 model, further trained (fine-tuned) exclusively on a massive corpus of code and software engineering text.
+
+This leads to a "nested" or "fractal" MoE architecture, which is a key source of the system's efficiency and power. The system employs sparse activation at two distinct levels:
+
+Framework-Level Sparsity: The Orchestrator activates only one or a few specialized agents from the entire pool for a given sub-task.
+
+Agent-Level Sparsity: The activated agent, being an MoE model itself, then activates only a fraction (e.g., 25%) of its internal neural pathways (its "experts") to process the input tokens.
+
+This two-tiered sparse activation allows the system to have an enormous total parameter count (the sum of all parameters in all agents) while keeping the computational cost (active parameters or FLOPs) for any given task relatively low. This provides a technically sound explanation for the claims of achieving state-of-the-art performance while managing computational resources effectively.
+
+### 6.3 Component: The Implicit Coordination Subsystem (Shared Memory)
+
+For a "study group" of agents to collaborate effectively, they require a communication mechanism that is far more efficient than traditional, high-latency API calls. The architecture must support a form of high-bandwidth, low-latency information sharing.
+
+Inferred Solution: The most plausible architecture for this is one based on implicit communication via a shared state, analogous to the Shared Recurrent Memory Transformer (SRMT), a recent innovation in multi-agent reinforcement learning.
+
+SRMT Mechanism: In an SRMT-based system, direct agent-to-agent messaging is minimized. Instead, the system operates as follows :
+
+Individual Memory: Each agent maintains its own private working memory, typically a recurrent state vector that summarizes its history of observations and actions.
+
+Global Memory Pool: At each time step, the memory vectors from all active agents are pooled into a single, globally accessible shared memory space.
+
+Cross-Attention: When an agent needs to make a decision, it uses a transformer-based cross-attention mechanism. Its own state serves as the "query," while the global shared memory serves as the "keys" and "values."
+
+Implicit Coordination: This allows the agent to "attend" to the most relevant parts of the collective memory, implicitly gaining insight into the current state, progress, and potential intentions of all other agents without them having to send explicit messages.
+
+This architecture directly enables the "diverse perspectives" and real-time collaboration mentioned in public descriptions. It provides a robust technical foundation for the claimed performance improvements by drastically reducing communication overhead and allowing agents to coordinate their actions implicitly and continuously.
+
+### 6.4 Component: Inter-Agent Communication Protocol (Explicit)
+
+While the SRMT-like subsystem handles low-level, high-frequency coordination, a more structured, explicit communication protocol is required for high-level workflow management by the Orchestrator. The evidence suggests a "protocol stack" approach, combining different standards for different purposes.
+
+Task Orchestration (ACP-like): For managing the lifecycle of tasks, the Orchestrator likely uses a protocol with semantics similar to IBM's Agent Communication Protocol (ACP). This involves structured messages for delegating tasks, querying their status (todo, in_progress, finished), retrieving results, and handling exceptions. This provides the robust, auditable workflow management needed for a complex system.
+
+Tool & Data Access (MCP-like): When an agent needs to use an external tool (e.g., the integrated real-time web search ), it likely uses a standardized protocol similar to the Model Context Protocol (MCP). MCP acts as a universal adapter, providing a secure and consistent way for agents to connect to external APIs, databases, and other data sources, without requiring custom integration code for each tool.
+
+Table 6.1: Dependency & FOSS Replacement Audit
+To construct a legally compliant, open-core implementation, all proprietary components of the inferred architecture must be replaced with functionally equivalent, permissively licensed Free and Open-Source Software (FOSS) alternatives.
+
+Proprietary Component\tInferred Function\tFOSS Replacement(s)\tLicense\tRationale
+Grok 4 Base Model\tCore LLM Engine\tMixtral 8x22B, Llama 3 70B\tApache 2.0\t
+State-of-the-art, open-weight MoE and dense models that can be fine-tuned. 
+
+Orchestrator Logic\tTask Decomposition & Routing\tAutoGen, CrewAI\tMIT / Apache 2.0\t
+Mature, well-documented open-source frameworks for multi-agent systems. 
+
+Implicit Coordination Bus\tShared Memory Broadcast\tRedis (Pub/Sub), Apache Kafka\tMIT / Apache 2.0\t
+High-performance, scalable messaging systems capable of emulating a global broadcast bus. 
+
+Explicit Protocol\tTask/Tool Communication\tgRPC, HTTP/REST with Pydantic\tApache 2.0 / MIT\tStandard, efficient, and well-supported protocols for building microservices.
+Vector Database\tRAG for Data Synthesis Agent\tQdrant, Weaviate, Milvus\tApache 2.0\t
+Scalable, open-source vector search engines for retrieval-augmented generation. 
+
+## 7.0 Re-implementation Blueprint
+
+This section provides a prescriptive and actionable blueprint for engineering a functionally equivalent, open-core implementation of the Grok 4 Heavy multi-agent framework.
+
+### 7.1 Proposed Technology Stack
+
+The selection of the technology stack is optimized for rapid development, scalability, and alignment with the existing AI/ML ecosystem.
+
+Primary Language: Python 3.11+. Its dominance in the AI/ML space, extensive libraries, and robust community support make it the logical choice.
+
+Multi-Agent Framework (Hybrid): A combination of CrewAI and AutoGen is proposed.
+
+CrewAI will be used for its high-level, declarative, role-based abstractions. It is ideal for defining the Crew (the overall system), the Agents (Planner, Coder, Reviewer), and the Process (the sequential or parallel workflow), providing a clear and maintainable structure for the orchestration logic.
+
+AutoGen will be used to implement the underlying communication layer between agents. Its event-driven, conversational model is better suited for the dynamic, "chat-based" collaboration of the "study group," allowing for more flexible and emergent interactions than a rigid, top-down process.
+
+Shared Memory Bus Emulation: Redis (v7.x) with its Pub/Sub functionality. Redis provides a high-performance, in-memory data store that is perfect for broadcasting agent state updates. Each agent can publish its memory vector to a central channel, and all other agents can subscribe to that channel, effectively simulating the global memory pool of an SRMT architecture.
+
+Task Queue & State Management: Celery with a PostgreSQL or Redis backend. The Orchestrator will place decomposed tasks onto a Celery queue, allowing for asynchronous execution, retries, and persistent state tracking of the entire task graph.
+
+Base LLM Models: The system will be initialized with open-weight MoE models like Mixtral 8x22B or powerful dense models like Llama 3 70B. These models, released under permissive licenses like Apache 2.0, will serve as the foundation for fine-tuning the specialized expert agents.
+
+### 7.2 Modular Design & Plan
+
+The system will be architected as a set of containerized microservices, promoting separation of concerns, independent scalability, and maintainability.
+
+- **Module 1: Orchestrator Service** – A Python service that implements the main Crew. It exposes an API endpoint to receive user prompts. Its core logic uses an LLM to generate a structured Tasklist and then publishes the individual tasks as messages to the Celery task queue.
+
+- **Module 2: Agent Runtime** – A standardized Docker container environment for executing a single agent. The runtime will be configured at launch with the agent's specific role, system prompt, and a pointer to its fine-tuned model weights. It listens for tasks on its dedicated Celery queue and subscribes to the global memory channel on Redis.
+
+- **Module 3: Shared Memory Controller** – A dedicated service that manages the Redis instance. It can be extended to include logic for snapshotting the global memory state for debugging or implementing more complex pooling strategies beyond simple Pub/Sub.
+
+- **Module 4: Tool Abstraction Layer (TAL)** – A Python library, imported by the Agent Runtime, that provides a standardized interface for agents to use external tools (e.g., `tool.web_search(query)`). This decouples the agent logic from the specific implementation of each tool, mirroring the function of an MCP-like protocol.
+
+Table 7.1: Module Implementation Plan & Milestones
+This plan breaks the development process into logical, sequential milestones, transforming the architectural design into an actionable engineering project.
+
+Milestone\tModule\tKey Tasks\tDependencies\tPriority
+1\tAgent Runtime\tImplement base ConversableAgent class using AutoGen. Define agent state and memory vector structure. Containerize with Docker.\tBase LLM (Mixtral)\tCritical
+2\tTool Abstraction Layer\tCreate Python wrappers for essential tools (web search, calculator, file I/O). Define a standard tool-call schema.\t-\tHigh
+3\tOrchestrator Service (v1)\tImplement basic prompt-to-task-graph decomposition using a CrewAI Crew. Publish tasks to Celery.\tModule 1, Celery/Postgres\tCritical
+4\tShared Memory Controller\tSet up Redis instance and Pub/Sub channels. Define the schema for memory update messages (e.g., JSON with agent ID, timestamp, memory vector).\tRedis\tHigh
+5\tAgent Runtime (v2)\tIntegrate Redis subscription for reading the global memory bus. Implement cross-attention logic (simplified or full) over the pooled memory.\tModule 1, Module 4\tMedium
+6\tOrchestrator Service (v2)\tImplement the full peer-review loop (task -> agent -> critique -> refine). Manage complex state transitions.\tModule 3, Module 5\tMedium
+7\tMLOps Pipeline\tBuild the full CI/CD/CT pipeline in GitLab CI or GitHub Actions for automated testing and deployment of all modules.\tAll Modules\tHigh
+
+### 7.3 MLOps Build & Deployment Pipeline
+
+Deploying a multi-agent system requires a more sophisticated MLOps pipeline than that for a monolithic model. The pipeline must manage a heterogeneous collection of services and models.
+
+Continuous Integration (CI):
+
+On every commit, run unit tests for each module (Orchestrator, Agent Runtime, etc.).
+
+Run integration tests that verify the interaction between components (e.g., can an agent correctly use the Tool Abstraction Layer?).
+
+Automate code linting, security scanning (e.g., bandit), and dependency vulnerability checks.
+
+Continuous Delivery (CD):
+
+Successfully merged code triggers a build process that creates versioned Docker images for each service (Orchestrator, Agent Runtime).
+
+These images are pushed to a container registry (e.g., Docker Hub, AWS ECR).
+
+Deployment is managed via Kubernetes or a similar orchestrator, allowing for independent scaling and rolling updates of each agent or service.
+
+Continuous Training (CT):
+
+This pipeline is dedicated to fine-tuning the specialized expert agents.
+
+It automates the process of pulling new training data, running a fine-tuning job on a base model (e.g., Mixtral), evaluating the new model against a benchmark set, and, if successful, registering the new model version in a model registry.
+
+A critical feature of this MLOps design is the treatment of each agent as a distinct, versioned microservice. A change to the CodeGen agent's model should not force a redeployment of the entire system. To ensure stability, the CI pipeline must include a system-level integration test. This test will spin up a temporary, ephemeral ensemble of the latest agent versions (e.g., CodeGen:v1.3, MathProof:v1.2, CritiqueAgent:v1.5) and run them through a suite of complex, multi-step tasks to validate their collaborative behavior before any single component is promoted to the production environment.
+
+## 8.0 Security & Compliance Assessment
+
+### 8.1 Security Threat Model
+
+The distributed, collaborative nature of the proposed multi-agent architecture introduces unique security challenges that must be addressed in the design.
+
+Agent Poisoning / Prompt Injection: An adversary could craft a malicious user prompt designed to compromise the behavior of a single agent. If, for example, the CritiqueAgent is poisoned, it could approve faulty or malicious code generated by the CodeGen agent, leading to a system-wide failure.
+
+Mitigation: Implement strict input sanitization and validation at the Orchestrator level before any prompt is processed. Each agent should also have its own "guardrails" or constitutional principles in its system prompt to refuse inappropriate or dangerous requests.
+
+Data Leakage via Shared Memory: The shared memory bus, while efficient, creates a potential channel for data leakage. A compromised or buggy agent could inadvertently write sensitive information (e.g., PII from a document it processed) to the global memory bus, making it accessible to all other agents in the pool.
+
+Mitigation: Enforce a strict, validated schema for all messages written to the memory bus. Implement a dedicated, lightweight "Sanitizer" agent that subscribes to the bus and actively monitors for and redacts patterns matching PII, API keys, or other sensitive data.
+
+Infinite Loops and Resource Exhaustion: As noted in multi-agent design patterns, poorly defined termination conditions can lead to agents "bouncing" a task between each other indefinitely, consuming significant computational resources.
+
+Mitigation: The Orchestrator must enforce strict resource limits on every task. This includes a maximum number of iterations or refinement loops, a time-based deadline, and a computational "cost" budget (e.g., based on total tokens processed). If any task exceeds its budget, it is terminated, and an error is flagged.
+
+### 8.2 FOSS License Compliance
+
+A core requirement of the project is to build a legally compliant, open-core system that can be commercialized. This necessitates a careful audit of the licenses of all proposed FOSS components.
+
+License Review: The primary components of the proposed technology stack are governed by permissive licenses:
+
+Python: Python Software Foundation License (GPL-compatible).
+
+AutoGen, CrewAI, Pydantic: MIT License.
+
+Mixtral, Llama 3, Qdrant, Kafka: Apache License 2.0.
+
+Redis: Redis Source Available License (RSALv2) or other variants. The specific license must be checked for commercial use restrictions. If necessary, a FOSS alternative like Valkey (Linux Foundation) can be used.
+
+PostgreSQL: PostgreSQL License (permissive).
+
+Compliance Assessment: The MIT and Apache 2.0 licenses are highly permissive and allow for commercial use, modification, and distribution, provided that attribution and original copyright notices are maintained. They are compatible with each other and do not impose a "copyleft" obligation on the proprietary code of the open-core product. Therefore, the proposed stack is fully compatible with the project's goal of creating a commercializable system built on an open foundation.
+
+## 9.0 Validation/Test Plan
+
+A comprehensive validation and testing plan is essential to ensure the re-implemented system is robust, reliable, and achieves functional equivalence with the target. The plan must address the unique challenges of testing a non-deterministic, collaborative multi-agent system.
+
+### 9.1 Behavioral Parity Testing
+
+The objective is not to produce bit-for-bit identical outputs, which is impossible with non-deterministic LLMs, but to achieve behavioral parity. This means the system should exhibit a similar quality of reasoning, task completion capability, and adherence to instructions as the target system.
+
+Methodology: The testing will be based on the "simulation agent" paradigm, where the system's behavior is compared against a baseline.
+
+Golden Dataset Creation: A curated set of 100+ complex, multi-step prompts will be developed. These prompts will span various domains (coding, math, creative writing, planning) and will serve as the "golden" test set.
+
+Baseline Generation: If access to Grok 4 Heavy is available, its responses to the golden dataset will be recorded to serve as the baseline for comparison. If not, the baseline will be defined by a human-generated, high-quality "ideal" response for each prompt.
+
+Automated Evaluation with LLM-as-a-Judge: The responses from the re-implemented system will be compared against the baseline. This comparison will be performed by a powerful, independent LLM (e.g., GPT-4o or Claude 3 Opus) using a structured evaluation prompt. The judge LLM will score both responses on a Likert scale for metrics like correctness, helpfulness, clarity, and reasoning depth.
+
+Semantic Comparison: For regression testing, embedding similarity scores will be used to detect significant semantic shifts in agent behavior between versions.
+
+### 9.2 Performance Benchmarking
+
+Quantitative benchmarks are required to measure the system's efficiency, speed, and scalability.
+
+Metrics:
+
+Task Completion Rate (TCR): The percentage of sub-tasks completed successfully without critical errors.
+
+Cooperative Success Rate (CSR): A binary metric indicating whether the entire agent crew successfully achieved the final goal of the prompt. This is a key measure of collaboration.
+
+Latency: End-to-end response time, time-to-first-token, and per-agent task execution time.
+
+Resource Utilization: Average and peak CPU, GPU, and RAM usage per agent container.
+
+Communication Efficiency: The volume of data (in KB/task) passed through the shared memory bus, used to measure coordination overhead.
+
+Benchmarks: Standard academic benchmarks will be adapted for multi-agent evaluation.
+
+MMLU-Agent: A complex question from the MMLU benchmark will be given to the Orchestrator, and the quality of the final, synthesized answer from the crew will be evaluated.
+
+MT-Bench-Agent: A multi-turn conversational task from MT-Bench will be used to evaluate the system's ability to maintain context and coherence over an extended interaction managed by the agent crew.
+
+### 9.3 Multi-Agent System-Specific Testing
+
+This category of testing focuses on the unique failure modes of collaborative agent systems.
+
+Interaction Protocol Testing: A test harness will be built to simulate a "rogue" or "faulty" agent. This agent will intentionally send malformed messages, violate task protocols, or stop responding. These tests will validate the resilience and error-handling capabilities of the Orchestrator and the other agents.
+
+Scalability Stress Tests: The system will be subjected to load tests where the number of active agents in the pool is progressively increased from 2 to 64. Performance metrics (latency, CSR) will be monitored to identify bottlenecks in the Shared Memory Controller, the Task Queue, or the Orchestrator itself.
+
+Consensus Mechanism Testing: Specific test cases will be designed to trigger the critique-and-refine loop. For example, a prompt will be given where the initial answer is known to be subtly flawed, and the test will verify that the CritiqueAgent correctly identifies the flaw and that the Orchestrator successfully initiates a refinement cycle.
+
+Table 9.1: Validation Test Matrix
+This matrix maps key system features to specific validation methods and defines clear success criteria, providing a structured framework for the entire testing effort.
+
+System Feature\tTest Method\tKey Metric(s)\tSuccess Criteria\tRelevant Sources
+Task Decomposition\tUnit Test (Orchestrator)\tTask Graph Validity\tGenerated graph is a valid Directed Acyclic Graph (DAG); all tasks are assigned to an appropriate agent role.\t
+Agent Collaboration\tIntegration Test (Ensemble)\tCooperative Success Rate (CSR)\tCSR > 95% on the golden dataset.\t
+Hallucination Reduction\tBehavioral Parity Test\tLLM-as-a-Judge Factuality Score\tRe-implementation scores within 10% of the baseline system on factuality and correctness.\t
+System Scalability\tStress Test\tLatency vs. Number of Agents\tLatency increases sub-linearly with up to 32 concurrent agents.\t
+Fault Tolerance\tChaos Test (Agent Failure)\tSystem Recovery Time\tOrchestrator detects agent failure and re-assigns its task within 5 seconds.\t
+Contextual Awareness\tMulti-Turn Conversation Test\tMT-Bench-Agent Score\tMaintains coherent context over 5+ turns, achieving a score comparable to top open models.\t
+
+## 10.0 Appendices
+
+### 10.1 Glossary
+
+ACP (Agent Communication Protocol): A protocol standard, developed by IBM, focused on orchestrating workflows, delegating tasks, and maintaining state across multiple agents in an enterprise context.
+
+Agent: An autonomous computational entity that can perceive its environment, make decisions, and take actions to achieve specific goals. In this context, an LLM-powered software program.
+
+AutoGen: An open-source framework from Microsoft for building multi-agent applications, focusing on flexible, conversational interactions between agents.
+
+CFG (Control Flow Graph): A graphical representation of all paths that might be traversed through a program during its execution.
+
+Clean Room Reverse Engineering: A method used to prevent copyright infringement, where two isolated teams—one for analysis and one for development—are used to re-create a piece of software based on its functional specifications.
+
+CrewAI: An open-source framework for orchestrating role-playing, autonomous AI agents to work together on complex tasks.
+
+CSR (Cooperative Success Rate): A benchmark metric for multi-agent systems that measures whether the entire group of agents successfully achieved a common goal.
+
+DBI (Dynamic Binary Instrumentation): A technique for analyzing the behavior of a binary program by injecting instrumentation code while it is running.
+
+DMCA (Digital Millennium Copyright Act): A United States copyright law that, among other things, provides a legal safe harbor for reverse engineering for the purpose of software interoperability (\u00a71201(f)).
+
+Frida: A popular dynamic instrumentation toolkit used for injecting scripts into running processes to hook functions and inspect memory.
+
+Ghidra: A free and open-source software reverse engineering suite developed by the NSA, including a disassembler, decompiler, and analysis tools.
+
+MCP (Model Context Protocol): A protocol standard designed to connect LLMs to external tools, APIs, and data sources in a universal way.
+
+MoE (Mixture-of-Experts): A neural network architecture, particularly for large transformer models, that consists of multiple "expert" sub-networks. For any given input, a routing mechanism activates only a sparse subset of these experts, increasing parameter count while keeping computational cost constant.
+
+Orchestrator: A master or supervisor agent in a multi-agent system responsible for decomposing tasks, routing them to appropriate worker agents, and managing the overall workflow.
+
+SRMT (Shared Recurrent Memory Transformer): A novel multi-agent architecture where agents coordinate implicitly by reading from and writing to a global shared memory space using attention mechanisms, rather than through explicit communication.
+
+### 10.2 Disassembly Excerpts (Illustrative)
+
+The following are illustrative, non-proprietary pseudocode examples representing the logic that would be recovered from key functions during decompilation. These are conceptual re-creations for demonstration purposes only.
+
+Example 1: Orchestrator Task Routing Logic
+
+```c
+// Decompiled pseudocode for a hypothetical function:
+// `TaskResult* route_task_to_agent(Task* task, AgentPool* pool)`
+
+TaskResult* route_task_to_agent(Task* pTask, AgentPool* pPool) {
+    char* required_specialization = get_specialization_for_task(pTask->type);
+    Agent* best_agent = NULL;
+    float max_score = 0.0;
+
+    // Iterate through the pool to find the best agent
+    for (int i = 0; i < pPool->agent_count; i++) {
+        Agent* current_agent = pPool->agents[i];
+        if (is_agent_available(current_agent) && 
+            strcmp(current_agent->specialization, required_specialization) == 0) {
+            
+            // Simple routing: pick the first available.
+            // A more complex implementation might score agents based on version or load.
+            best_agent = current_agent;
+            break;
+        }
+    }
+
+    if (best_agent!= NULL) {
+        // Dispatch task to the selected agent via an RPC call or message queue
+        int task_id = dispatch_async_task(best_agent->handle, pTask);
+        // Wait for the result with a timeout
+        TaskResult* result = await_task_result(task_id, 300000); // 5 min timeout
+        return result;
+    } else {
+        // Handle case where no suitable agent is available
+        log_error("No available agent for specialization: %s", required_specialization);
+        return NULL;
+    }
+}
+```
+
+### 10.3 Captured Data Traces (Illustrative)
+
+The following are examples of sanitized, hypothetical data structures that would be captured and reconstructed during dynamic analysis.
+
+Example 1: JSON representation of a Decomposed Task Graph
+
+```json
+{
+  "graph_id": "prompt-a4d8b",
+  "tasks": [
+    {
+      "task_id": "task_01",
+      "agent_role": "DataSynth",
+      "prompt": "Collect quarterly revenue figures for Nvidia and AMD and return them as a table.",
+      "outputs": ["nvidia_revenue_data", "amd_revenue_data"],
+      "dependencies": []
+    },
+    {
+      "task_id": "task_02",
+      "agent_role": "CodeGen",
+      "prompt": "Using the provided revenue data, write a Python script with matplotlib to generate a bar chart comparing the revenues. Save the chart to 'revenue_comparison.png'.",
+      "inputs": ["nvidia_revenue_data", "amd_revenue_data"],
+      "outputs": ["python_script", "chart_file"],
+      "dependencies": ["task_01"]
+    },
+    {
+      "task_id": "task_03",
+      "agent_role": "Critique",
+      "prompt": "Review the generated Python script for correctness and the bar chart for clarity and accuracy. Ensure the chart is properly labeled.",
+      "inputs": ["python_script", "chart_file"],
+      "outputs": ["critique_report"],
+      "dependencies": ["task_02"]
+    }
+  ]
+}
+```
+
+Example 2: Redis Pub/Sub Message for a Shared Memory Update
+
+```json
+{
+  "channel": "grok_heavy:global_memory",
+  "message": {
+    "timestamp": "2025-07-10T14:30:15.123Z",
+    "agent_id": "agent_002_mathproof",
+    "task_id": "task_b7c1a",
+    "status": "in_progress",
+    "memory_vector": [0.123, -0.456, 0.789,...],
+    "summary": "Attempting proof by induction. Step 2 seems problematic."
+  }
+}
+```
+
+### 10.4 Bibliography
+
+A complete list of all sources  through  and  through  would be included here in a standard bibliographic format (e.g., APA).
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - Overview: ai-research/index.md
       - Logical Chunking: ai-research/logical-chunking.md
       - Reverse Engineering Codex: ai-research/reverse-engineering-codex.md
+      - Reverse Engineering Grok 4 Heavy: ai-research/reverse-engineering-grok4-heavy.md
       - DeepThought-ReThought Roadmap: ai-research/strategic-roadmap-deepthought.md
       - Friend or Foe PRD: ai-research/discord-friend-foe-prd.md
       - Neurosymbolic Reasoning Dossier: ai-research/neurosymbolic-reasoning-dossier.md


### PR DESCRIPTION
## Summary
- add Grok 4 Heavy reverse engineering report to AI research docs
- include page in navigation and AI research index
- format headings in the new report for better readability
- tweak spacing and add bullet lists in the new report

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ac7a769348326b087dcb4c6573398