### PR TITLE
feat: add messaging integration for notifications

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from fastapi.testclient import TestClient
 import sys
+import smtplib
+import requests
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
@@ -31,9 +33,21 @@ def test_revision_notification(tmp_path: Path, monkeypatch):
     sub_store.subscribe("doc1", "user1", ["email"])
 
     sent = []
-    monkeypatch.setattr(
-        api, "_send_notification", lambda s, c, p: sent.append((s, c, p))
-    )
+
+    class DummySMTP:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def send_message(self, msg):  # pragma: no cover - simple capture
+            sent.append(msg)
+
+    monkeypatch.setattr(smtplib, "SMTP", lambda *a, **kw: DummySMTP())
     monkeypatch.setattr(api, "post_event", lambda e: None)
     monkeypatch.setattr(api, "_notify_comments", lambda d, s: None)
 
@@ -48,8 +62,7 @@ def test_revision_notification(tmp_path: Path, monkeypatch):
         },
     )
     assert res.status_code == 200
-    assert sent[0][0] == "user1"
-    assert sent[0][2]["revision_id"] == 1
+    assert len(sent) == 1
 
 
 def test_comment_notification_unsub(tmp_path: Path, monkeypatch):
@@ -57,13 +70,13 @@ def test_comment_notification_unsub(tmp_path: Path, monkeypatch):
     rev_store.save_document("doc1", "hello", "agent1")
     client.post(
         "/docs/doc1/subscriptions",
-        json={"subscriber_id": "user1", "channels": ["email"]},
+        json={"subscriber_id": "user1", "channels": ["webhook"]},
     )
     client.delete("/docs/doc1/subscriptions/user1")
 
-    sent = []
+    calls = []
     monkeypatch.setattr(
-        api, "_send_notification", lambda s, c, p: sent.append((s, c, p))
+        requests, "post", lambda url, json, timeout=3: calls.append((url, json))
     )
     monkeypatch.setattr(api, "post_event", lambda e: None)
 
@@ -72,7 +85,7 @@ def test_comment_notification_unsub(tmp_path: Path, monkeypatch):
         json={"section_ref": "L1", "author_id": "u1", "body": "note"},
     )
     assert res.status_code == 200
-    assert sent == []
+    assert calls == []
 
 
 def test_comment_notification_payload(tmp_path: Path, monkeypatch):
@@ -80,13 +93,15 @@ def test_comment_notification_payload(tmp_path: Path, monkeypatch):
     rev = rev_store.save_document("doc1", "hello", "agent1")
     client.post(
         "/docs/doc1/subscriptions",
-        json={"subscriber_id": "user1", "channels": ["websocket"]},
+        json={"subscriber_id": "user1", "channels": ["webhook"]},
     )
 
-    sent = []
-    monkeypatch.setattr(
-        api, "_send_notification", lambda s, c, p: sent.append((s, c, p))
-    )
+    calls = []
+
+    def fake_post(url, json, timeout=3):  # pragma: no cover - network stub
+        calls.append((url, json))
+
+    monkeypatch.setattr(requests, "post", fake_post)
     monkeypatch.setattr(api, "post_event", lambda e: None)
 
     res = client.post(
@@ -94,5 +109,44 @@ def test_comment_notification_payload(tmp_path: Path, monkeypatch):
         json={"section_ref": "L1", "author_id": "u1", "body": "note"},
     )
     assert res.status_code == 200
-    assert sent[0][2]["revision_id"] == rev.version
-    assert sent[0][2]["comment_link"].endswith("/comments/1")
+    assert calls[0][1]["revision_id"] == rev.version
+    assert calls[0][1]["comment_link"].endswith("/comments/1")
+
+
+def test_comment_author_notified_on_revision(tmp_path: Path, monkeypatch):
+    client, rev_store, com_store, token_store, sub_store = setup_app(tmp_path)
+    rev_store.save_document("doc1", "hello", "agent1")
+    com_store.add_comment("doc1", "L1", "user1", "note")
+    token = token_store.create_token("agent1").token
+
+    sent = []
+
+    class DummySMTP:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def send_message(self, msg):  # pragma: no cover - simple capture
+            sent.append(msg)
+
+    monkeypatch.setattr(smtplib, "SMTP", lambda *a, **kw: DummySMTP())
+    monkeypatch.setattr(api, "post_event", lambda e: None)
+    monkeypatch.setattr(api, "_notify_subscribers", lambda *a, **kw: None)
+
+    res = client.put(
+        "/docs/doc1",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "content": " world",
+            "author_id": "agent1",
+            "summary": "update",
+            "append": True,
+        },
+    )
+    assert res.status_code == 200
+    assert len(sent) == 1


### PR DESCRIPTION
## Summary
- send notifications via SMTP or webhook with retry and logging
- notify comment authors when a document is revised
- test notification dispatch for revisions and comments

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eadad5b748326943dfb89591dbb3e