### PR TITLE
Implement exponential backoff for UME event retries

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,39 @@
+import pytest
+import requests
+
+from ume import events
+
+
+def test_post_event_retries_with_exponential_backoff(monkeypatch):
+    event = events.EventPayload(
+        document_id="doc1",
+        event_type="test",
+        author_id="author",
+        timestamp="2024-01-01T00:00:00Z",
+        revision_id=None,
+    )
+
+    calls = []
+
+    def fake_post(url, json, timeout):
+        calls.append(1)
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(events.requests, "post", fake_post)
+
+    delays = []
+
+    def fake_sleep(seconds):
+        delays.append(seconds)
+
+    monkeypatch.setattr(events.time, "sleep", fake_sleep)
+
+    with pytest.raises(requests.RequestException):
+        events.post_event(event)
+
+    assert len(calls) == events.MAX_RETRIES
+    expected_delays = [
+        min(2 ** attempt, events.MAX_BACKOFF)
+        for attempt in range(1, events.MAX_RETRIES)
+    ]
+    assert delays == expected_delays


### PR DESCRIPTION
## Summary
- add `MAX_BACKOFF` and swap fixed retry delays for exponential backoff
- raise the last exception when retries are exhausted
- add tests confirming exponential backoff and retry limit behavior

## Testing
- `python -m flake8 ume/events.py tests/test_events.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebb5e88fc8326b73be6cc3906660e