### PR TITLE
feat: add conflict resolution endpoint

### DIFF
--- a/docs/versioning-api.md
+++ b/docs/versioning-api.md
@@ -1,0 +1,33 @@
+# Versioning API
+
+The document service supports optimistic concurrency control. Updating a
+revision with a `base_version` that differs from the latest version returns
+`409 Conflict` with a unified diff and metadata describing conflicting line
+ranges:
+
+```json
+{
+  "diff": "...",
+  "latest": 3,
+  "conflicts": [
+    {"base": [1,2], "incoming": [1,2], "current": [1,2]}
+  ]
+}
+```
+
+After resolving the conflicts locally, submit the merged content using
+`POST /docs/{doc_id}/resolve`:
+
+```bash
+curl -X POST /docs/mydoc/resolve \
+  -H "Authorization: Bearer <token>" \
+  -d '{
+        "content": "final text",
+        "author_id": "agent1",
+        "summary": "merge",
+        "base_version": 3
+      }'
+```
+
+If `base_version` is stale the same conflict structure is returned. A
+successful call creates a new revision and dispatches the usual notifications.

--- a/tests/test_put_docs.py
+++ b/tests/test_put_docs.py
@@ -86,7 +86,8 @@ def test_put_doc_auth(tmp_path: Path):
 
 def test_put_doc_conflict(tmp_path: Path, monkeypatch):
     client, rev_store, com_store, token_store = setup_app(tmp_path)
-    rev_store.save_document("doc1", "hello", "agent1")
+    rev_store.save_document("doc1", "a\nb\n", "agent1")
+    rev_store.save_document("doc1", "a\nB\n", "agent2")
     token = token_store.create_token("agent1").token
     monkeypatch.setattr(api, "_notify_comments", lambda d, s: None)
     monkeypatch.setattr(api, "post_event", lambda e: None)
@@ -95,15 +96,16 @@ def test_put_doc_conflict(tmp_path: Path, monkeypatch):
         "/docs/doc1",
         headers={"Authorization": f"Bearer {token}"},
         json={
-            "content": " world",
+            "content": "a\nb2\n",
             "author_id": "agent1",
-            "summary": "append test",
-            "append": True,
-            "base_version": 0,
+            "summary": "edit",
+            "append": False,
+            "base_version": 1,
         },
     )
     assert res.status_code == 409
-    assert "diff" in res.json()["detail"]
+    detail = res.json()["detail"]
+    assert "diff" in detail and "conflicts" in detail and detail["conflicts"]
 
 
 def test_diff_endpoint(tmp_path: Path):
@@ -113,3 +115,47 @@ def test_diff_endpoint(tmp_path: Path):
     res = client.get("/docs/doc1/diff/1/2")
     assert res.status_code == 200
     assert "-a" in res.json()["diff"]
+
+
+def test_resolve_doc(tmp_path: Path, monkeypatch):
+    client, rev_store, com_store, token_store = setup_app(tmp_path)
+    rev_store.save_document("doc1", "a\nb\n", "agent1")
+    rev_store.save_document("doc1", "a\nB\n", "agent2")
+    token = token_store.create_token("agent1").token
+    monkeypatch.setattr(api, "_notify_comments", lambda d, s: None)
+    monkeypatch.setattr(api, "post_event", lambda e: None)
+
+    res = client.post(
+        "/docs/doc1/resolve",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "content": "a\nB2\n",
+            "author_id": "agent1",
+            "summary": "merge",
+            "base_version": 2,
+        },
+    )
+    assert res.status_code == 200
+    assert rev_store.list_revisions("doc1")[-1]["content"] == "a\nB2\n"
+
+
+def test_resolve_doc_conflict(tmp_path: Path, monkeypatch):
+    client, rev_store, com_store, token_store = setup_app(tmp_path)
+    rev_store.save_document("doc1", "a\nb\n", "agent1")
+    rev_store.save_document("doc1", "a\nB\n", "agent2")
+    token = token_store.create_token("agent1").token
+    monkeypatch.setattr(api, "_notify_comments", lambda d, s: None)
+    monkeypatch.setattr(api, "post_event", lambda e: None)
+
+    res = client.post(
+        "/docs/doc1/resolve",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "content": "a\nb2\n",
+            "author_id": "agent1",
+            "summary": "merge",
+            "base_version": 1,
+        },
+    )
+    assert res.status_code == 409
+    assert res.json()["detail"]["conflicts"]


### PR DESCRIPTION
## Summary
- enhance document updates with conflict-range metadata
- add endpoint to resolve conflicted revisions
- document versioning API conflict workflow

## Testing
- `flake8 versioning tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebb5d55348326bb6b55d2cc63e38d