### PR TITLE
Hash and expire agent tokens with migration support

### DIFF
--- a/agentauth/__init__.py
+++ b/agentauth/__init__.py
@@ -1,3 +1,3 @@
-from .store import TokenStore, Token
+from .store import TokenStore, Token, migrate_tokens_file
 
-__all__ = ["TokenStore", "Token"]
+__all__ = ["TokenStore", "Token", "migrate_tokens_file"]

--- a/agentauth/store.py
+++ b/agentauth/store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import hashlib
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from secrets import token_hex
@@ -11,31 +13,74 @@ from typing import Dict, Optional
 class Token:
     token: str
     agent_id: str
+    expires: int
 
 
 class TokenStore:
     """Persist and verify API tokens for agents."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path, ttl: int = 3600):
         self.path = path
+        self.ttl = ttl
         if path.exists():
-            self.data: Dict[str, str] = json.loads(path.read_text())
+            self.data: Dict[str, Dict[str, int]] = json.loads(path.read_text())
         else:
             self.data = {}
+        self.cleanup()
 
     def _write(self) -> None:
         self.path.write_text(json.dumps(self.data, indent=2))
 
+    def _now(self) -> int:
+        return int(time.time())
+
+    def _digest(self, token: str) -> str:
+        return hashlib.sha256(token.encode()).hexdigest()
+
     def create_token(self, agent_id: str) -> Token:
         token = token_hex(16)
-        self.data[token] = agent_id
+        digest = self._digest(token)
+        expires = self._now() + self.ttl
+        self.data[digest] = {"agent_id": agent_id, "expires": expires}
         self._write()
-        return Token(token=token, agent_id=agent_id)
+        return Token(token=token, agent_id=agent_id, expires=expires)
 
     def delete_token(self, token: str) -> None:
-        if token in self.data:
-            del self.data[token]
+        digest = self._digest(token)
+        if digest in self.data:
+            del self.data[digest]
             self._write()
 
     def verify(self, token: str) -> Optional[str]:
-        return self.data.get(token)
+        self.cleanup()
+        digest = self._digest(token)
+        info = self.data.get(digest)
+        if info and info["expires"] > self._now():
+            return info["agent_id"]
+        return None
+
+    def cleanup(self) -> None:
+        now = self._now()
+        expired = [d for d, info in self.data.items() if info["expires"] <= now]
+        if expired:
+            for d in expired:
+                del self.data[d]
+            self._write()
+
+
+def migrate_tokens_file(path: Path, ttl: int = 3600) -> None:
+    """Migrate a plaintext token file to hashed format with expiration."""
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return
+    if data and all(isinstance(v, dict) and "agent_id" in v for v in data.values()):
+        return
+    now = int(time.time())
+    new_data = {}
+    for token, agent_id in data.items():
+        digest = hashlib.sha256(token.encode()).hexdigest()
+        new_data[digest] = {"agent_id": agent_id, "expires": now + ttl}
+    path.write_text(json.dumps(new_data, indent=2))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 import sys
+import json
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from agentauth.store import TokenStore  # noqa: E402
+from agentauth.store import TokenStore, migrate_tokens_file  # noqa: E402
 
 
 def test_token_store(tmp_path: Path):
@@ -13,3 +14,20 @@ def test_token_store(tmp_path: Path):
     assert store.verify(token.token) == "agent1"
     store.delete_token(token.token)
     assert store.verify(token.token) is None
+
+
+def test_token_expiration(tmp_path: Path, monkeypatch):
+    store = TokenStore(tmp_path / "tokens.json", ttl=1)
+    token = store.create_token("agent1")
+    orig_now = store._now
+    monkeypatch.setattr(store, "_now", lambda: orig_now() + 2)
+    assert store.verify(token.token) is None
+
+
+def test_migrate_tokens(tmp_path: Path):
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"tok": "agent1"}))
+    migrate_tokens_file(path, ttl=60)
+    store = TokenStore(path, ttl=60)
+    assert "tok" not in path.read_text()
+    assert store.verify("tok") == "agent1"


### PR DESCRIPTION
## Summary
- hash API tokens with SHA-256 and store only digests
- add expiration timestamps, verification, and cleanup for tokens
- provide migration utility and tests for token expiration and migration

## Testing
- `flake8 agentauth tests versioning comments`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eb0a6c26083268c0248168655d2d5