### PR TITLE
Add authenticated document update endpoint and token management

### DIFF
--- a/agentauth/__init__.py
+++ b/agentauth/__init__.py
@@ -1,0 +1,3 @@
+from .store import TokenStore, Token
+
+__all__ = ["TokenStore", "Token"]

--- a/agentauth/store.py
+++ b/agentauth/store.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from secrets import token_hex
+from typing import Dict, Optional
+
+
+@dataclass
+class Token:
+    token: str
+    agent_id: str
+
+
+class TokenStore:
+    """Persist and verify API tokens for agents."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        if path.exists():
+            self.data: Dict[str, str] = json.loads(path.read_text())
+        else:
+            self.data = {}
+
+    def _write(self) -> None:
+        self.path.write_text(json.dumps(self.data, indent=2))
+
+    def create_token(self, agent_id: str) -> Token:
+        token = token_hex(16)
+        self.data[token] = agent_id
+        self._write()
+        return Token(token=token, agent_id=agent_id)
+
+    def delete_token(self, token: str) -> None:
+        if token in self.data:
+            del self.data[token]
+            self._write()
+
+    def verify(self, token: str) -> Optional[str]:
+        return self.data.get(token)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from agentauth.store import TokenStore  # noqa: E402
+
+
+def test_token_store(tmp_path: Path):
+    store = TokenStore(tmp_path / "tokens.json")
+    token = store.create_token("agent1")
+    assert store.verify(token.token) == "agent1"
+    store.delete_token(token.token)
+    assert store.verify(token.token) is None

--- a/tests/test_put_docs.py
+++ b/tests/test_put_docs.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+import sys
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from versioning import api  # noqa: E402
+from versioning.store import RevisionStore  # noqa: E402
+from comments.store import CommentStore  # noqa: E402
+from agentauth.store import TokenStore  # noqa: E402
+
+
+def setup_app(tmp_path: Path):
+    rev_store = RevisionStore(tmp_path / "rev.json")
+    com_store = CommentStore(tmp_path / "com.json")
+    token_store = TokenStore(tmp_path / "tok.json")
+    api._store = rev_store
+    api._comment_store = com_store
+    api._token_store = token_store
+    client = TestClient(api.app)
+    return client, rev_store, com_store, token_store
+
+
+def test_put_doc_append(tmp_path: Path, monkeypatch):
+    client, rev_store, com_store, token_store = setup_app(tmp_path)
+    rev_store.save_document("doc1", "hello", "agent1")
+    com_store.add_comment("doc1", "L1", "user1", "note")
+    token = token_store.create_token("agent1").token
+    calls = []
+
+    def fake_notify(doc_id, summary):
+        calls.append((doc_id, summary))
+
+    monkeypatch.setattr(api, "_notify_comments", fake_notify)
+
+    res = client.put(
+        "/docs/doc1",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "content": " world",
+            "author_id": "agent1",
+            "summary": "append test",
+            "append": True,
+        },
+    )
+    assert res.status_code == 200
+    assert rev_store.list_revisions("doc1")[-1]["content"] == "hello world"
+    assert calls == [("doc1", "append test")]
+
+
+def test_put_doc_replace(tmp_path: Path, monkeypatch):
+    client, rev_store, com_store, token_store = setup_app(tmp_path)
+    rev_store.save_document("doc1", "hello", "agent1")
+    token = token_store.create_token("agent1").token
+    monkeypatch.setattr(api, "_notify_comments", lambda d, s: None)
+
+    res = client.put(
+        "/docs/doc1",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "content": "new",
+            "author_id": "agent1",
+            "summary": "replace test",
+            "append": False,
+        },
+    )
+    assert res.status_code == 200
+    assert rev_store.list_revisions("doc1")[-1]["content"] == "new"
+
+
+def test_put_doc_auth(tmp_path: Path):
+    client, rev_store, com_store, token_store = setup_app(tmp_path)
+    rev_store.save_document("doc1", "hello", "agent1")
+    token_store.create_token("agent1")
+    res = client.put(
+        "/docs/doc1",
+        headers={"Authorization": "Bearer wrong"},
+        json={
+            "content": " world",
+            "author_id": "agent1",
+            "summary": "append test",
+            "append": True,
+        },
+    )
+    assert res.status_code == 401

--- a/versioning/api.py
+++ b/versioning/api.py
@@ -3,16 +3,35 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
 from .store import RevisionStore
 from comments.store import CommentStore
 from .render import render_document
+from agentauth import TokenStore
 
 app = FastAPI()
 _store = RevisionStore(Path("revision_store.json"))
 _comment_store = CommentStore(Path("comments_store.json"))
+_token_store = TokenStore(Path("api_tokens.json"))
+
+_security = HTTPBearer()
+
+
+def _get_agent(credentials: HTTPAuthorizationCredentials = Depends(_security)) -> str:
+    agent_id = _token_store.verify(credentials.credentials)
+    if agent_id is None:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return agent_id
+
+
+def _notify_comments(doc_id: str, summary: str) -> None:
+    """Placeholder notification workflow for document comments."""
+    for c in _comment_store.list_comments(doc_id):
+        # Real implementation could notify comment authors here
+        print(f"Notify comment {c['comment_id']} on {doc_id}: {summary}")
 
 
 class CommentCreate(BaseModel):
@@ -24,6 +43,17 @@ class CommentCreate(BaseModel):
 class CommentUpdate(BaseModel):
     body: Optional[str] = None
     status: Optional[str] = None
+
+
+class DocUpdate(BaseModel):
+    content: str
+    author_id: str
+    summary: str
+    append: bool = True
+
+
+class TokenCreate(BaseModel):
+    agent_id: str
 
 
 @app.get("/docs/{doc_id}/revisions")
@@ -60,6 +90,32 @@ def update_comment(comment_id: int, payload: CommentUpdate):
     if comment is None:
         raise HTTPException(status_code=404, detail="Comment not found")
     return comment
+
+
+@app.post("/tokens")
+def create_token(payload: TokenCreate):
+    token = _token_store.create_token(payload.agent_id)
+    return token
+
+
+@app.delete("/tokens/{token}")
+def delete_token(token: str):
+    _token_store.delete_token(token)
+    return {"status": "deleted"}
+
+
+@app.put("/docs/{doc_id}")
+def update_document(
+    doc_id: str, payload: DocUpdate, agent_id: str = Depends(_get_agent)
+):
+    if payload.author_id != agent_id:
+        raise HTTPException(status_code=403, detail="author_id must match token")
+    revs = _store.list_revisions(doc_id)
+    current = revs[-1]["content"] if revs else ""
+    new_content = current + payload.content if payload.append else payload.content
+    revision = _store.save_document(doc_id, new_content, payload.author_id)
+    _notify_comments(doc_id, payload.summary)
+    return revision
 
 
 @app.get("/docs/{doc_id}/render")


### PR DESCRIPTION
## Summary
- add API token store with create and delete endpoints for agent authentication
- secure new PUT /docs/{id} endpoint that appends or replaces document content and records revisions
- trigger comment notification workflow after each update
- cover token store and update endpoint with tests

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e608532b483268481c90f4921fb92