### PR TITLE
Allow read-only DB transactions

### DIFF
--- a/comments/store.py
+++ b/comments/store.py
@@ -26,7 +26,7 @@ class CommentStore:
 
     def __init__(self, path: Path):
         self.path = path
-        with get_db(self.path) as db:
+        with get_db(self.path, "write") as db:
             db.execute(
                 """
                 CREATE TABLE IF NOT EXISTS comments (
@@ -51,7 +51,7 @@ class CommentStore:
         self, document_id: str, section_ref: str, author_id: str, body: str
     ) -> Comment:
         now = datetime.now(timezone.utc).isoformat()
-        with get_db(self.path) as db:
+        with get_db(self.path, "write") as db:
             cur = db.execute(
                 """
                 INSERT INTO comments (
@@ -82,7 +82,7 @@ class CommentStore:
         return Comment(**data)
 
     def list_comments(self, document_id: str) -> List[Comment]:
-        with get_db(self.path) as db:
+        with get_db(self.path, "read") as db:
             rows = db.execute(
                 """
                 SELECT
@@ -100,7 +100,7 @@ class CommentStore:
         return [self._row_to_comment(row) for row in rows]
 
     def get_comment(self, comment_id: int) -> Optional[Comment]:
-        with get_db(self.path) as db:
+        with get_db(self.path, "read") as db:
             row = db.execute(
                 """
                 SELECT
@@ -120,7 +120,7 @@ class CommentStore:
     def update_comment(
         self, comment_id: int, body: Optional[str] = None, status: Optional[str] = None
     ) -> Optional[Comment]:
-        with get_db(self.path) as db:
+        with get_db(self.path, "write") as db:
             row = db.execute(
                 """
                 SELECT

--- a/db.py
+++ b/db.py
@@ -5,13 +5,18 @@ from typing import Iterator
 
 
 @contextmanager
-def get_db(path: Path) -> Iterator[sqlite3.Connection]:
+def get_db(path: Path, mode: str = "read") -> Iterator[sqlite3.Connection]:
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
     conn.row_factory = sqlite3.Row
     try:
         conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("BEGIN IMMEDIATE")
+        if mode == "read":
+            conn.execute("BEGIN")
+        elif mode == "write":
+            conn.execute("BEGIN IMMEDIATE")
+        else:
+            raise ValueError("mode must be 'read' or 'write'")
         yield conn
         conn.commit()
     finally:

--- a/notifications/store.py
+++ b/notifications/store.py
@@ -22,7 +22,7 @@ class SubscriptionStore:
 
     def __init__(self, path: Path):
         self.path = path
-        with get_db(self.path) as db:
+        with get_db(self.path, "write") as db:
             db.execute(
                 """
                 CREATE TABLE IF NOT EXISTS subscriptions (
@@ -38,7 +38,7 @@ class SubscriptionStore:
         self, document_id: str, subscriber_id: str, channels: List[str]
     ) -> None:
         """Add or update a subscription."""
-        with get_db(self.path) as db:
+        with get_db(self.path, "write") as db:
             db.execute(
                 """
                 INSERT INTO subscriptions (document_id, subscriber_id, channels)
@@ -51,7 +51,7 @@ class SubscriptionStore:
 
     def unsubscribe(self, document_id: str, subscriber_id: str) -> None:
         """Remove a subscription if present."""
-        with get_db(self.path) as db:
+        with get_db(self.path, "write") as db:
             db.execute(
                 "DELETE FROM subscriptions WHERE document_id=? AND subscriber_id=?",
                 (document_id, subscriber_id),
@@ -59,7 +59,7 @@ class SubscriptionStore:
 
     def get_subscribers(self, document_id: str) -> List[Dict]:
         """Return all subscriptions for ``document_id``."""
-        with get_db(self.path) as db:
+        with get_db(self.path, "read") as db:
             rows = db.execute(
                 """
                 SELECT document_id, subscriber_id, channels

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -36,7 +36,7 @@ def test_comment_index_and_listing(tmp_path: Path):
     assert len(comments) == 3
 
     # ensure the query plan uses the index for fast lookups
-    with get_db(store.path) as db:
+    with get_db(store.path, "read") as db:
         plan = db.execute(
             "EXPLAIN QUERY PLAN SELECT * FROM comments WHERE document_id=?",
             ("doc1",),


### PR DESCRIPTION
## Summary
- support read and write modes in `get_db`
- specify transaction mode for store operations

## Testing
- `flake8 --count`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689138fbd31c8326a4927155ff622074