### PR TITLE
Add headings to docs

### DIFF
--- a/docs/ai-research/logical-chunking.md
+++ b/docs/ai-research/logical-chunking.md
@@ -5,6 +5,8 @@ project: culture
 updated: 2025-07-24
 ---
 
+# Logical Chunking Strategies
+
 This brief note summarizes common approaches for splitting long markdown files
 into semantically coherent chunks. Effective chunking improves retrieval for RAG
 pipelines and makes indexing large documents more efficient.

--- a/docs/ai-research/strategic-roadmap-deepthought.md
+++ b/docs/ai-research/strategic-roadmap-deepthought.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-27
 ---
 
+# Strategic R&D Roadmap for the DeepThought-ReThought Initiative
+
 Strategic R&D Roadmap for the DeepThought-ReThought Initiative: A Bayesian
 Synthesis for Maximizing Expected Value
 

--- a/docs/wave4-money-autonomy.md
+++ b/docs/wave4-money-autonomy.md
@@ -5,6 +5,8 @@ project: docs-hub
 updated: 2025-07-29
 ---
 
+# Real-World Cyberpunk Manifesto — Wave 4: Money & Autonomy
+
 This document is provided for research purposes only and does not constitute legal or financial advice.
 
 Introduction: From OPSEC to FINSEC — The Financial Counter-Attack


### PR DESCRIPTION
## Summary
- insert headings after front matter in logical chunking doc
- add heading after front matter in deepthought roadmap doc
- add heading after front matter in Wave 4 money & autonomy doc

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b8dc4b0c48326a49fb7b9b797410b