### PR TITLE
Add comment system with API endpoints and rendering

### DIFF
--- a/comments/__init__.py
+++ b/comments/__init__.py
@@ -1,0 +1,5 @@
+"""Comment persistence module."""
+
+from .store import Comment, CommentStore
+
+__all__ = ["Comment", "CommentStore"]

--- a/comments/store.py
+++ b/comments/store.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Comment:
+    """Representation of a document comment."""
+
+    comment_id: int
+    document_id: str
+    section_ref: str
+    author_id: str
+    body: str
+    status: str
+    created_at: str
+
+
+class CommentStore:
+    """Persist and retrieve document comments."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        if path.exists():
+            self.data: Dict[str, List[Dict]] = json.loads(path.read_text())
+        else:
+            self.data = {"comments": []}
+
+    def _write(self) -> None:
+        self.path.write_text(json.dumps(self.data, indent=2))
+
+    def _next_id(self) -> int:
+        return len(self.data["comments"]) + 1
+
+    def add_comment(
+        self, document_id: str, section_ref: str, author_id: str, body: str
+    ) -> Comment:
+        comment = Comment(
+            comment_id=self._next_id(),
+            document_id=document_id,
+            section_ref=section_ref,
+            author_id=author_id,
+            body=body,
+            status="open",
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        self.data["comments"].append(asdict(comment))
+        self._write()
+        return comment
+
+    def list_comments(self, document_id: str) -> List[Dict]:
+        return [c for c in self.data["comments"] if c["document_id"] == document_id]
+
+    def get_comment(self, comment_id: int) -> Optional[Dict]:
+        for c in self.data["comments"]:
+            if c["comment_id"] == comment_id:
+                return c
+        return None
+
+    def update_comment(
+        self, comment_id: int, body: Optional[str] = None, status: Optional[str] = None
+    ) -> Optional[Dict]:
+        comment = self.get_comment(comment_id)
+        if comment is None:
+            return None
+        if body is not None:
+            comment["body"] = body
+        if status is not None:
+            comment["status"] = status
+        self._write()
+        return comment

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import sys
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from comments.store import CommentStore  # noqa: E402
+from versioning.store import RevisionStore  # noqa: E402
+from versioning import api  # noqa: E402
+
+
+def test_comment_store(tmp_path: Path):
+    store = CommentStore(tmp_path / "db.json")
+    c1 = store.add_comment("doc1", "L1-2", "user1", "note")
+    assert c1.comment_id == 1
+    assert store.list_comments("doc1")[0]["body"] == "note"
+
+    store.update_comment(1, status="resolved")
+    assert store.get_comment(1)["status"] == "resolved"
+
+
+def test_comment_endpoints(tmp_path: Path, monkeypatch):
+    rev_store = RevisionStore(tmp_path / "rev.json")
+    com_store = CommentStore(tmp_path / "com.json")
+    monkeypatch.setattr(api, "_store", rev_store)
+    monkeypatch.setattr(api, "_comment_store", com_store)
+    client = TestClient(api.app)
+
+    rev_store.save_document("doc1", "line1\nline2", "user1")
+    res = client.post(
+        "/docs/doc1/comments",
+        json={"section_ref": "L1-1", "author_id": "user1", "body": "test"},
+    )
+    assert res.status_code == 200
+    cid = res.json()["comment_id"]
+
+    res = client.get("/docs/doc1/comments")
+    assert len(res.json()) == 1
+
+    res = client.patch(f"/comments/{cid}", json={"status": "resolved"})
+    assert res.json()["status"] == "resolved"
+
+    rendered = client.get("/docs/doc1/render").json()
+    assert "[comment:" in rendered["content"]

--- a/versioning/api.py
+++ b/versioning/api.py
@@ -1,13 +1,29 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
 from .store import RevisionStore
+from comments.store import CommentStore
+from .render import render_document
 
 app = FastAPI()
 _store = RevisionStore(Path("revision_store.json"))
+_comment_store = CommentStore(Path("comments_store.json"))
+
+
+class CommentCreate(BaseModel):
+    section_ref: str
+    author_id: str
+    body: str
+
+
+class CommentUpdate(BaseModel):
+    body: Optional[str] = None
+    status: Optional[str] = None
 
 
 @app.get("/docs/{doc_id}/revisions")
@@ -21,3 +37,31 @@ def get_revision(doc_id: str, version: int):
     if revision is None:
         raise HTTPException(status_code=404, detail="Revision not found")
     return revision
+
+
+@app.post("/docs/{doc_id}/comments")
+def create_comment(doc_id: str, payload: CommentCreate):
+    comment = _comment_store.add_comment(
+        doc_id, payload.section_ref, payload.author_id, payload.body
+    )
+    return comment
+
+
+@app.get("/docs/{doc_id}/comments")
+def list_comments(doc_id: str):
+    return _comment_store.list_comments(doc_id)
+
+
+@app.patch("/comments/{comment_id}")
+def update_comment(comment_id: int, payload: CommentUpdate):
+    comment = _comment_store.update_comment(
+        comment_id, body=payload.body, status=payload.status
+    )
+    if comment is None:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    return comment
+
+
+@app.get("/docs/{doc_id}/render")
+def render(doc_id: str):
+    return render_document(doc_id, _store, _comment_store)

--- a/versioning/render.py
+++ b/versioning/render.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import List, Dict
+
+from .store import RevisionStore
+from comments.store import CommentStore
+
+
+def render_document(
+    doc_id: str, rev_store: RevisionStore, comment_store: CommentStore
+) -> Dict[str, str | List[Dict]]:
+    """Return document content with comment anchors."""
+    content = rev_store._latest_content(doc_id)
+    comments = comment_store.list_comments(doc_id)
+    lines = content.splitlines()
+    for c in comments:
+        ref = c["section_ref"]
+        anchor = f"[comment:{c['comment_id']}]"
+        if ref.startswith("L"):
+            try:
+                _, end = ref[1:].split("-")
+                idx = int(end)
+                lines.insert(idx, anchor)
+                continue
+            except Exception:  # pragma: no cover - best effort
+                pass
+        for i, line in enumerate(lines):
+            if line.strip() == ref.strip():
+                lines.insert(i + 1, anchor)
+                break
+        else:
+            lines.append(anchor)
+    rendered = "\n".join(lines)
+    return {"content": rendered, "comments": comments}


### PR DESCRIPTION
## Summary
- add comment persistence module storing per-document comments
- expose CRUD endpoints for document comments
- render documents with comment anchors for UI integration

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_688e5be767408326ab02b49b8280f10f