### PR TITLE
Add missing navigation entry for qualia document

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Inspiring Figures: inspiring-figures.md
   - Concrete Cognition Anthology: concrete-cognition-anthology.md
   - High-Level Intelligence Qualia Atlas: high-level-intelligence-qualia-atlas.md
+  - From Qualia to Simulacra: from-qualia-to-simulacra.md
   - The Metaorganism Framework: metaorganism.md
   - Add Hours to Your Day?: add-hours-to-your-day.md
   - Security:


### PR DESCRIPTION
## Summary
- include "From Qualia to Simulacra" in mkdocs navigation so the page is accessible

## Testing
- `flake8`
- `pytest` *(fails: DID NOT RAISE <class 'ValueError'>, assert 200 == 400, AttributeError: 'CommentStore' object has no attribute 'toggle_comment')*
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6894b7e7e88c832698be5caaed7412ba