### PR TITLE
Add document revision backend and CLI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 88
+exclude = node_modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-material
 mkdocs-monorepo-plugin
 pytest
 flake8
+fastapi

--- a/scripts/revert_revision.py
+++ b/scripts/revert_revision.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from versioning.store import RevisionStore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Revert a document to a specific revision",
+    )
+    parser.add_argument("document_id", help="Document identifier")
+    parser.add_argument("version", type=int, help="Revision number to revert to")
+    parser.add_argument(
+        "--author",
+        default="admin",
+        help="Author performing the revert",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path("revision_store.json"),
+        help="Revision database file",
+    )
+    args = parser.parse_args()
+
+    store = RevisionStore(args.db)
+    store.revert(args.document_id, args.version, args.author)
+    print(f"Reverted {args.document_id} to revision {args.version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from versioning.store import RevisionStore
+
+
+def test_revision_save_and_list(tmp_path: Path):
+    store = RevisionStore(tmp_path / "db.json")
+    store.save_document("doc1", "Hello", "user1")
+    store.save_document("doc1", "Hello world", "user1")
+
+    revisions = store.list_revisions("doc1")
+    assert [r["version"] for r in revisions] == [1, 2]
+
+    rev2 = store.get_revision("doc1", 2)
+    assert rev2["content"] == "Hello world"
+    assert rev2["author_id"] == "user1"
+
+
+def test_revert(tmp_path: Path):
+    store = RevisionStore(tmp_path / "db.json")
+    store.save_document("doc1", "First", "user1")
+    store.save_document("doc1", "Second", "user1")
+
+    store.revert("doc1", 1, "admin")
+    latest = store.get_revision("doc1", 3)
+    assert latest["content"] == "First"
+    assert latest["author_id"] == "admin"

--- a/versioning/__init__.py
+++ b/versioning/__init__.py
@@ -1,0 +1,5 @@
+"""Simple document revision tracking."""
+
+from .store import Revision, RevisionStore
+
+__all__ = ["Revision", "RevisionStore"]

--- a/versioning/api.py
+++ b/versioning/api.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+
+from .store import RevisionStore
+
+app = FastAPI()
+_store = RevisionStore(Path("revision_store.json"))
+
+
+@app.get("/docs/{doc_id}/revisions")
+def list_revisions(doc_id: str):
+    return _store.list_revisions(doc_id)
+
+
+@app.get("/docs/{doc_id}/revisions/{version}")
+def get_revision(doc_id: str, version: int):
+    revision = _store.get_revision(doc_id, version)
+    if revision is None:
+        raise HTTPException(status_code=404, detail="Revision not found")
+    return revision

--- a/versioning/store.py
+++ b/versioning/store.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import difflib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Revision:
+    """Representation of a single document revision."""
+
+    document_id: str
+    version: int
+    author_id: str
+    timestamp: str
+    diff: str
+    content: str
+
+
+class RevisionStore:
+    """Persist and retrieve document revisions."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        if path.exists():
+            self.data: Dict[str, List[Dict]] = json.loads(path.read_text())
+        else:
+            self.data = {}
+
+    def _write(self) -> None:
+        self.path.write_text(json.dumps(self.data, indent=2))
+
+    def list_revisions(self, document_id: str) -> List[Dict]:
+        """Return all revisions for ``document_id``."""
+        return self.data.get(document_id, [])
+
+    def get_revision(self, document_id: str, version: int) -> Optional[Dict]:
+        """Retrieve a specific revision."""
+        for rev in self.data.get(document_id, []):
+            if rev["version"] == version:
+                return rev
+        return None
+
+    def _latest_content(self, document_id: str) -> str:
+        revs = self.data.get(document_id, [])
+        return revs[-1]["content"] if revs else ""
+
+    def save_document(self, document_id: str, content: str, author_id: str) -> Revision:
+        """Record a new revision for ``document_id``."""
+        previous = self._latest_content(document_id)
+        diff = "".join(
+            difflib.unified_diff(
+                previous.splitlines(keepends=True),
+                content.splitlines(keepends=True),
+                fromfile="previous",
+                tofile="current",
+            )
+        )
+        revisions = self.data.setdefault(document_id, [])
+        revision = Revision(
+            document_id=document_id,
+            version=len(revisions) + 1,
+            author_id=author_id,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            diff=diff,
+            content=content,
+        )
+        revisions.append(asdict(revision))
+        self._write()
+        return revision
+
+    def revert(self, document_id: str, version: int, author_id: str) -> Revision:
+        """Revert ``document_id`` to ``version`` recording the action."""
+        target = self.get_revision(document_id, version)
+        if target is None:
+            raise ValueError("Revision not found")
+        return self.save_document(document_id, target["content"], author_id)


### PR DESCRIPTION
## Summary
- implement revision store for documents with versioning and metadata
- expose FastAPI endpoints for listing and fetching revisions
- add CLI to revert documents to earlier revisions

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_688e56077a808326b3ffee469b61338a