### PR TITLE
Add comprehensive netrunning research document

### DIFF
--- a/docs/netrunning-fiction-reality.md
+++ b/docs/netrunning-fiction-reality.md
@@ -1,0 +1,1389 @@
+---
+title: "Netrunning — Fiction, Reality, and the Modern Hacker Tool-Chain"
+tags: [cyberpunk, hacking]
+project: docs-hub
+updated: 2025-07-31
+---
+
+This document is provided for research purposes only and does not constitute legal or financial advice.
+
+# “Netrunning” — Fiction, Reality, and the Modern Hacker Tool-Chain
+
+## The Fictional Matrix: Deconstructing the Netrunner Archetype
+The concept of the "netrunner"—a digital renegade navigating a virtual world of pure data—is a cornerstone of the cyberpunk genre. It is an archetype that has evolved significantly since its inception, shaped by the technological anxieties and the narrative demands of the medium in which it is portrayed. Tracing this evolution from the abstract literary cyberspace of William Gibson to the gamified augmented reality of modern video games reveals a fascinating interplay between speculative fiction and the constraints of interactive storytelling. This lineage provides the essential cultural vocabulary needed to deconstruct the myths and map the realities of modern hacking.
+
+## The Gibsonian Cyberspace: The Foundational Text
+The entire aesthetic and lexicon of netrunning originates with William Gibson’s seminal 1984 novel, Neuromancer. Gibson did not just write a story; he forged a new mythology for the information age, introducing a set of concepts that would define the genre for decades to come. His work established the foundational tropes that remain culturally resonant today.
+
+At the heart of Gibson's vision is the "Matrix," a term he coined to describe a global computer network experienced as a "consensual hallucination". This was not a physical location but a vast, three-dimensional dataspace, a graphical representation of data abstracted from the memory banks of every computer in the human system. It was a universe of pure information, visualized as geometric shapes and glowing lines of light, a digital frontier to be explored and exploited.
+
+Navigating this frontier was the "console cowboy," the archetypal hacker as a marginalized, high-tech outlaw. Epitomized by the novel’s protagonist, Case, this figure is not a state-sponsored operative but a freelance mercenary operating in the urban decay of the "sprawl." This juxtaposition of immense technological power with a precarious, marginalized existence established the genre's central theme of "high tech, low life". The console cowboy is a product of the anxieties of the late 20th century, a forerunner to the real-world citizen investigator, activist, and whistleblower who operate on the digital margins of the contemporary corporate-state apparatus.
+
+The interface between the human and this digital world was the act of "jacking in." Through a direct neural link to a customized computer, or "cyberdeck," the console cowboy could achieve full sensory immersion in the matrix. This act, however, came at a cost: while the mind roamed cyberspace, the physical body ("meatspace") was left limp, unconscious, and utterly vulnerable—a critical thematic point emphasizing the disassociation between the digital and physical self.
+
+This digital world was not an empty space but a contested territory, defended by weaponized software known as Intrusion Countermeasures Electronics (ICE). Gibson popularized this term to describe security programs, often visualized as literal walls of ice or stone that had to be shattered by "icebreakers". The most feared variant was
+
+"Black ICE," a lethal form of security that could kill an intruding netrunner by inducing neural feedback, effectively frying their brain. This concept was revolutionary, as it translated the physical risks of trespass and espionage directly into the digital domain, giving cyberspace a tangible sense of danger.
+
+## Gamifying the Run: Cyberpunk 2020 & RED
+While Gibson provided the abstract vision, it was Mike Pondsmith and R. Talsorian Games that translated these literary concepts into a concrete, playable system with the tabletop role-playing game Cyberpunk 2020, first published in 1990. This act of adaptation required de-abstracting Gibson's "consensual hallucination" into a set of quantifiable rules, mechanics, and lore, a process that would define the popular understanding of netrunning for a generation.
+
+The most significant change was the transformation of the Net into a dungeon. In the mechanics of Cyberpunk 2020, the abstract dataspace of the Matrix became a literal grid-based map. Corporate systems, known as "Data Fortresses," were represented as multi-level virtual structures that the netrunner character would explore, moving from node to node as if traversing a dungeon. This design choice gamified the act of hacking, turning it into a tactical dungeon crawl with its own rules for movement, line-of-sight, combat initiative, and turn-based actions, completely separate from the physical world's mechanics.
+
+Within this virtual dungeon, the netrunner's arsenal was codified into a suite of programs that functioned like spells. The abstract "icebreakers" of Gibson's novels were given specific functions and names: "Hammers" were used to break down "Data Walls," "Codecrackers" were needed to open "Code Gates," and "Worms" served as intrusion tools. This created a clear and understandable mechanical framework for offense and defense, where a netrunner's effectiveness was determined by the strength and variety of the programs loaded onto their cyberdeck.
+
+
+The lore of the universe was further developed in the game's successor, Cyberpunk RED (2020), which is set in the year 2045. This edition introduced a cataclysmic event known as the
+
+DataKrash. According to the lore, the legendary netrunner Rache Bartmoss, upon his death, unleashed a wave of data-destroying viruses and rogue AIs (Artificial Intelligences) called R.A.B.I.D.S. into the global Net. This event shattered the old, unified cyberspace, leaving it a treacherous and largely impassable wasteland haunted by malevolent AIs. In response, the corporate-state entity Netwatch erected the
+
+"Blackwall," a powerful AI-driven firewall to quarantine the old Net. The "new Net" of the 2045 era is a fragmented collection of secure local area networks and a few heavily fortified data havens. This lore change had a profound impact on gameplay, forcing netrunners to be physically present at a location to "jack in" to its local network, fundamentally altering the dynamic from remote hacking to on-site infiltration.
+
+This shift reinforced a core concept from the original game: the meatspace problem. In both 2020 and RED, the act of jacking in renders the netrunner physically vulnerable. Their body is often incapacitated, blind and deaf to the physical world while their mind is in the Net. This creates a critical gameplay dependency, requiring the rest of the team (the Solos and Techs) to provide physical overwatch, protecting the netrunner's defenseless body from guards and security systems while the digital intrusion is underway.
+
+## The Modern Visualization: Cyberpunk 2077 and the Quickhack
+The 2020 video game adaptation, Cyberpunk 2077 by CD Projekt Red, represents the most recent and widely known iteration of netrunning, and it marks another significant evolution in the concept. Faced with the challenge of integrating the slow, turn-based "dungeon crawl" of the tabletop game into a fast-paced, first-person action RPG, the developers made a crucial design choice: they re-abstracted netrunning from a virtual reality experience into an augmented reality interface.
+
+This shift from VR to AR is the defining feature of netrunning in Cyberpunk 2077. With few exceptions, the player does not leave their body to enter a separate virtual world. Instead, the Net is experienced as an overlay on the physical environment. As Mike Pondsmith, the creator of the original tabletop game and a consultant on the video game, explained, this was a deliberate decision to move away from the classic "Gibson-esque worldview" and to keep the player character physically present and "under risk" during combat and infiltration scenarios. The slow, methodical netrun that would require the rest of the party to stand around and wait was deemed incompatible with the fluid pace of a modern video game.
+
+The primary mechanic for this new model is the "quickhack." By using their cybernetic eyes to scan enemies, cameras, turrets, and other devices, the player can instantly upload pre-packaged programs that have a direct and immediate effect. These quickhacks function like instant-cast spells, consuming a resource called
+
+RAM. They are divided into distinct categories:
+
+Covert hacks for stealth (e.g., disabling cameras, distracting enemies), Combat hacks for direct damage (e.g., Overheat, Short Circuit), Control hacks for crowd control (e.g., disabling cyberware, immobilizing enemies), and powerful Ultimate hacks that can neutralize targets instantly (e.g., Cyberpsychosis, Suicide). This system is explained in the lore as a new technique that was developed in the decades between
+
+Cyberpunk RED and Cyberpunk 2077.
+
+Another key trope introduced in the game is Braindance (BD) infiltration. Braindance is a technology that allows a user to relive a recording of another person's complete sensory and emotional experience. While primarily used for entertainment and illicit thrills in the world of Night City, the player uses a modified BD editor for forensic investigation. During these sequences, the player can pause the recording, move around the scene in a free-camera mode, and scan the environment in different spectra (visual, thermal, and audio) to uncover clues and reconstruct events. This mechanic provides a narrative tool for "infiltrating" a memory, turning a recorded experience into an interactive crime scene.
+
+The evolution of netrunning across these three major cultural touchstones is not merely a series of creative choices but a direct reflection of the design constraints and possibilities of each medium. Gibson's prose allowed for a highly abstract and metaphorical cyberspace. The structured rules of a tabletop RPG required a more literal and tactical representation, hence the "dungeon crawl." The demand for fluid, real-time gameplay in a first-person video game necessitated a move back toward abstraction, integrating hacking directly into the primary action loop as an augmented reality system. This journey from abstract VR to a literal dungeon and finally to an abstract AR interface demonstrates how the medium shapes the message, transforming the very definition of what it means to be a netrunner.
+
+## The Concrete Dystopia: Mapping Fiction to Real-World Hacking
+The dramatic, neon-drenched tropes of cyberpunk fiction, while stylized, are potent metaphors for the realities of modern offensive and defensive cybersecurity. The "console cowboy" jacking into the matrix is no longer a futuristic fantasy but an allegorical representation of the highly skilled individuals who operate in the digital world today. By systematically deconstructing these fictional concepts, one can create a direct map to the tools, techniques, and philosophies of the real-world hacker, transforming the popular imagination into a legible framework for understanding the concrete dystopia of the present.
+
+The following matrix serves as this translation layer, bridging the gap between the fictional netrunner and the modern cybersecurity professional. It grounds the fantasy in the tangible world of operating systems, security software, and established methodologies, revealing that the core conflicts of the cyberpunk genre—the struggle for access, the defense against intrusion, and the exploitation of information—are the daily business of the digital age.
+
+| Fiction Concept | Real-World Analogue | Primary Tools & Technologies |
+| --------------- | ------------------- | ---------------------------- |
+| **Cyberdeck** | Hardened Laptop / Secure Workstation | Hardware: ThinkPad/Framework laptop with neutralized Intel ME; OS: Qubes OS, Tails, Whonix; Core Philosophy: Endpoint Sovereignty, Security by Isolation. |
+| **ICE (Intrusion Countermeasures Electronics)** | Defensive Security Stack (Firewall, IDS/IPS, EDR) | Firewall: pfSense, OPNsense; IDS/IPS: Snort, Suricata, Zeek; EDR: SentinelOne, CrowdStrike Falcon, Microsoft Defender for Endpoint. |
+| **Black ICE** | Active Response Systems / Honeypots | Active Response: Automated blocking/quarantining in EDR/IPS; Honeypots: Systems designed to trap and analyze attackers (e.g., Cowrie, Dionaea). |
+| **Quickhack: Overheat / Short Circuit** | Destructive/Disruptive Payload | Exploit Frameworks: Metasploit modules for Denial-of-Service (DoS); Malware: Ransomware encryption routines, wiper malware. |
+| **Quickhack: System Reset / Suicide** | Remote Access Trojan (RAT) / Post-Exploitation Payload | C2 Frameworks: Cobalt Strike Beacon, Metasploit's Meterpreter; Actions: Remote command execution, process termination, privilege escalation. |
+| **Netrunner Programs (Worm, Hammer)** | Exploits & Vulnerability Scanners | Scanners: Nmap, Nessus; Exploit Kits: Pre-packaged exploits targeting specific vulnerabilities; Custom Scripts: Python/PowerShell for bespoke exploits. |
+| **Jacking In / Netrunning** | Gaining Initial Access & Post-Exploitation | Techniques: Phishing, exploiting public-facing applications; Frameworks: Metasploit, Cobalt Strike. |
+| **Data Fortress Run** | Penetration Test / Red Team Operation | Methodologies: PTES, MITRE ATT&CK; Objective: Emulate an adversary to test defenses and achieve objectives. |
+| **Meatspace Overwatch** | Physical Security / Incident Response Team | Physical Security: Guards, cameras, access controls; Incident Response (IR): SOC analysts monitoring alerts, IR teams responding to breaches. |
+| **Braindance Infiltration** | Advanced Social Engineering / Human Intelligence (HUMINT) | Techniques: Deepfake CEO Fraud, Reverse Social Engineering, AI-Personalized Spear Phishing; Tools: OSINT frameworks (Maltego, SpiderFoot), AI voice cloning. |
+
+A deeper analysis of this mapping reveals a fundamental inversion of a key strategic principle: the role of stealth versus noise. In fiction, the act of netrunning is often portrayed as a "loud," visually spectacular, and confrontational event. The console cowboy is depicted flying through glowing geometric landscapes, engaging in direct combat with anthropomorphic ICE constructs designed to violently repel them. The narrative climax is the dramatic breach, the shattering of the final layer of defense in a direct assault.
+
+The reality of modern, sophisticated hacking is precisely the opposite. The most effective and dangerous real-world operations are not loud but "low and slow." The primary strategic goal is not a dramatic breach but quiet, long-term persistence. A state-of-the-art command-and-control (C2) framework like Cobalt Strike is not designed to "hammer" a data wall. Its signature payload, the "Beacon," is engineered for stealth. It is designed to blend in with normal network traffic, communicating asynchronously with its controller and using "Malleable C2" profiles to disguise its communications to look like legitimate applications, such as a web browser checking for updates. The objective is to remain undetected within a network for months or even years, silently gathering intelligence and escalating privileges.
+
+Similarly, the fictional concept of "Black ICE"—a dramatic, lethal countermeasure that instantly kills the hacker—is a poor analogue for modern defensive systems. Real-world Endpoint Detection and Response (EDR) solutions are not designed to "fry the brain" of an attacker. Instead, they are built for subtle behavioral analysis and anomaly detection. They collect vast amounts of telemetry from endpoints and use machine learning to identify deviations from baseline behavior that might indicate an intrusion. They do not try to "kill" the operator; they aim to identify their Tactics, Techniques, and Procedures (TTPs) and silently generate an alert for a human Security Operations Center (SOC) analyst to investigate.
+
+This reveals a crucial strategic inversion. Fiction dramatizes the breach as a noisy, climactic event. Reality prioritizes the persistence that follows a silent, often trivial, initial entry. The true danger in the modern world is not the spectacular crash of a firewall, but the advanced persistent threat (APT) actor who has been reading an organization's internal communications for six months without anyone ever knowing they were there.
+
+## The Data Fortress Run: Modern Offensive Security Methodology
+The fictional "data fortress run" provides a compelling narrative for the act of hacking: a linear progression of casing the target, breaching the perimeter, navigating the internal network, achieving the objective, and escaping undetected. While a simplification, this narrative structure serves as a surprisingly effective metaphor for the highly structured, methodical processes that govern real-world offensive security operations. Far from being a chaotic art form, modern ethical hacking is a disciplined science, guided by established frameworks and a clear understanding of the adversary's lifecycle.
+
+### The Attack Lifecycle: PTES and MITRE ATT&CK
+The process of a professional hacking engagement is not improvised; it follows a well-defined lifecycle. The Penetration Testing Execution Standard (PTES) is a formal methodology that deconstructs an operation into seven distinct phases, providing a comprehensive roadmap from initial planning to final reporting. This standard provides a direct, professional analogue to the narrative arc of a fictional netrun.
+
+The seven phases of PTES are :
+
+Pre-Engagement Interactions: This is the planning phase, equivalent to the cyberpunk "fixer" meeting with a client to define the target and the rules of engagement. It involves scoping the assessment, defining objectives, and handling all legal and logistical preliminaries.
+
+Intelligence Gathering: This is the reconnaissance or "casing" phase. The operator uses Open-Source Intelligence (OSINT) techniques to gather as much information as possible about the target's infrastructure, personnel, and technology stack.
+
+Threat Modeling: The operator analyzes the intelligence gathered to identify the most likely attack vectors and threat actors. This is akin to a netrunner studying the blueprints of a data fortress to identify its weakest points.
+
+Vulnerability Analysis: This phase involves actively scanning and probing the target systems to identify specific, exploitable vulnerabilities. This is the direct equivalent of a netrunner scanning a data fortress for weak ICE or unpatched nodes.
+
+Exploitation: This is the "breach" phase, where the operator attempts to gain initial access by exploiting a discovered vulnerability. This corresponds to the netrunner using an "icebreaker" program to shatter the first layer of corporate defenses.
+
+Post-Exploitation: Once inside, the operator attempts to escalate privileges, move laterally through the network, and achieve the engagement's objectives (e.g., accessing a specific database, exfiltrating sensitive data). This is the "dungeon crawl" itself, the process of navigating the internal architecture of the data fortress to reach the data vault.
+
+Reporting: The final phase involves documenting all findings, detailing the attack path, assessing the business impact of the vulnerabilities, and providing concrete recommendations for remediation. This is the operator's "debriefing" with the client, delivering the valuable intelligence for which they were hired.
+
+While PTES describes the process of an attack, the MITRE ATT&CK framework provides the vocabulary for the actions taken within that process. ATT&CK is a globally recognized, curated knowledge base of adversary tactics and techniques based on real-world observations of cyberattacks. It allows security professionals to structure their analysis and communicate with a common language. For an operator, OSINT findings are mapped to ATT&CK's pre-attack tactics, such as
+
+TA0043: Reconnaissance and TA0042: Resource Development. For example, discovering a list of employee email addresses maps to technique T1589.002: Email Addresses, while finding that an adversary has registered a typosquatted domain for phishing maps to T1583.001: Domains. Actions taken during the exploitation and post-exploitation phases are then mapped to subsequent tactics, such as
+
+TA0001: Initial Access, TA0004: Privilege Escalation, and TA0008: Lateral Movement. This structured mapping transforms a collection of raw data points into a coherent intelligence picture of an adversary's capabilities and a target's vulnerabilities.
+
+### The Spectrum of Operations: Pentesting vs. Red Teaming vs. Bug Bounties
+The term "ethical hacking" encompasses a spectrum of activities, each with distinct objectives, methodologies, and rules of engagement. Understanding these distinctions is crucial for comprehending the different roles an operator might play in the cybersecurity ecosystem.
+
+Penetration Testing is the most traditional form of offensive security assessment. Its primary objective is to identify and exploit as many vulnerabilities as possible within a strictly defined scope and a limited timeframe (typically one to three weeks). A pentest is designed to provide a comprehensive snapshot of an organization's security posture at a given moment. The focus is on breadth over depth; the goal is to produce a detailed report of all findings to help the organization prioritize remediation efforts. This is analogous to a netrunner being hired to perform a full security audit on a specific corporate data fortress, testing every piece of ICE and reporting on its weaknesses.
+
+Red Teaming, by contrast, is a form of adversary simulation. Its objective is not to find every possible vulnerability but to test an organization's detection and response capabilities (often referred to as the "Blue Team"). A red team engagement is goal-oriented; the team is given a specific objective, such as "exfiltrate the customer database" or "gain domain administrator privileges," and is tasked with achieving it while remaining undetected for as long as possible. Stealth, evasion, and the emulation of a specific real-world threat actor's TTPs are paramount. A red team only needs to find a single, viable attack path to be successful. This is the direct equivalent of a classic cyberpunk heist: a netrunner and their team attempting to steal a specific piece of data from a megacorporation without alerting Netwatch or corporate security forces.
+
+Bug Bounty Hunting represents a crowdsourced and continuous approach to vulnerability discovery. Companies establish programs that offer financial rewards ("bounties") to independent security researchers for finding and responsibly disclosing vulnerabilities in their systems. Unlike a pentest, a bug bounty program is typically open-ended and operates on a pay-for-results model. This model mirrors the freelance, mercenary lifestyle of many cyberpunk protagonists, who take on "gigs" from various fixers and corporations, with their payout depending on their success.
+
+The classic "data fortress run" metaphor, while an excellent model for a penetration test, is becoming an increasingly flawed analogy for the challenges of modern cybersecurity. The concept of a fortress implies a "castle-and-moat" security architecture: a hardened perimeter protecting a trusted internal network. However, the modern enterprise, with its reliance on cloud services, remote work, and interconnected third-party applications, no longer has a clearly defined perimeter.
+
+In response to this reality, the industry has shifted towards a "Zero Trust" security model. This model operates on the principle of "never trust, always verify." It assumes that the perimeter has already been breached and that no user or device, whether internal or external, should be trusted by default. Every request for access must be authenticated and authorized. This philosophical shift is why red teaming has become a more critical measure of an organization's true security maturity. A red team engagement is designed to test the efficacy of a Zero Trust environment by simulating an adversary who is already inside the network. The challenge is not merely to defend the front gate but to detect, contain, and respond to a threat that is already moving laterally through the internal systems.
+
+## The Ghost in the Machine: AI-Augmented Offense
+The bleeding edge of offensive security is the integration of artificial intelligence to automate, accelerate, and enhance attack capabilities. This represents a paradigm shift, moving from human-driven tools to autonomous or semi-autonomous agents capable of discovering and exploiting vulnerabilities at a scale and speed previously unimaginable.
+
+### AI for Vulnerability Discovery
+Traditional "fuzzing"—the process of feeding a program with malformed or random data to induce a crash—is being revolutionized by AI. AI-powered fuzzers, such as Google's OSS-Fuzz with its AI enhancements or commercial tools like CI Fuzz, use machine learning and reinforcement learning to intelligently guide the input generation process. Instead of random inputs, these tools learn which inputs are more likely to explore new code paths and trigger bugs, making the vulnerability discovery process exponentially more efficient. Research from 2025 has demonstrated AI agents, such as "EnIGMA" developed by NYU researchers, that can autonomously solve complex Capture The Flag (CTF) hacking challenges, a direct simulation of real-world vulnerability exploitation.
+
+### Large Language Models in Exploit Generation and Social Engineering
+Large Language Models (LLMs) are also being repurposed for both exploit generation and social engineering. Academic projects like "FaultLine" are using LLM-based agents to read vulnerability reports and automatically generate functional proof-of-concept exploit code, a task that previously required a skilled human developer. Simultaneously, AI is being used to industrialize social engineering. LLMs can now generate thousands of highly personalized and context-aware phishing emails, scraping data from public sources like LinkedIn to craft lures that are indistinguishable from legitimate communications. This capability is already being actively used by criminal and state-sponsored groups to bypass human defenses at an unprecedented scale.
+
+## The Real-World Netrunner's Toolchain (2025)
+A netrunner, whether fictional or real, is defined by their toolset. In the modern cybersecurity landscape, the "cyberdeck" is not a single piece of hardware but a curated ecosystem of specialized operating systems, software utilities, and physical devices. This arsenal is in a constant state of evolution, with new tools emerging and old ones being refined to keep pace with a dynamic threat environment. The following catalog represents the state-of-the-art toolchain for a real-world netrunner operating in 2025.
+
+### Operating Systems: The Foundation of the Cyberdeck
+The choice of operating system is the most fundamental security decision an operator makes. The OS forms the trusted computing base upon which all other tools and operations depend. For offensive and defensive security work, specialized Linux distributions are the industry standard, providing a pre-configured environment packed with the necessary utilities.
+
+Kali Purple: A recent evolution of the legendary Kali Linux, Kali Purple is designed to be a comprehensive platform for both offensive (Red Team) and defensive (Blue Team) security, enabling integrated "Purple Team" exercises. While it includes the vast arsenal of penetration testing tools that Kali is known for, it adds a suite of defensive tools organized according to the NIST Cybersecurity Framework (Identify, Protect, Detect, Respond, Recover). This includes tools for real-time threat monitoring and incident response, such as the Suricata Intrusion Detection System (IDS), the ELK stack (Elasticsearch, Logstash, Kibana) for log analysis and visualization, the GVM vulnerability scanner, and TheHive incident response platform. This makes Kali Purple an ideal "SOC-in-a-box" for security training and testing defensive postures.
+
+Parrot OS 6: Parrot OS is another leading security-focused distribution that emphasizes both penetration testing and privacy. The version 6 series, released through 2025, features significant updates, including a modern Linux kernel (6.12+) for improved hardware support, and the latest versions of core offensive tools like Metasploit, Sliver, and Empire. A key feature of Parrot OS is its commitment to user privacy, which includes providing a patched version of Firefox ESR with telemetry and "call home" features disabled by default, ensuring that user configurations persist across updates.
+
+BlackArch Linux: For the operator who requires the most comprehensive and up-to-date collection of tools, BlackArch is the distribution of choice. Based on Arch Linux, it follows a rolling-release model, meaning its packages are constantly updated to the latest versions. Its most notable feature is its massive repository, which contains over 2,800 specialized security tools, categorized and easily installable via the pacman package manager. BlackArch is designed for advanced users who are comfortable with the Arch Linux environment and value granular control and an exhaustive toolset over a pre-configured desktop experience.
+
+### Core Utilities: The Tools of the Trade
+These are the foundational software applications that form the day-to-day toolkit of the modern hacker.
+
+#### Network & Web Reconnaissance
+
+Nmap (Network Mapper): The indispensable tool for network discovery and security auditing. Nmap is used to identify live hosts on a network, discover open ports, and determine the services and operating systems they are running.
+
+Dirb / Gobuster: These tools are used for web content discovery. They work by launching dictionary-based attacks against a web server to find hidden directories and files that are not linked from the main website, often revealing sensitive information or administrative interfaces.
+
+Burp Suite: The industry-standard proxy tool for web application security testing. It sits between the operator's browser and the target application, allowing the operator to intercept, inspect, and modify all traffic. Its powerful features, including a scanner, repeater, and intruder, are essential for finding and exploiting web vulnerabilities like SQL injection and Cross-Site Scripting (XSS).
+
+#### Exploitation & Post-Exploitation
+
+Metasploit Framework: An open-source platform for developing, testing, and executing exploit code. It contains a vast database of exploits for known vulnerabilities and provides a powerful post-exploitation agent called "Meterpreter," which allows an operator to maintain control over a compromised system.
+
+BloodHound: A critical tool for analyzing Active Directory (AD) environments. BloodHound uses graph theory to visualize complex permission relationships within an AD domain, allowing an operator to quickly identify and map attack paths that lead to privilege escalation and control of the network.
+
+#### Vulnerability Exploitation & Password Cracking
+
+SQLmap: An open-source tool that automates the process of detecting and exploiting SQL injection vulnerabilities. It can be used to fingerprint the back-end database, retrieve data, and in some cases, gain full control over the database server.
+
+John the Ripper: A powerful and versatile password cracking tool. It can automatically detect the hash type of encrypted passwords and use various methods—including dictionary attacks, brute-force attacks, and hybrid attacks—to recover the plaintext password.
+
+#### Advanced Tools
+
+AI Fuzzers: A new generation of tools that use machine learning to automate vulnerability discovery. Tools like CI Fuzz and platforms like Google's OSS-Fuzz are now incorporating AI to intelligently guide the fuzzing process, making it far more efficient at finding exploitable bugs in software.
+
+Shodan / Censys: These are search engines for the internet itself. Instead of indexing web content, they continuously scan the entire internet, indexing servers, webcams, industrial control systems, and other internet-connected devices. They are invaluable for infrastructure reconnaissance, allowing an operator to find a target's exposed assets and potentially vulnerable services.
+
+### Support & Analysis Tools
+These tools are used for the critical tasks of intelligence gathering, data analysis, and reverse engineering that support an offensive operation.
+
+#### OSINT Frameworks
+
+SpiderFoot: An open-source OSINT automation tool that can query hundreds of public data sources to gather intelligence on a target, including IP addresses, domain names, email addresses, and social media profiles.
+
+Maltego: A graphical link analysis tool used to visualize complex relationships between pieces of information gathered from open sources. It is a powerful tool for mapping out corporate structures, social networks, and technical infrastructure.
+
+#### Network & Software Analysis
+
+Wireshark: The world's foremost network protocol analyzer. It allows an operator to capture and interactively browse the traffic running on a computer network, providing a granular view of every packet for troubleshooting, analysis, and security auditing.
+
+Ghidra: A software reverse engineering (SRE) framework developed and open-sourced by the U.S. National Security Agency (NSA). It is a powerful suite of tools for disassembling, decompiling, and analyzing compiled code (executables and libraries), making it an essential tool for malware analysis and vulnerability research.
+
+### Hardware Arsenal
+While most operations are software-based, a physical toolkit is essential for engagements that require on-site access or interaction with radio frequency systems.
+
+Flipper Zero: A portable, multi-functional hacking device often described as a "cyber-dolphin." It combines a wide range of tools into a single, pocket-sized device, including a Sub-1 GHz radio for interacting with remote controls and wireless sensors, RFID and NFC readers/emulators for cloning access cards, an infrared transceiver, and a BadUSB interface for keystroke injection attacks.
+
+HackRF One: A highly versatile and affordable Software Defined Radio (SDR) peripheral. It is capable of transmitting and receiving radio signals across a massive frequency range (1 MHz to 6 GHz), allowing an operator to analyze, intercept, and interact with a wide variety of wireless protocols, from garage door openers to GPS signals.
+
+USB Rubber Ducky: The original keystroke injection tool, developed by Hak5. Disguised as a standard USB flash drive, it acts as a pre-programmed keyboard when plugged into a target machine, rapidly typing a malicious payload to execute commands, install malware, or exfiltrate data.
+
+O.MG Cable: A more advanced and covert version of the keystroke injection concept. The O.MG Cable is a malicious USB cable with a hidden Wi-Fi implant. It functions as a normal charging or data cable but allows an attacker to remotely connect to it and inject keystrokes or exfiltrate data from the connected device, even after the initial physical access is over.
+
+
+## The Law as Code: Legal and Ethical Boundaries
+In the world of the netrunner, the law is not an abstract moral guide but a concrete system of control, a form of code that defines the operational battlespace. Understanding this legal code—its statutes, precedents, and jurisdictional boundaries—is as critical as understanding network protocols. For the real-world operator, fluency in this legal framework is the primary defense against catastrophic strategic failure. An action that is a low-risk vulnerability scan in one jurisdiction can be a felony in another. This section provides a strategic intelligence briefing on the key legal instruments that govern the digital world.
+
+### The Code of Control: Key Legislation
+Several key statutes in the United States, the United Kingdom, and the European Union form the primary legal architecture governing hacking, data protection, and surveillance.
+
+Computer Fraud and Abuse Act (CFAA) - United States: The CFAA is the principal U.S. anti-hacking law. Its core provision criminalizes intentionally accessing a computer "without authorization" or "exceeding authorized access". For years, a dangerously broad interpretation of this language threatened to criminalize a wide range of security research and journalism, as prosecutors argued that merely violating a website's terms of service constituted "exceeding authorized access." The landmark 2021 Supreme Court case,
+
+Van Buren v. United States, decisively rejected this interpretation. The Court established a clear "gates-up-or-down" standard: an individual only violates the CFAA if they circumvent a technical or code-based barrier they are forbidden from bypassing (a "gates-down" system). Accessing information that is publicly available, even for a purpose forbidden by a website's terms, is not a crime under the CFAA. This ruling provides a critical legal shield for passive OSINT and security research.
+
+Computer Misuse Act 1990 - United Kingdom: This is the foundational anti-hacking law in the U.K. It establishes three primary offenses :
+
+Unauthorized access to computer material (Section 1): The basic hacking offense, covering acts like guessing a password to access an account.
+
+Unauthorized access with intent to commit or facilitate further offenses (Section 2): An aggravated offense, such as hacking into a system with the intent to commit fraud or theft.
+
+Unauthorized acts with intent to impair, or with recklessness as to impairing, the operation of a computer (Section 3): This covers the deployment of malware, denial-of-service attacks, or any other action intended to damage or disrupt a system.
+Subsequent amendments have added offenses related to making or supplying hacking tools and have introduced life sentences for attacks that cause serious harm to human welfare or national security.
+
+General Data Protection Regulation (GDPR) Article 32 - European Union: While the GDPR is a broad data protection law, Article 32 specifically addresses the "Security of processing." It mandates that data controllers and processors implement "appropriate technical and organisational measures" to ensure a level of security appropriate to the risk. The article explicitly lists several examples of such measures, including the pseudonymization and
+
+encryption of personal data, the ability to ensure the ongoing confidentiality, integrity, availability, and resilience of systems, and a process for regularly testing, assessing, and evaluating the effectiveness of security measures. This article effectively codifies the principles of a robust cybersecurity program into law, making security not just a best practice but a legal requirement for any entity handling the data of EU citizens.
+
+Critical Infrastructure Laws: There is a strong global trend toward increased regulation of cybersecurity for critical infrastructure. In the U.S., the 2024 National Security Memorandum on Critical Infrastructure Security and Resilience elevated the importance of minimum security requirements, moving away from a purely voluntary approach. The
+
+Cybersecurity Incident Reporting for Critical Infrastructure Act (CIRCIA), which is currently being implemented, will create mandatory requirements for critical infrastructure operators to report significant cyber incidents to the government, further entrenching federal oversight. These laws reflect a broader shift where the state is asserting greater control over the security of privately-owned infrastructure deemed vital to national security.
+
+### The Jurisdictional Heat Map
+An operator's physical location—and the location of their servers and data—is a primary variable in their risk calculus. The legal landscape is a fragmented patchwork of national regimes with vastly different approaches to surveillance, encryption, and dissent.
+
+Germany generally represents a Green (More Protective) environment. Rooted in a historical aversion to state surveillance, its Constitutional Court has repeatedly struck down excessive surveillance laws. The government has also affirmed a "right to encryption," with draft legislation in 2025 aiming to mandate end-to-end encryption for messaging services. However, it remains subject to EU-wide mandates like the proposed "Chat Control" law, which seeks to compel the scanning of private communications, and the NIS2 directive, which imposes strict cybersecurity and reporting requirements on critical entities.
+
+Brazil is an Amber (Contested) environment. While it has foundational data protection laws, recent years have seen increased political and judicial pressure on digital platforms. The ongoing debate around the "Fake News Bill" and a 2025 Supreme Court decision weakening the "safe harbor" liability protections for platforms indicate a move toward greater content moderation and potential censorship. Furthermore, the deployment of AI-powered facial recognition systems during public events like Carnaval signals an expansion of state surveillance capabilities.
+
+Japan is also an Amber (Eroding) environment, having recently made a significant shift in its cybersecurity posture. The Active Cyber Defense Law, enacted in May 2025, authorizes the government for the first time to take pre-emptive, offensive action against foreign cyber threats. The law grants authorities the power to access and disable foreign servers suspected of being used for attacks and, critically, to analyze metadata from cross-border internet traffic. While the law prohibits monitoring the content of domestic communications and establishes an oversight commission, it represents a major expansion of the state's power to conduct surveillance and offensive operations in cyberspace.
+
+## The Strategic Horizon: Forecasting the 2025-2030 Landscape
+The battlefield of digital autonomy is dynamic. The tools and tactics of today will be rendered obsolete by the technological and legislative shifts of tomorrow. A forward-looking, strategic analysis of emerging trends is essential for any operator seeking to maintain their freedom of action. The period between 2025 and 2030 will be defined by three critical, intersecting developments: the breaking of classical cryptography, an accelerating arms race in artificial intelligence, and a concerted legal effort to criminalize the very tools of privacy and security.
+
+### The Quantum Crack
+The most profound technological disruption on the horizon is the advent of a cryptographically relevant quantum computer (CRQC). The expert consensus now places the arrival of a machine capable of breaking the widely used RSA-2048 encryption standard between 2030 and 2035. This event, often dubbed "Q-Day," will trigger a global crisis of confidence in digital infrastructure.
+
+The most immediate and tangible danger is the "Harvest Now, Decrypt Later" attack strategy. Nation-state intelligence agencies are currently intercepting and archiving vast quantities of encrypted data. This data, while secure today, is a ticking time bomb. Once a CRQC is operational, these archives can be retroactively decrypted, exposing decades of state secrets, corporate intellectual property, and private communications. This reality creates a new arms race in the realm of Post-Quantum Cryptography (PQC). We will see the emergence of
+
+quantum-resistant botnets, where malware operators use new PQC algorithms to secure their command-and-control channels against future decryption by law enforcement. In response, privacy-conscious users and services will accelerate the adoption of
+
+quantum-proof VPN tunneling, using hybrid cryptographic schemes that combine a classical algorithm with a PQC algorithm to ensure long-term confidentiality.
+
+### The AI Arms Race
+The rapid advancement of artificial intelligence is creating a new arms race between offensive and defensive actors. This conflict will define the tactical landscape of the late 2020s.
+
+Offensive AI: The development of AI copilots for red team automation is already underway. At conferences like Black Hat and DEF CON, researchers are demonstrating how LLMs can be used to automate post-exploitation tasks, generate phishing content, and even write novel exploit code. These "AI hackers" will dramatically lower the barrier to entry for sophisticated attacks and increase the speed and scale at which they can be executed.
+
+Defensive AI: In response, the cybersecurity industry is developing defender LLMs for advanced anomaly detection. These systems will move beyond simple signature-based detection to analyze massive streams of telemetry data (network logs, endpoint events, user behavior) in real-time. By learning the baseline of normal activity, these AI-driven Security Operations Centers (SOCs) will be able to identify the subtle, novel attack patterns of both human and AI adversaries, flagging anomalies that would be invisible to human analysts.
+
+### The Criminalization of Code
+The proliferation of powerful, accessible tools for both offense and defense is triggering a legislative backlash aimed at criminalizing the tools themselves. This trend represents a direct threat to the open-source security community and the principles of a free and open internet.
+
+European Union's Digital Services Act (DSA): While primarily focused on content moderation, the DSA's broad definitions of "illegal content" and its "crisis response mechanism" create a framework that could be used to compel platforms to block access to or remove what governments deem to be "harmful code". This could include dual-use security tools, encryption software, or even technical tutorials, under the pretext that they could be used for malicious purposes.
+
+United States' Kids Online Safety Act (KOSA): This bill, which has gained significant bipartisan support, would impose a "duty of care" on online platforms to prevent and mitigate a vaguely defined list of harms to minors, including anxiety and depression. Critics argue that this vague standard would force platforms to engage in aggressive censorship to avoid liability, potentially blocking access to legitimate resources on topics like mental health, gender identity, or cybersecurity. A state attorney general could argue that providing access to hacking tools or advanced privacy techniques constitutes a "harm" to minors, pressuring platforms to de-platform security researchers and educators.
+
+This convergence of legislative pressure from both the EU and the U.S. signals a clear trajectory: a future where the simple act of creating, sharing, or even learning about dual-use security tools is increasingly framed as a criminal or harmful act, creating a chilling effect on security research and the development of privacy-enhancing technologies.
+
+## The Operator's Gymnasium: A Practical Starter Kit (Lawful Use Only)
+Theoretical knowledge must be forged into practical skill through hands-on experience. This section provides a blueprint for constructing a personal cybersecurity home lab and a structured curriculum for developing foundational skills. This guide is intended strictly for educational and lawful purposes, such as preparing for certifications, participating in Capture The Flag (CTF) competitions, and ethical security research. Unauthorized access to any computer system is illegal and unethical.
+
+### Home Lab Architecture: The Virtual Proving Ground
+A secure, isolated home lab is the essential training environment for any aspiring operator. It allows for the safe execution and analysis of malware, the testing of exploits, and the practice of defensive techniques without risk to one's primary network. The following architecture uses free and open-source tools to create a powerful and flexible virtual lab.
+
+Hypervisor: Proxmox Virtual Environment (VE): Proxmox VE is a powerful, open-source virtualization platform that will serve as the foundation of the lab. It is installed directly on a dedicated physical machine ("bare-metal") and provides a web-based interface for creating and managing virtual machines (VMs) and containers.
+
+Firewall & Router: pfSense/OPNsense: Instead of relying on a physical router, the lab will use a dedicated VM running pfSense or OPNsense. These are open-source firewall and router distributions that provide enterprise-grade features. The pfSense VM will act as the gateway for the entire lab, controlling all traffic between the virtual networks and the physical home network.
+
+Network Segmentation with VLANs: The core of the lab's security is network segmentation, achieved using Virtual LANs (VLANs). By configuring VLANs within Proxmox and pfSense, the operator can create multiple, logically isolated networks on a single physical network interface. A typical cybersecurity lab setup would include:
+
+Management VLAN: A secure network for accessing the Proxmox and pfSense web interfaces.
+
+Attacker VLAN: The network from which the operator will launch attacks, containing a VM running Kali Linux or Parrot OS.
+
+Target VLAN: An isolated network containing the vulnerable target VMs. This network is often configured with strict firewall rules in pfSense to prevent it from initiating connections to the outside world, containing any potential malware outbreaks.
+
+Target Virtual Machines: The lab should be populated with a variety of target systems to practice against. These can include:
+
+Intentionally Vulnerable Machines: Pre-built VMs designed for hacking practice, such as Metasploitable2 or VulnHub machines.
+
+Modern Operating Systems: Standard installations of Windows 10/11 and various Linux distributions to practice attacks against up-to-date, patched systems, which is more representative of real-world engagements.
+
+### 5-Day Skill-Ramp Curriculum
+This curriculum provides a structured, one-week plan for a beginner to develop foundational offensive security skills using their home lab and online training platforms.
+
+Day 1: Foundations - Networking & Reconnaissance
+
+Objective: Understand core networking concepts and learn how to gather information about a target.
+
+Topics: TCP/IP model, DNS, HTTP/HTTPS.
+
+Tools: Nmap for port scanning and service discovery, Wireshark for packet analysis.
+
+Practical Lab: Use Nmap to scan a target VM in the lab. Use Wireshark to capture and analyze the traffic generated by the scan.
+
+CTF Link: TryHackMe - "Network Services" Room.
+
+Day 2: Web Application Hacking
+
+Objective: Learn to identify and exploit common web application vulnerabilities.
+
+Topics: OWASP Top 10, SQL Injection, Cross-Site Scripting (XSS).
+
+Tools: Burp Suite for intercepting and manipulating web traffic, SQLmap for automated SQL injection.
+
+Practical Lab: Use Burp Suite to find a login bypass vulnerability on a web server VM. Use SQLmap to extract data from a vulnerable database.
+
+CTF Link: Hack The Box - "Intro to Web Hacking" Track.
+
+Day 3: System Exploitation
+
+Objective: Gain initial access to a target system by exploiting a known vulnerability.
+
+Topics: Vulnerability scanning, exploit databases, payloads, shells.
+
+Tool: Metasploit Framework.
+
+Practical Lab: Use Metasploit to find and execute an exploit against a service running on a Metasploitable2 VM to gain a remote shell.
+
+CTF Link: TryHackMe - "Metasploit" Module.
+
+Day 4: Post-Exploitation & Active Directory
+
+Objective: Learn what to do after gaining initial access: escalate privileges and move laterally.
+
+Topics: Privilege escalation, password cracking, Active Directory reconnaissance.
+
+Tools: Metasploit's post-exploitation modules, John the Ripper, BloodHound.
+
+Practical Lab: Use a Metasploit module to escalate privileges from a user to an administrator on a Windows VM. Use BloodHound to analyze a sample Active Directory dataset.
+
+CTF Link: TryHackMe - "Post-Exploitation Basics" Room.
+
+Day 5: Putting It All Together - The CTF Challenge
+
+Objective: Apply all learned skills in a simulated penetration test.
+
+Task: Download a beginner-friendly boot-to-root machine from VulnHub or tackle a full easy-rated box on Hack The Box or TryHackMe.
+
+Methodology: Follow the PTES lifecycle: Recon, Vulnerability Analysis, Exploitation, and Post-Exploitation to capture the user and root flags.
+
+CTF Link: TryHackMe - "Simple CTF" Room.
+
+### OPSEC Checklist for the Operator
+Maintaining strong operational security (OPSEC) is paramount. A single mistake can compromise an operation, an identity, or a dataset. This checklist provides foundational hygiene practices.
+
+#### Endpoint Security
+
+Use a security-focused operating system like Qubes OS or a hardened Linux distribution for all sensitive work.
+
+Employ full-disk encryption on all devices.
+
+Keep all software and systems fully patched and updated.
+
+#### Network Security
+
+Use a reputable, no-logs VPN provider that has undergone independent security audits for all internet traffic.
+
+Configure system-wide encrypted DNS (DoH or DoT) to prevent your ISP from logging your browsing history.
+
+Isolate sensitive work on a dedicated VLAN within your network.
+
+#### Digital Hygiene & Anonymity
+
+Use hardened, anti-fingerprinting browsers like Mullvad Browser or the Tor Browser.
+
+Compartmentalize your digital identity. Use different aliases, email addresses, and accounts for different purposes.
+
+Be meticulous about metadata. Strip all identifying information from files before sharing them.
+
+#### Physical Security
+
+When high levels of anonymity are required, follow a strict "burner" protocol for acquiring and using devices and SIM cards.
+
+Use a Faraday bag to block all wireless signals to and from a device when in transit or high-risk environments.
+
+Never cross an international border with sensitive data on a device. Follow a strict data minimization protocol.
+
+#### Data Management
+
+Use a strong, open-source password manager (e.g., KeePassXC) with a long, high-entropy master passphrase.
+
+Encrypt all sensitive files at rest using tools like GPG or Veracrypt.
+
+Maintain secure, offline, and geographically distributed backups of all critical data.
+
+
+## Sources used in the report
+
+numberanalytics.com
+The Evolution of Cyberpunk - Number Analytics
+Opens in a new window
+
+gamefaqs.gamespot.com
+Is Cyberpunk lore based straight off of Neuromancer? (Book & game spoilers) - GameFAQs
+Opens in a new window
+
+lysator.liu.se
+ice - Lysator
+Opens in a new window
+
+reddit.com
+So, what's the significance of ice? : r/cyberpunkgame - Reddit
+Opens in a new window
+
+reddit.com
+How do I play a Netrunner : r/cyberpunk2020 - Reddit
+Opens in a new window
+
+altchar.com
+Cyberpunk 2077 stepped away from Neuromancer Netrunning - AltChar
+Opens in a new window
+
+youtube.com
+Cyberpunk 2077 - NetWatch EXPLAINED under 3 minutes - YouTube
+Opens in a new window
+
+reddit.com
+Reading Neuromancer and Count Zero made me realize what this game could have been : r/cyberpunkgame - Reddit
+Opens in a new window
+
+youtube.com
+Neuromancer: The Origin of Cyberpunk | A Horrifying Dystopia - YouTube
+Opens in a new window
+
+youtube.com
+Cyberpunk 2077 - Braindance & Its History! (Lore!) - YouTube
+Opens in a new window
+
+youtube.com
+What is Cyberpunk 2077 Braindance & How Is It Used? Cyberpunk Lore (Cyberpunk Braindance) - YouTube
+Opens in a new window
+
+youtube.com
+All Objectives In Evelyn Parker's Braindance | The Information Main Quest | Cyberpunk 2077
+Opens in a new window
+
+youtube.com
+Everything You Need to Know About Braindance! Lore Dive! - YouTube
+Opens in a new window
+
+reddit.com
+So how do Quickhack builds work in lore? : r/cyberpunkgame - Reddit
+Opens in a new window
+
+Real‑World Cyberpunk Manifesto — Wave 1: Foundations
+
+scribd.com
+Netrunner Quick 1 Page Guide - Cyberpunk 2020 | PDF - Scribd
+Opens in a new window
+
+cyberpunk2077.wiki.fextralife.com
+Quickhacks | Cyberpunk 2077 Wiki - FextraLife
+Opens in a new window
+
+netrunner-2077.webflow.io
+Cyberpunk 2077 Lore: Braindance - NETRUNNER 2077
+Opens in a new window
+
+en.wikipedia.org
+Intrusion Countermeasures Electronics - Wikipedia
+Opens in a new window
+
+usa.kaspersky.com
+The Hacker's Toolkit according to Cyberpunk 2020 | Kaspersky ...
+Opens in a new window
+
+reddit.com
+Red vs 2020 Netrunning : r/cyberpunk2020 - Reddit
+Opens in a new window
+
+youtube.com
+Everything You Need to Know About the Blackwall and DataKrash | Cyberpunk 2077 Lore
+Opens in a new window
+
+youtube.com
+A.I. Caused The Datakrash! [Game Lore & Theories] #cyberpunk2077 #cyberpunk #ps5 #spacejb - YouTube
+Opens in a new window
+
+screenrant.com
+Cyberpunk 2077: Who Rache Bartmoss Really Was - Screen Rant
+Opens in a new window
+
+reddit.com
+How do you picture Netrunning in meat space : r/cyberpunkred - Reddit
+Opens in a new window
+
+reddit.com
+An Argument for Cyberpunk 2020's Netrunning - Try it instead of Red : r/rpg - Reddit
+Opens in a new window
+
+rtalsoriangames.com
+Kitbashing: Netrunning - R. Talsorian Games
+Opens in a new window
+
+reddit.com
+How exactly does "Meatspace" and Netspace interact/how do you describe Netrunning in the narrative? : r/cyberpunkred - Reddit
+Opens in a new window
+
+youtube.com
+Cyberpunk 2077 Lore - The Net, Netrunning Gear & Rache Bartmoss! - YouTube
+Opens in a new window
+
+youtube.com
+Cyberpunk 2077 Lore | Being A Netrunner Within The Cyberpunk Universe - YouTube
+Opens in a new window
+
+youtube.com
+Cyberpunk 2077 prequel 'RED' is Released (First impressions, lore & more) - YouTube
+Opens in a new window
+
+youtube.com
+Netrunner | Cyberpunk 2077 Lore and World Explained - YouTube
+Opens in a new window
+
+en.wikipedia.org
+Neuromancer - Wikipedia
+Opens in a new window
+
+press.cdprojektred.com
+Cyberpunk 2077 - The Board Game Crowdfunding Campaign is Live! - Press Center
+Opens in a new window
+
+en.wikipedia.org
+Cyberpunk 2077 - Wikipedia
+Opens in a new window
+
+en.wikipedia.org
+Cyberpunk (role-playing game) - Wikipedia
+Opens in a new window
+
+reddit.com
+Cyberpunk 2020 and RED : r/cyberpunkgame - Reddit
+Opens in a new window
+
+snort.org
+Snort - Network Intrusion Detection & Prevention System
+Opens in a new window
+
+levelblue.com
+Open Source IDS Tools: Comparing Suricata, Snort, Bro (Zeek), Linux - LevelBlue
+Opens in a new window
+
+suricata.io
+Suricata: Home
+Opens in a new window
+
+stamus-networks.com
+Open Source Intrusion Detection Tools - Stamus Networks
+Opens in a new window
+
+logz.io
+Top 5 open-source HIDS systems - Logz.io
+Opens in a new window
+
+learn.g2.com
+My Top 7 EDR Software Picks After Hours of Research
+Opens in a new window
+
+evolvesecurity.com
+Tools of the Trade: Exploitation and Beyond with Metasploit - Evolve Security
+Opens in a new window
+
+malpedia.caad.fkie.fraunhofer.de
+Cobalt Strike (Malware Family) - Malpedia
+Opens in a new window
+
+thectoclub.com
+25 Best EDR Tools Reviewed in 2025 - The CTO Club
+Opens in a new window
+
+vectra.ai
+What is Cobalt Strike? - Vectra AI
+Opens in a new window
+
+hackviser.com
+Metasploit - Hackviser
+Opens in a new window
+
+imperva.com
+What Is Cobalt Strike | Advanced Threats and Defenses - Imperva
+Opens in a new window
+
+evolvesecurity.com
+SQLmap: Uncovering and Exploiting SQL Injection Vulnerabilities - Evolve Security
+Opens in a new window
+
+malpedia.caad.fkie.fraunhofer.de
+Cobalt Strike (Malware Family) - Malpedia
+Opens in a new window
+
+thectoclub.com
+25 Best EDR Tools Reviewed in 2025 - The CTO Club
+Opens in a new window
+
+vectra.ai
+What is Cobalt Strike? - Vectra AI
+Opens in a new window
+
+hackviser.com
+Metasploit - Hackviser
+Opens in a new window
+
+imperva.com
+What Is Metasploit | Tools & Components Explained - Imperva
+Opens in a new window
+
+attack.mitre.org
+Initial Access, Tactic TA0001 - Enterprise - MITRE ATT&CK®
+Opens in a new window
+
+fluidattacks.com
+What is red teaming? - Fluid Attacks
+Opens in a new window
+
+blog.gitguardian.com
+What are MITRE ATT&CK initial access techniques - GitGuardian Blog
+Opens in a new window
+
+futurelearn.com
+Penetration Testing Execution Standard (PTES) - FutureLearn
+Opens in a new window
+
+kirkpatrickprice.com
+Stages of Penetration Testing According to PTES - KirkpatrickPrice
+Opens in a new window
+
+Cyberpunk Social Engineering, Trust Networks
+
+Cyberpunk Manifesto — Wave 3: Privacy & OPSEC
+
+arxiv.org
+FaultLine: Automated Proof-of-Vulnerability Generation using LLM Agents - arXiv
+Opens in a new window
+
+trendmicro.com
+Trend Micro State of AI Security Report 1H 2025
+Opens in a new window
+
+reddit.com
+Datafortresses and Netrunning; what makes a Datafortress? : r/cyberpunk2020 - Reddit
+Opens in a new window
+
+rtalsoriangames.com
+Cyberpunk - R. Talsorian Games
+Opens in a new window
+
+synack.com
+Red Teaming vs Penetration Testing: Understanding the Differences - Synack
+Opens in a new window
+
+medium.com
+AI-Powered & Automated Vulnerability Discovery: The Future of Pentesting Has Arrived | by Ekene Joseph | Jul, 2025 | Medium
+Opens in a new window
+
+engineering.nyu.edu
+NYU Tandon researchers develop AI agent that solves cybersecurity challenges autonomously
+Opens in a new window
+
+github.com
+OSS-Fuzz - continuous fuzzing for open source software. - GitHub
+Opens in a new window
+
+code-intelligence.com
+Top Fuzz Testing Tools of 2025: Feature Comparison - Code Intelligence
+Opens in a new window
+
+wolfssl.com
+AI-automated fuzz testing uncovered a vulnerability in wolfSSL
+Opens in a new window
+
+blog.shellnetsecurity.com
+Revolutionizing Vulnerability Discovery with AI-Powered Fuzzing
+Opens in a new window
+
+nccgroup.com
+Pentesting V. Red Teaming V. Bug Bounty - NCC Group
+Opens in a new window
+
+edendata.com
+Differentiating a Bug Bounty vs. a Penetration Test - Eden Data
+Opens in a new window
+
+cobalt.io
+Pentesting vs Bug Bounty: Which is Better for Your Company's Security? - Cobalt
+Opens in a new window
+
+github.com
+usb-rubber-ducky · GitHub Topics
+Opens in a new window
+
+eagleeyet.net
+Kali Linux Red vs. Kali Linux Purple: Exploring Offensive and Defensive Cybersecurity
+Opens in a new window
+
+codelivly.com
+Kali Purple: The New Face of Defensive Cybersecurity - Codelivly
+Opens in a new window
+
+linuxsecurity.com
+Parrot OS 6.4 Release Overview: Key Updates and Features for Admins - Linux Security
+Opens in a new window
+
+github.com
+hackrf-wiki/HackRF-One.md at master · dodgymike/hackrf-wiki - GitHub
+Opens in a new window
+
+parrotsec.org
+Parrot 6.4 Release Notes
+Opens in a new window
+
+greatscottgadgets.com
+HackRF One - Great Scott Gadgets
+Opens in a new window
+
+en.wikipedia.org
+Flipper Zero - Wikipedia
+Opens in a new window
+
+cybersectools.com
+Ghidra Software Reverse Engineering Framework | CyberSecTools
+Opens in a new window
+
+en.wikipedia.org
+John the Ripper - Wikipedia
+Opens in a new window
+
+flipperzero.one
+Flipper Zero — Portable Multi-tool Device for Geeks
+Opens in a new window
+
+helpnetsecurity.com
+Ghidra: Open-source software reverse engineering framework - Help Net Security
+Opens in a new window
+
+hackviser.com
+John the Ripper | Hackviser
+Opens in a new window
+
+michigan.gov
+Cyber Snapshot - State of Michigan
+Opens in a new window
+
+varonis.com
+How to Use Ghidra to Reverse Engineer Malware - Varonis
+Opens in a new window
+
+esecurityplanet.com
+John the Ripper: Password Cracking Tutorial and Review - eSecurity Planet
+Opens in a new window
+
+cisa.gov
+sqlmap - CISA
+Opens in a new window
+
+kali.org
+sqlmap | Kali Linux Tools
+Opens in a new window
+
+evolvesecurity.com
+SQLmap: Uncovering and Exploiting SQL Injection Vulnerabilities - Evolve Security
+Opens in a new window
+
+redcanary.com
+BloodHound - Red Canary Threat Detection Report
+Opens in a new window
+
+bloodhound.readthedocs.io
+BloodHound: Six Degrees of Domain Admin — BloodHound 4.3.1 documentation
+Opens in a new window
+
+cyberpanel.net
+BlackArch Linux Download & Install Guide (Security Distro) - CyberPanel
+Opens in a new window
+
+blog.netwrix.com
+Finding Abusable Active Directory Permissions with BloodHound - Netwrix Blog
+Opens in a new window
+
+blackarch.org
+Download BlackArch
+Opens in a new window
+
+kali.org
+dirb | Kali Linux Tools
+Opens in a new window
+
+kali.org
+gobuster | Kali Linux Tools
+Opens in a new window
+
+hackertarget.com
+Gobuster tutorial - HackerTarget.com
+Opens in a new window
+
+en.wikipedia.org
+Computer Misuse Act 1990 - Wikipedia
+Opens in a new window
+
+termsfeed.com
+Computer Misuse Act 1990 - TermsFeed
+Opens in a new window
+
+ikandp.co.uk
+Computer Misuse Act Offences
+Opens in a new window
+
+vaia.com
+Computer Misuse Act: Summary & Examples - Vaia
+Opens in a new window
+
+freeprivacypolicy.com
+The Computer Misuse Act 1990 - Free Privacy Policy
+Opens in a new window
+
+gdpr-info.eu
+Art. 32 GDPR – Security of processing - General Data Protection Regulation (GDPR)
+Opens in a new window
+
+imperva.com
+GDPR Article 32 | Imperva
+Opens in a new window
+
+wileyconnect.com
+Federal Cybersecurity Policy in 2025: What to Watch in Changing Times - Wiley Connect
+Opens in a new window
+
+docs.alertlogic.com
+GDPR Article 32: Security of Processing - Alert Logic Product Documentation
+Opens in a new window
+
+Real-World Cyberpunk Manifesto — Wave 4: Reconnaissance & Open-Source Intelligence
+
+youtube.com
+Living off Microsoft Copilot - YouTube
+Opens in a new window
+
+algorithmwatch.org
+A guide to the Digital Services Act, the EU's new law to rein in Big Tech - AlgorithmWatch
+Opens in a new window
+
+ec.europa.eu
+Questions and answers on the Digital Services Act* - European Commission
+Opens in a new window
+
+adfinternational.org
+Unpacking the EU Digital Services Act (DSA) - ADF International
+Opens in a new window
+
+researchgate.net
+A Quantum-Resistant Cryptography for Secure IoT Communication Using Novel QRC_BIKAES Framework - ResearchGate
+Opens in a new window
+
+blumenthal.senate.gov
+Kids Online Safety Act (KOSA) - Senator Richard Blumenthal
+Opens in a new window
+
+brookings.edu
+Children's online safety laws are failing LGBTQ+ youth - Brookings Institution
+Opens in a new window
+
+eff.org
+The Kids Online Safety Act Will Make the Internet Worse for Everyone
+Opens in a new window
+
+transformativeworks.org
+KOSA and Other Bad Internet Bills | Organization for Transformative Works
+Opens in a new window
+
+en.wikipedia.org
+Kids Online Safety Act - Wikipedia
+Opens in a new window
+
+tryhackme.com
+Simple CTF - TryHackMe
+Opens in a new window
+
+academy.hackthebox.com
+HTB Academy: Best Online Cybersecurity Courses & Certifications
+Opens in a new window
+
+youtube.com
+VLAN Setup from Scratch: OPNsense + Proxmox + Switch (Complete Guide) - YouTube
+Opens in a new window
+
+molware.org
+Proxmox Homelab | m0lware Cybersecurity Blog
+Opens in a new window
+
+medium.com
+Homelab learning: Configuring pfSense in Proxmox VE for isolation and traffic routing
+Opens in a new window
+
+reddit.com
+How to setup Proxmox with pfSense & VLAN´s - Reddit
+Opens in a new window
+
+openkritis.de
+NIS2 in Germany (NIS2UmsuCG) - OpenKRITIS
+Opens in a new window
+
+benheater.com
+Create a pfSense Firewall for Our Proxmox Lab - 0xBEN
+Opens in a new window
+
+forum.proxmox.com
+[SOLVED] - Setup a Lab-LAN within Proxmox
+Opens in a new window
+
+techradar.com
+The EU could be scanning your chats by October 2025 – here's everything we know
+Opens in a new window
+
+technologylawdispatch.com
+Germany's government plans to introduce a statutory 'right to encryption' for users of messaging and cloud storage services | Technology Law Dispatch
+Opens in a new window
+
+cov.com
+Brazil's Supreme Court to Strike Down Internet Governance Safe Harbor Clause
+Opens in a new window
+
+asiapacific.ca
+Japan's New Cybersecurity Law Signals More Offensive Posture
+Opens in a new window
+
+japantimes.co.jp
+Japan enacts active cyberdefense law
+Opens in a new window
+
+centerforcybersecuritypolicy.org
+Japan's new Active Cyber Defense Law: A Strategic Evolution in National Cybersecurity
+Opens in a new window
+
+cgs.illinois.edu
+Webinar Recording: Kainen Bell, "Resisting Digital Surveillance in Brazil: Preliminary Fieldwork on AI and Facial Recognition at Carnaval" | Center for Global Studies | Illinois
+Opens in a new window
+
+eff.org
+Brazil's Internet Intermediary Liability Rules Under Trial: What Are the Risks?
+Opens in a new window
+
+internetsociety.org
+Internet Impact Brief: Proposals to Regulate Digital Platforms In Brazil, Potential Impacts in the Internet
+Opens in a new window
+
+therecord.media
+Japan enacts new Active Cyberdefense Law allowing for offensive cyber operations
+Opens in a new window
+
+cisa.gov
+National Security Memorandum on Critical Infrastructure Security ...
+Opens in a new window
+
+insights2techinfo.com
+Quantum Computing and its Potential Impact on IoT Security
+Opens in a new window
+
+triaxiomsecurity.com
+What is the Penetration Testing Execution Standard? » Triaxiom ...
+Opens in a new window
+
+blogs.nvidia.com
+Discover How AI Is Revolutionizing Cybersecurity at Black Hat and ...
+Opens in a new window
+
+securinc.io
+Differences Between Penetration Testing, Bug Bounty and Red ...
+Opens in a new window
+
+## Sources read but not used in the report
+
+gamesradar.com
+Best anime: 25 essential shows to watch in 2025 - GamesRadar
+Opens in a new window
+
+en.wikipedia.org
+Cyberpunk - Wikipedia
+Opens in a new window
+
+reddit.com
+Is Netrunner/Android in the same universe as Cyberpunk 2077? - Reddit
+Opens in a new window
+
+twingate.com
+What is an ICE? Origins, Functions & Implementation - Twingate
+Opens in a new window
+
+reddit.com
+What is Netrunning? : r/cyberpunk2020 - Reddit
+Opens in a new window
+
+thegamingden.github.io
+Intrusion Countermeasures - The Ends of The Matrix
+Opens in a new window
+
+youtube.com
+Netrunning Tutorial: Part One | Cyberpunk 2020 - YouTube
+Opens in a new window
+
+youtube.com
+The Netrunning Example | Cyberpunk Red in a Nutshell #8 - YouTube
+Opens in a new window
+
+youtube.com
+Cyberpunk 2077 Lore - Braindance Explained - YouTube
+Opens in a new window
+
+gamefaqs.gamespot.com
+Does uh someone want to explain how quickhacks work? - Cyberpunk 2077 - GameFAQs
+Opens in a new window
+
+steamcommunity.com
+Explain Cyberware to Me, Please :: Cyberpunk 2077 Genel Tartışmalar - Steam Community
+Opens in a new window
+
+reddit.com
+People familiar with Cyberpunk lore, what's the deal with quick hacking? - Reddit
+Opens in a new window
+
+youtube.com
+All Quickhacks Ranked Worst to Best in Cyberpunk 2077 2.3 - YouTube
+Opens in a new window
+
+store.steampowered.com
+Cyberpunk 2077 on Steam
+Opens in a new window
+
+blog.playstation.com
+PlayStation Plus Game Catalog for July: Cyberpunk 2077, Abiotic Factor, Banishers: Ghosts of New Eden and more
+Opens in a new window
+
+realmedia.ucsf.edu
+Cyberpunk Release Date - Media Innovation Hub
+Opens in a new window
+
+steamcommunity.com
+Netrunning seems like the worst job :: Cyberpunk 2077 Story Discussions [SPOILERS]
+Opens in a new window
+
+youtube.com
+Discusssing Cyberpunk 2020 Conversions & Netrunners With James Hutt - YouTube
+Opens in a new window
+
+youtube.com
+Datakrash Mastermind & Legend - Rache Bartmoss | Cyberpunk Lore - YouTube
+Opens in a new window
+
+dicebreaker.com
+Cyberpunk Red RPG has a release date and price, launching alongside Cyberpunk 2077 | Dicebreaker
+Opens in a new window
+
+youtube.com
+The Netrunner : Role Breakdown Episode 8 For Cyberpunk Red And 2020. - YouTube
+Opens in a new window
+
+reddit.com
+Can we make canon that "DataKrash" is now "Dead Internet Theory"? - Reddit
+Opens in a new window
+
+dicebreaker.com
+Cyberpunk Red RPG rulebook gets a tentative new release date - Dicebreaker
+Opens in a new window
+
+m.youtube.com
+The Man Who Destroyed the Internet: Rache Bartmoss | Cyberpunk Lore - YouTube
+Opens in a new window
+
+pcgamesn.com
+Cyberpunk 2077 gets a tabletop prequel this August - PCGamesN
+Opens in a new window
+
+enworld.org
+Cyberpunk Red Review (It's Only Three Years Old) - EN World
+Opens in a new window
+
+theguardian.com
+Cyberpunk 2077: how 2020's biggest video game launch turned into a shambles
+Opens in a new window
+
+goodreads.com
+Neuromancer by William Gibson | Goodreads
+Opens in a new window
+
+simple.wikipedia.org
+Neuromancer - Simple English Wikipedia, the free encyclopedia
+Opens in a new window
+
+shakespeareandcompany.com
+Neuromancer by William Gibson | Shakespeare & Company
+Opens in a new window
+
+elitistbookreviews.com
+Review: Neuromancer by William Gibson - Elitist Book Reviews
+Opens in a new window
+
+dicebreaker.com
+Cyberpunk Red RPG release date delayed after coronavirus 'gut punch' | Dicebreaker
+Opens in a new window
+
+m.youtube.com
+Cyberpunk 2077 2.0 - The Speed Daemon Netrunner build (Very Hard) - YouTube
+Opens in a new window
+
+hackthebox.com
+A step-by-step guide to the Metasploit Framework - HackTheBox
+Opens in a new window
+
+cobaltstrike.com
+Features | Beacon, C2 Profiles, Arsenal Kit, and More | Cobalt Strike
+Opens in a new window
+
+docs.rapid7.com
+About Post-Exploitation | Metasploit Documentation - Docs | © Rapid7
+Opens in a new window
+
+cloud.google.com
+Defining Cobalt Strike Components & BEACON | Google Cloud Blog
+Opens in a new window
+
+offsec.com
+Post Module Reference - Metasploit Unleashed - OffSec
+Opens in a new window
+
+youtube.com
+Netrunning: Basic and Advanced Tactics For Cyberpunk Red ...
+Opens in a new window
+
+mindpointgroup.com
+Social Engineering: Open-Source Intelligence (OSINT) - MindPoint Group
+Opens in a new window
+
+webasha.com
+Essential Tools and Technologies Every Penetration Tester Should Master for Effective Security Assessments | Comprehensive Guide
+Opens in a new window
+
+mindgard.ai
+Red Team Operations: 5 Phases of Engagement - Mindgard AI
+Opens in a new window
+
+lockheedmartin.com
+Cyber Kill Chain® | Lockheed Martin
+Opens in a new window
+
+bluevoyant.com
+Penetration Testing: Complete Guide to Process, Types, and Tools - BlueVoyant
+Opens in a new window
+
+corelight.com
+What Is the Cyber Kill Chain? (7 Steps + How to Improve) | Corelight
+Opens in a new window
+
+redcanary.com
+Initial Access | Red Canary Threat Detection Report
+Opens in a new window
+
+securityboulevard.com
+The Five Stages of the Red Team Methodology - Security Boulevard
+Opens in a new window
+
+strikegraph.com
+Penetration Testing: Phases, Steps, Timeline & AI Streamlining - Strike Graph
+Opens in a new window
+
+fortra.com
+Learn the Cyber Kill Chain. Stage One: Reconnaissance | Fortra
+Opens in a new window
+
+manageengine.com
+Initial access techniques and mitigation - ManageEngine
+Opens in a new window
+
+datami.ee
+Penetration Testing Execution Standard: 7 PTES Stages – Datami
+Opens in a new window
+
+qualysec.com
+Penetration Testing Execution Standard (PTES) – 2025 Guide - Qualysec
+Opens in a new window
+
+scribd.com
+Cyberpunk 2020 - Datafortress 2020 - GM Screen Elite Edition - Scribd
+Opens in a new window
+
+wjarr.com
+Automated security testing in DevSecOps pipelines: Integrating AI-based vulnerability discovery and compliance validation - World Journal of Advanced Research and Reviews
+Opens in a new window
+
+m.youtube.com
+Netrunning Tutorial Pt 1 Data Fortresses - YouTube
+Opens in a new window
+
+writeups.letsyouandhimfight.com
+Cyberpunk 2020 by SirPhoebos - RPG Writeups
+Opens in a new window
+
+blackfog.com
+Understanding the Biggest AI Security Vulnerabilities of 2025 | BlackFog
+Opens in a new window
+
+mindgard.ai
+31 Best Tools for Red Teaming (2025): Mitigating Bias, AI Vulnerabilities - Mindgard
+Opens in a new window
+
+rtalsoriangames.com
+Unlocking Datafortress 2020: The Combat Zone - R. Talsorian Games
+Opens in a new window
+
+researchgate.net
+(PDF) AI for Automated Vulnerability Assessment and Patch Management in Cloud Systems
+Opens in a new window
+
+a16z.com
+Next-Gen Pentesting: AI Empowers the Good Guys | Andreessen Horowitz
+Opens in a new window
+
+reddit.com
+What is the difference between Ethical hacking and penetration testing? - Reddit
+Opens in a new window
+
+linuxsecurity.com
+Parrot OS 6.2 Release: New Security Tools and Performance Enhancements
+Opens in a new window
+
+youtube.com
+20 Things You MUST DO After Installing Kali Purple - YouTube
+Opens in a new window
+
+docs.flipper.net
+125 kHz RFID - Flipper Zero - Documentation
+Opens in a new window
+
+distrowatch.com
+BlackArch Linux - DistroWatch.com
+Opens in a new window
+
+quest.com
+Attack Path Management Software | SpecterOps BloodHound Enterprise
+Opens in a new window
+
+sourceforge.net
+BlackArch Linux Reviews in 2025 - SourceForge
+Opens in a new window
+
+legislation.gov.uk
+Computer Misuse Act 1990 - Legislation.gov.uk
+Opens in a new window
+
+globalpolicywatch.com
+U.S. Government Issues Cybersecurity Warning to Critical Infrastructure Operators and Others | Global Policy Watch
+Opens in a new window
+
+bitlyft.com
+Cyber Threats to U.S. Critical Infrastructure: What's Going On and How to Stay Prepared
+Opens in a new window
+
+gibsondunn.com
+U.S. Cybersecurity and Data Privacy Review and Outlook – 2025 - Gibson Dunn
+Opens in a new window
+
+insidegovernmentcontracts.com
+May 2025 Cybersecurity Developments Under the Trump Administration
+Opens in a new window
+
+gdprlocal.com
+GDPR Article 32 Explained
+Opens in a new window
+
+isms.online
+How to Demonstrate Compliance With GDPR Article 32 | ISMS.online
+Opens in a new window
+
+nyujilp.org
+Breaching the Unknown: Five Lessons from GDPR Article 32 Fines - NYU Journal of International Law and Politics
+Opens in a new window
+
+brennancenter.org
+FISA Section 702 Backdoor Searches: Myths and Facts | Brennan Center for Justice
+Opens in a new window
+
+eff.org
+VICTORY! Federal Court (Finally) Rules Backdoor Searches of 702 Data Unconstitutional
+Opens in a new window
+
+digitalcommons.lmunet.edu
+Fourth and Fifth Circuits Split Over Geofencing in Fourth Amendment Interpretation - LMU Institutional Repository
+Opens in a new window
+
+brennancenter.org
+Congress Must Close Backdoor Search Loophole by Requiring Warrant/FISA Title I Order for U.S. Person Queries | Brennan Center for Justice
+Opens in a new window
+
+msba.org
+Exploring the Legal Implications of Geofence Warrants: Insights From United States v. Chatrie | Maryland State Bar Association
+Opens in a new window
+
+brennancenter.org
+What's Next for Reforming Section 702 of the Foreign Intelligence Surveillance Act
+Opens in a new window
+
+harvardlawreview.org
+Much Ado About Geofence Warrants - Harvard Law Review
+Opens in a new window
+
+brennancenter.org
+Vote "YES" on Amendment to Close Backdoor Search Loophole by Requiring Warrant/FISA Title I Order for U.S. Person Queries | Brennan Center for Justice
+Opens in a new window
+
+thefinancialexpress.com.bd
+How social business can power a sustainable future | The Financial Express
+Opens in a new window
+
+commission.europa.eu
+The EU's Digital Services Act - European Commission
+Opens in a new window
+
+daiglelawgroup.com
+Dividing Lines: The Fourth Circuit's Take on Geofence Warrants in United States v. Chatrie Amid Growing Circuit Split
+Opens in a new window
+
+lw.com
+The Digital Services Act: Practical Implications for Online Services and Platforms - Latham & Watkins LLP
+Opens in a new window
+
+scholarship.shu.edu
+The Fifth Circuit's Categorical Ban on Geofence Warrants Amid Broader Trends in State Legislation - eRepository @ Seton Hall
+Opens in a new window
+
+congress.gov
+Geofence Warrants and the Fourth Amendment - Congress.gov
+Opens in a new window
+
+researchgate.net
+Implementation of Quantum Cryptography for Securing IoT Devices - ResearchGate
+Opens in a new window
+
+acyd.fiu.edu
+A Quantum Resistant Security for Resource-Constrained IoT Device Encryption - Analytics for Cyber Defense (ACyD) Lab
+Opens in a new window
+
+pmc.ncbi.nlm.nih.gov
+Secure IoT in the Era of Quantum Computers—Where Are the Bottlenecks? - PMC
+Opens in a new window
+
+brennancenter.org
+Closing Section 702's Front-Door Search Loophole: A Critical Protection for Americans | Brennan Center for Justice
+Opens in a new window
+
+eff.org
+The Kids Online Safety Act is Still A Huge Danger to Our Rights Online
+Opens in a new window
+
+iclg.com
+Data Protection Laws and Regulations Report 2025 Germany - ICLG.com
+Opens in a new window
+
+hoganlovells.com
+The NIS2 Directive in Germany: Looking Ahead - Hogan Lovells
+Opens in a new window
+
+privacymatters.dlapiper.com
+Germany: New government plans to centralize data protection supervision and reduce regulation for small and medium-sized companies | Privacy Matters
+Opens in a new window
+
+cov.com
+Brazil's Digital Policy in 2025: AI, Cloud, Cyber, Data Centers, and Social Media
+Opens in a new window
+
+juncyber.com
+Japan's Cyber Law 2025: A New Direction in Defense
+Opens in a new window
+
+practiceguides.chambers.com
+Cybersecurity 2025 - Japan - Global Practice Guides - Chambers and Partners
+Opens in a new window
+
+freedomhouse.org
+Brazil: Freedom in the World 2025 Country Report
+Opens in a new window
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Terminal Workflow: terminal-workflow/index.md
   - Culture Project: culture-project/index.md
   - Cyberpunk Cookbook: cyberpunk-cookbook.md
+  - Netrunning Research: netrunning-fiction-reality.md
   - Internet Anonymity Research: internet-anonymity-cyberpunk-response.md
   - An Audit of an Oracle: audit-of-an-oracle.md
   - Inspiring Figures: inspiring-figures.md


### PR DESCRIPTION
## Summary
- add a detailed research document on netrunning and modern hacker toolchains
- link the new page in the site navigation
- format the document with a GitHub-friendly table

## Testing
- `npx -y markdownlint-cli "docs/netrunning-fiction-reality.md"`

------
https://chatgpt.com/codex/tasks/task_e_688b8e0d7de08326957b45a79e3db4c0