### PR TITLE
Refactor comment store to return dataclasses

### DIFF
--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -17,10 +17,10 @@ def test_comment_store(tmp_path: Path):
     store = CommentStore(tmp_path / "db.sqlite")
     c1 = store.add_comment("doc1", "L1-2", "user1", "note")
     assert c1.comment_id == 1
-    assert store.list_comments("doc1")[0]["body"] == "note"
+    assert store.list_comments("doc1")[0].body == "note"
 
     store.update_comment(1, status="resolved")
-    assert store.get_comment(1)["status"] == "resolved"
+    assert store.get_comment(1).status == "resolved"
 
 
 def test_comment_index_and_listing(tmp_path: Path):
@@ -126,4 +126,4 @@ def test_concurrent_comment_writes(tmp_path: Path):
 
     comments = store.list_comments("doc")
     assert len(comments) == 5
-    assert [c["comment_id"] for c in comments] == [1, 2, 3, 4, 5]
+    assert [c.comment_id for c in comments] == [1, 2, 3, 4, 5]

--- a/tests/test_docs_client.py
+++ b/tests/test_docs_client.py
@@ -72,4 +72,4 @@ def test_create_comment(tmp_path: Path):
         correlation_id="corr-2",
     )
     assert res["body"] == "note"
-    assert com_store.list_comments("doc1")[0]["body"] == "note"
+    assert com_store.list_comments("doc1")[0].body == "note"

--- a/versioning/api.py
+++ b/versioning/api.py
@@ -44,9 +44,9 @@ def _notify_comments(doc_id: str, summary: str) -> None:
             "document_id": doc_id,
             "event_type": "revision_created",
             "summary": summary,
-            "comment_id": c["comment_id"],
+            "comment_id": c.comment_id,
         }
-        _send_notification(c["author_id"], "email", payload)
+        _send_notification(c.author_id, "email", payload)
 
 
 def _send_notification(subscriber_id: str, channel: str, payload: dict) -> None:
@@ -287,7 +287,7 @@ def update_comment(
     existing = _comment_store.get_comment(comment_id)
     if existing is None:
         raise HTTPException(status_code=404, detail="Comment not found")
-    if existing["author_id"] != agent_id:
+    if existing.author_id != agent_id:
         raise HTTPException(status_code=403, detail="author_id must match token")
     return _comment_store.update_comment(
         comment_id, body=payload.body, status=payload.status
@@ -300,9 +300,9 @@ def toggle_comment(comment_id: int, agent_id: str = Depends(_get_agent)):
     comment = _comment_store.get_comment(comment_id)
     if comment is None:
         raise HTTPException(status_code=404, detail="Comment not found")
-    if comment["author_id"] != agent_id:
+    if comment.author_id != agent_id:
         raise HTTPException(status_code=403, detail="author_id must match token")
-    new_status = "open" if comment["status"] == "resolved" else "resolved"
+    new_status = "open" if comment.status == "resolved" else "resolved"
     return _comment_store.update_comment(comment_id, status=new_status)
 
 

--- a/versioning/render.py
+++ b/versioning/render.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import List, Dict
+from dataclasses import asdict
+from typing import Dict, List
 
 from .store import RevisionStore
 from comments.store import CommentStore
@@ -13,11 +14,12 @@ def render_document(
     content = rev_store._latest_content(doc_id)
     comments = comment_store.list_comments(doc_id)
     lines = content.splitlines()
+    rendered_comments = []
     for c in comments:
-        ref = c["section_ref"]
-        unresolved = c.get("status") != "resolved"
-        anchor = f"[comment:{c['comment_id']}{'!' if unresolved else ''}]"
-        c["unresolved"] = unresolved
+        ref = c.section_ref
+        unresolved = c.status != "resolved"
+        anchor = f"[comment:{c.comment_id}{'!' if unresolved else ''}]"
+        rendered_comments.append({**asdict(c), "unresolved": unresolved})
         if ref.startswith("L"):
             try:
                 _, end = ref[1:].split("-")
@@ -33,4 +35,4 @@ def render_document(
         else:
             lines.append(anchor)
     rendered = "\n".join(lines)
-    return {"content": rendered, "comments": comments}
+    return {"content": rendered, "comments": rendered_comments}


### PR DESCRIPTION
## Summary
- Use `Comment` dataclass for comment store methods
- Update API and render logic to handle dataclass objects
- Adjust tests for new comment model

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689020a0d2e8832690f937ad2336b763