### PR TITLE
Use Comment dataclasses across comment API

### DIFF
--- a/comments/store.py
+++ b/comments/store.py
@@ -137,13 +137,13 @@ class CommentStore:
             ).fetchone()
             if row is None:
                 return None
-            data = dict(row)
+            comment = self._row_to_comment(row)
             if body is not None:
-                data["body"] = body
+                comment.body = body
             if status is not None:
-                data["status"] = status
+                comment.status = status
             db.execute(
                 "UPDATE comments SET body=?, status=? WHERE comment_id=?",
-                (data["body"], data["status"], comment_id),
+                (comment.body, comment.status, comment_id),
             )
-        return Comment(**data)
+        return comment

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from comments.store import CommentStore  # noqa: E402
+from comments.store import Comment, CommentStore  # noqa: E402
 from db import get_db  # noqa: E402
 from versioning.store import RevisionStore  # noqa: E402
 from agentauth.store import TokenStore  # noqa: E402
@@ -17,10 +17,16 @@ def test_comment_store(tmp_path: Path):
     store = CommentStore(tmp_path / "db.sqlite")
     c1 = store.add_comment("doc1", "L1-2", "user1", "note")
     assert c1.comment_id == 1
-    assert store.list_comments("doc1")[0].body == "note"
+    comments = store.list_comments("doc1")
+    assert isinstance(comments[0], Comment)
+    assert comments[0].body == "note"
 
-    store.update_comment(1, status="resolved")
-    assert store.get_comment(1).status == "resolved"
+    updated = store.update_comment(1, status="resolved")
+    assert isinstance(updated, Comment)
+    assert updated.status == "resolved"
+    fetched = store.get_comment(1)
+    assert isinstance(fetched, Comment)
+    assert fetched.status == "resolved"
 
 
 def test_comment_index_and_listing(tmp_path: Path):


### PR DESCRIPTION
## Summary
- refactor CommentStore.update_comment to operate on Comment dataclasses
- type hint comment endpoints to return Comment dataclasses
- validate in tests that comment store methods return Comment objects

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6894a876eb188326be3b74b5951dd44a