### PR TITLE
Optimize document view diff handling

### DIFF
--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -89,6 +89,7 @@ def test_document_view_endpoint(tmp_path: Path, monkeypatch):
     assert data["content"].startswith("line1")
     assert len(data["comments"]) == 1
     assert len(data["revisions"]) == 2
+    assert data["revisions"][0]["diff"] == ""
     assert data["revisions"][1]["diff"]
 
 

--- a/tests/test_document_view_performance.py
+++ b/tests/test_document_view_performance.py
@@ -1,0 +1,42 @@
+import time
+import difflib
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+from versioning import api
+from versioning.store import RevisionStore
+from comments.store import CommentStore
+
+
+def test_document_view_latest_only_is_fast(tmp_path: Path, monkeypatch):
+    rev_store = RevisionStore(tmp_path / "rev.sqlite")
+    com_store = CommentStore(tmp_path / "com.sqlite")
+    monkeypatch.setattr(api, "_store", rev_store)
+    monkeypatch.setattr(api, "_comment_store", com_store)
+    monkeypatch.setattr(api, "post_event", lambda e: None)
+
+    for i in range(100):
+        rev_store.save_document("doc", f"line{i}", "u1")
+
+    calls = {"count": 0}
+
+    def slow_diff(*args, **kwargs):
+        calls["count"] += 1
+        time.sleep(0.001)
+        return []
+
+    monkeypatch.setattr(difflib, "unified_diff", slow_diff)
+    client = TestClient(api.app)
+
+    start = time.time()
+    res = client.get("/docs/doc/view")
+    latest_duration = time.time() - start
+    assert res.status_code == 200
+    assert calls["count"] == 1
+
+    start = time.time()
+    res = client.get("/docs/doc/view?latest_only=false")
+    full_duration = time.time() - start
+    assert res.status_code == 200
+    assert calls["count"] == 101
+    assert full_duration > latest_duration * 5


### PR DESCRIPTION
## Summary
- reduce cost of `/docs/{doc_id}/view` by diffing only the latest revision by default
- add optimistic locking to revision storage
- test document view performance with many revisions

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f909cd28c8326bc417dfa9c30febf