### PR TITLE
Add docs client and conflict-aware updates

### DIFF
--- a/docs/versioning-api.md
+++ b/docs/versioning-api.md
@@ -31,3 +31,17 @@ curl -X POST /docs/mydoc/resolve \
 
 If `base_version` is stale the same conflict structure is returned. A
 successful call creates a new revision and dispatches the usual notifications.
+
+## Python Client
+
+Use the bundled ``DocsClient`` for authenticated interactions with the API:
+
+```python
+from versioning.client import DocsClient
+
+client = DocsClient("http://localhost:8000", token="secrettoken")
+client.create_comment("doc1", "L1", "user1", "Nice!", correlation_id="c-1")
+client.update_document(
+    "doc1", " more text", author_id="agent1", summary="edit", correlation_id="c-2"
+)
+```

--- a/tests/test_docs_client.py
+++ b/tests/test_docs_client.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import sys
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from versioning import api  # noqa: E402
+from versioning.client import ConflictError, DocsClient  # noqa: E402
+from versioning.store import RevisionStore  # noqa: E402
+from comments.store import CommentStore  # noqa: E402
+from agentauth.store import TokenStore  # noqa: E402
+
+
+def setup_client(
+    tmp_path: Path,
+) -> tuple[DocsClient, RevisionStore, CommentStore, TokenStore]:
+    rev_store = RevisionStore(tmp_path / "rev.sqlite")
+    com_store = CommentStore(tmp_path / "com.sqlite")
+    token_store = TokenStore(tmp_path / "tok.json")
+    api._store = rev_store
+    api._comment_store = com_store
+    api._token_store = token_store
+    test_client = TestClient(api.app)
+    token = token_store.create_token("agent1").token
+    docs_client = DocsClient(test_client.base_url, token=token, session=test_client)
+    api.post_event = lambda event: None
+    return docs_client, rev_store, com_store, token_store
+
+
+def test_update_document_end_to_end(tmp_path: Path):
+    client, rev_store, _, _ = setup_client(tmp_path)
+    rev_store.save_document("doc1", "hello", "agent1")
+    client.update_document(
+        "doc1",
+        " world",
+        author_id="agent1",
+        summary="append",
+        correlation_id="corr-1",
+    )
+    assert rev_store.list_revisions("doc1")[-1]["content"] == "hello world"
+
+
+def test_update_document_conflict(tmp_path: Path):
+    client, rev_store, _, _ = setup_client(tmp_path)
+    rev_store.save_document("doc1", "a\nb\n", "agent1")
+    rev_store.save_document("doc1", "a\nB\n", "agent2")
+    try:
+        client.update_document(
+            "doc1",
+            "a\nb2\n",
+            author_id="agent1",
+            summary="edit",
+            append=False,
+            base_version=1,
+        )
+    except ConflictError as exc:
+        assert exc.latest == 2
+        assert exc.conflicts
+    else:
+        assert False, "ConflictError not raised"
+
+
+def test_create_comment(tmp_path: Path):
+    client, rev_store, com_store, _ = setup_client(tmp_path)
+    rev_store.save_document("doc1", "hello", "agent1")
+    res = client.create_comment(
+        "doc1",
+        section_ref="L1",
+        author_id="user1",
+        body="note",
+        correlation_id="corr-2",
+    )
+    assert res["body"] == "note"
+    assert com_store.list_comments("doc1")[0]["body"] == "note"

--- a/versioning/client.py
+++ b/versioning/client.py
@@ -1,0 +1,126 @@
+"""Client wrapper for the docs versioning API.
+
+Example:
+    from versioning.client import DocsClient
+    client = DocsClient("http://localhost:8000", token="secrettoken")
+    client.update_document("doc1", "content", author_id="agent1", summary="demo")
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class ConflictError(Exception):
+    """Raised when the server reports a version conflict."""
+
+    def __init__(self, diff: str, latest: int, conflicts: Any):
+        super().__init__("document update conflict")
+        self.diff = diff
+        self.latest = latest
+        self.conflicts = conflicts
+
+
+@dataclass
+class DocsClient:
+    """Simple client for interacting with the versioning API.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL of the running API server.
+    token:
+        Bearer token used for authentication.
+    session:
+        Optional ``requests`` compatible session. This is primarily useful
+        for injecting ``TestClient`` during unit tests.
+    """
+
+    base_url: str
+    token: str
+    session: Optional[requests.sessions.Session] = None
+
+    def __post_init__(self) -> None:
+        self.base_url = str(self.base_url).rstrip("/")
+        self._session = self.session or requests.Session()
+        self._session.headers.update({"Authorization": f"Bearer {self.token}"})
+
+    # Internal request helper
+    def _request(
+        self,
+        method: str,
+        path: str,
+        json: Optional[Dict[str, Any]] = None,
+        correlation_id: Optional[str] = None,
+    ) -> requests.Response:
+        url = f"{self.base_url}{path}"
+        headers: Dict[str, str] = {}
+        if correlation_id:
+            # send in header for cross-service tracing
+            headers["X-Correlation-ID"] = correlation_id
+            if json is not None:
+                json.setdefault("correlation_id", correlation_id)
+            else:
+                json = {"correlation_id": correlation_id}
+        resp = self._session.request(method, url, json=json, headers=headers)
+        return resp
+
+    def update_document(
+        self,
+        doc_id: str,
+        content: str,
+        author_id: str,
+        summary: str,
+        *,
+        append: bool = True,
+        base_version: Optional[int] = None,
+        correlation_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "content": content,
+            "author_id": author_id,
+            "summary": summary,
+            "append": append,
+        }
+        if base_version is not None:
+            payload["base_version"] = base_version
+        resp = self._request(
+            "PUT",
+            f"/docs/{doc_id}",
+            json=payload,
+            correlation_id=correlation_id,
+        )
+        if resp.status_code == 409:
+            detail = resp.json().get("detail", {})
+            raise ConflictError(
+                detail.get("diff", ""),
+                detail.get("latest", 0),
+                detail.get("conflicts", []),
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    def create_comment(
+        self,
+        doc_id: str,
+        section_ref: str,
+        author_id: str,
+        body: str,
+        *,
+        correlation_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "section_ref": section_ref,
+            "author_id": author_id,
+            "body": body,
+        }
+        resp = self._request(
+            "POST",
+            f"/docs/{doc_id}/comments",
+            json=payload,
+            correlation_id=correlation_id,
+        )
+        resp.raise_for_status()
+        return resp.json()


### PR DESCRIPTION
## Summary
- add `DocsClient` for token-authenticated document updates and comments
- handle correlation IDs and conflict responses
- document and test client usage end-to-end

## Testing
- `flake8 versioning/client.py tests/test_docs_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec0ec970c8326bc11c6ac0a37775b