### PR TITLE
Fix disclaimers for markdown docs

### DIFF
--- a/docs/cyberpunk-cookbook.md
+++ b/docs/cyberpunk-cookbook.md
@@ -5,7 +5,8 @@ project: docs-hub
 updated: 2025-07-30
 ---
 
-This document is provided for research purposes only and does not constitute legal or financial advice.
+!!! note "Disclaimer"
+    This document is provided for research purposes only and does not constitute legal or financial advice.
 
 # Cyberpunk Cookbook
 

--- a/docs/internet-anonymity-cyberpunk-response.md
+++ b/docs/internet-anonymity-cyberpunk-response.md
@@ -5,7 +5,8 @@ project: docs-hub
 updated: 2025-07-31
 ---
 
-This document is provided for research purposes only and does not constitute legal or financial advice.
+!!! note "Disclaimer"
+    This document is provided for research purposes only and does not constitute legal or financial advice.
 
 # Internet Anonymity – Past, Present Crackdowns, and the Cyberpunk Response
 

--- a/docs/netrunning-fiction-reality.md
+++ b/docs/netrunning-fiction-reality.md
@@ -5,7 +5,8 @@ project: docs-hub
 updated: 2025-07-31
 ---
 
-This document is provided for research purposes only and does not constitute legal or financial advice.
+!!! note "Disclaimer"
+    This document is provided for research purposes only and does not constitute legal or financial advice.
 
 # “Netrunning” — Fiction, Reality, and the Modern Hacker Tool-Chain
 

--- a/docs/wave4-money-autonomy.md
+++ b/docs/wave4-money-autonomy.md
@@ -7,7 +7,8 @@ updated: 2025-07-29
 
 # Real-World Cyberpunk Manifesto — Wave 4: Money & Autonomy
 
-This document is provided for research purposes only and does not constitute legal or financial advice.
+!!! note "Disclaimer"
+    This document is provided for research purposes only and does not constitute legal or financial advice.
 
 Introduction: From OPSEC to FINSEC — The Financial Counter-Attack
 This manual marks the fourth wave of the strategic doctrine initiated in this series. It transitions from the defensive postures of operational security (OPSEC), detailed in Wave 3, to the proactive measures of financial security (FINSEC). The core argument of this text is that financial autonomy is not a tangential objective but a critical, non-negotiable enabler of the "Radical Autonomy" mindset articulated in Wave 1[^1] The capacity for authentic thought, dissent, and action is fundamentally compromised when one's ability to acquire, store, and transact value is contingent upon permission from the very corporate-state sovereigns whose architectures of control were mapped in Wave 2[^1] A kill switch on your bank account is a kill switch on your dissent.


### PR DESCRIPTION
## Summary
- convert plain-text disclaimers into admonition blocks
- keep wise payouts disclaimer consistent with the rest

## Testing
- `npx markdownlint docs`

------
https://chatgpt.com/codex/tasks/task_e_688bb5384d908326980a93dc66584563