### PR TITLE
feat: expose latest revision content

### DIFF
--- a/versioning/render.py
+++ b/versioning/render.py
@@ -11,7 +11,7 @@ def render_document(
     doc_id: str, rev_store: RevisionStore, comment_store: CommentStore
 ) -> Dict[str, str | List[Dict]]:
     """Return document content with comment anchors."""
-    content = rev_store._latest_content(doc_id)
+    content = rev_store.latest_content(doc_id)
     comments = comment_store.list_comments(doc_id)
     lines = content.splitlines()
     rendered_comments = []

--- a/versioning/store.py
+++ b/versioning/store.py
@@ -70,6 +70,13 @@ class RevisionStore:
             ).fetchone()
         return row["content"] if row else ""
 
+    def latest_content(self, document_id: str) -> str:
+        """Return the latest content for ``document_id``.
+
+        This is a public wrapper around :meth:`_latest_content`.
+        """
+        return self._latest_content(document_id)
+
     def save_document(
         self,
         document_id: str,


### PR DESCRIPTION
## Summary
- expose latest revision content via public method
- use new RevisionStore.latest_content in render_document

## Testing
- `flake8 versioning && echo LINT_OK`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68914fcc778c832696a75ae7d8f18f5c