### PR TITLE
Integrate UME event emissions for document updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ mkdocs-monorepo-plugin
 pytest
 flake8
 fastapi
+requests
+httpx

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -25,6 +25,7 @@ def test_comment_endpoints(tmp_path: Path, monkeypatch):
     com_store = CommentStore(tmp_path / "com.json")
     monkeypatch.setattr(api, "_store", rev_store)
     monkeypatch.setattr(api, "_comment_store", com_store)
+    monkeypatch.setattr(api, "post_event", lambda e: None)
     client = TestClient(api.app)
 
     rev_store.save_document("doc1", "line1\nline2", "user1")

--- a/tests/test_put_docs.py
+++ b/tests/test_put_docs.py
@@ -28,11 +28,8 @@ def test_put_doc_append(tmp_path: Path, monkeypatch):
     com_store.add_comment("doc1", "L1", "user1", "note")
     token = token_store.create_token("agent1").token
     calls = []
-
-    def fake_notify(doc_id, summary):
-        calls.append((doc_id, summary))
-
-    monkeypatch.setattr(api, "_notify_comments", fake_notify)
+    monkeypatch.setattr(api, "_notify_comments", lambda d, s: calls.append((d, s)))
+    monkeypatch.setattr(api, "post_event", lambda e: None)
 
     res = client.put(
         "/docs/doc1",
@@ -54,6 +51,7 @@ def test_put_doc_replace(tmp_path: Path, monkeypatch):
     rev_store.save_document("doc1", "hello", "agent1")
     token = token_store.create_token("agent1").token
     monkeypatch.setattr(api, "_notify_comments", lambda d, s: None)
+    monkeypatch.setattr(api, "post_event", lambda e: None)
 
     res = client.put(
         "/docs/doc1",

--- a/ume/__init__.py
+++ b/ume/__init__.py
@@ -1,0 +1,3 @@
+from .events import EventPayload, post_event
+
+__all__ = ["EventPayload", "post_event"]

--- a/ume/events.py
+++ b/ume/events.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+import requests
+
+UME_EVENT_ENDPOINT = "https://ume.example.com/events"
+MAX_RETRIES = 3
+RETRY_DELAY = 1  # seconds
+
+
+@dataclass
+class EventPayload:
+    document_id: str
+    event_type: str
+    author_id: str
+    timestamp: str
+    revision_id: Optional[int]
+    correlation_id: Optional[str] = None
+
+
+def post_event(event: EventPayload) -> None:
+    """POST an event to the UME ingestion endpoint with retries."""
+    payload = asdict(event)
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            res = requests.post(UME_EVENT_ENDPOINT, json=payload, timeout=5)
+            res.raise_for_status()
+            return
+        except Exception as exc:  # pragma: no cover - logging of all failures
+            logging.warning(
+                "Failed to send UME event (attempt %s/%s): %s",
+                attempt,
+                MAX_RETRIES,
+                exc,
+            )
+            time.sleep(RETRY_DELAY)
+    logging.error(
+        "Giving up sending UME event after %s attempts", MAX_RETRIES
+    )


### PR DESCRIPTION
## Summary
- define `EventPayload` schema and HTTP client to post events with retries
- emit UME events on revision and comment creation with optional correlation IDs
- add dependencies for event posting and test client

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e88cc8bec8326b324db2f767f3dba