### PR TITLE
feat: add atomic writes with file locking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ flake8
 fastapi
 requests
 httpx
+filelock


### PR DESCRIPTION
## Summary
- ensure token store writes are atomic by using a temp file replace strategy
- add file-based locking to prevent concurrent token store modifications
- update requirements for filelock dependency

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd721ba90832681960e3110323d8e