### PR TITLE
Wrap long Markdown lines

### DIFF
--- a/docs/ai-research/index.md
+++ b/docs/ai-research/index.md
@@ -26,4 +26,5 @@ navigation sidebar.
 - [Thick Band of 21st-Century Possibilities](thick-band-of-21st-century-possibilities.md)
 - [You Weren't Supposed to Invent Infinite Jest](you-werent-supposed-to-invent-infinite-jest.md)
 - [The Cognitive Architecture of Artificial Societies](cognitive-architecture-of-artificial-societies.md)
-- [Democratizing Brain-Inspired AI: A Strategic Analysis and 5-Year Roadmap for an Open Neuromorphic Ecosystem](open-neuromorphic-roadmap.md)
+- [Democratizing Brain-Inspired AI: A Strategic Analysis and 5-Year Roadmap for an
+  Open Neuromorphic Ecosystem](open-neuromorphic-roadmap.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,11 +85,13 @@ git lfs install
 scripts/setup_hooks.sh
 ```
 
-The hooks enforce Markdown and Python linting via the `.githooks/pre-commit` script, which runs `markdownlint-cli` and `flake8`.
+The hooks enforce Markdown and Python linting via the `.githooks/pre-commit` script,
+which runs `markdownlint-cli` and `flake8`.
 
 ## Building the Docs
 
-Install Python packages from `requirements.txt` to ensure all dependencies (MkDocs, pytest, flake8) install consistently, then launch the dev server:
+Install Python packages from `requirements.txt` to ensure all dependencies (MkDocs,
+pytest, flake8) install consistently, then launch the dev server:
 
 ```bash
 pip install -r requirements.txt
@@ -121,7 +123,9 @@ scripts/setup_hooks.sh
 ## Invoking the Migration Script
 
 You can import configuration and prompt snippets from the old
-[`d0tTino/d0tTino`](https://github.com/d0tTino/d0tTino) repository. Ensure `git-filter-repo` is installed (for example via `pip install git-filter-repo` or your package manager) before running the script.
+[`d0tTino/d0tTino`](https://github.com/d0tTino/d0tTino) repository. Ensure
+`git-filter-repo` is installed (for example via `pip install git-filter-repo` or
+your package manager) before running the script.
 
 Run the migration script from the repository root:
 
@@ -129,7 +133,9 @@ Run the migration script from the repository root:
 scripts/migrate_old_docs.sh
 ```
 
-The script clones the legacy repo, filters only the documentation files using `git filter-repo`, and fetches the result as a local branch called `d0tTino-import`. Merge that branch to incorporate the history:
+The script clones the legacy repo, filters only the documentation files using
+`git filter-repo`, and fetches the result as a local branch called
+`d0tTino-import`. Merge that branch to incorporate the history:
 
 ```bash
 git merge d0tTino-import --allow-unrelated-histories


### PR DESCRIPTION
## Summary
- wrap long sentences in main docs index and AI research index to meet line-length conventions
- verify formatting with markdownlint

## Testing
- `npx markdownlint docs/index.md docs/ai-research/index.md`


------
https://chatgpt.com/codex/tasks/task_e_6894b7e5f86c832699793f3de4b88752