### PR TITLE
chore: normalize line wrapping in cognitive architecture doc

### DIFF
--- a/docs/ai-research/cognitive-architecture-of-artificial-societies.md
+++ b/docs/ai-research/cognitive-architecture-of-artificial-societies.md
@@ -9,166 +9,643 @@ updated: 2025-09-15
 
 ## Part I: Foundations of Cognitive Architectures in Multi-Agent Systems
 
-The quest to create autonomous artificial agents capable of forming complex societies begins with a fundamental question: what is the nature of an artificial mind? The design of an individual agent's cognitive architecture—its internal structure for perception, reasoning, memory, and learning—profoundly shapes not only its own behavior but also the collective dynamics that emerge when thousands or millions of such agents interact. This section establishes the theoretical foundations of these architectures, tracing their intellectual lineage from the foundational debates in artificial intelligence and cognitive science to the specific frameworks that power today's multi-agent systems. By dissecting the core paradigms of artificial cognition, we can begin to understand how the choice of an agent's internal "mind" sets the stage for the emergence of its external "society."
+The quest to create autonomous artificial agents capable of forming complex societies begins with a
+fundamental question: what is the nature of an artificial mind? The design of an individual agent's
+cognitive architecture—its internal structure for perception, reasoning, memory, and
+learning—profoundly shapes not only its own behavior but also the collective dynamics that emerge
+when thousands or millions of such agents interact. This section establishes the theoretical
+foundations of these architectures, tracing their intellectual lineage from the foundational debates
+in artificial intelligence and cognitive science to the specific frameworks that power today's
+multi-agent systems. By dissecting the core paradigms of artificial cognition, we can begin to
+understand how the choice of an agent's internal "mind" sets the stage for the emergence of its
+external "society."
 
 ### Section 1: Paradigms of Artificial Cognition
-The architecture of an intelligent agent is not designed in a vacuum; it is an embodiment of a particular philosophy of mind. The history of artificial intelligence has been shaped by a dynamic interplay between competing paradigms, each offering a different answer to what it means to know, reason, and learn. These theoretical underpinnings—from the crisp logic of symbolic systems to the distributed patterns of connectionism and the rational inference of Bayesian models—are the blueprints from which agent behaviors are constructed and, by extension, from which societal complexity arises.
+The architecture of an intelligent agent is not designed in a vacuum; it is an embodiment of a
+particular philosophy of mind. The history of artificial intelligence has been shaped by a dynamic
+interplay between competing paradigms, each offering a different answer to what it means to know,
+reason, and learn. These theoretical underpinnings—from the crisp logic of symbolic systems to the
+distributed patterns of connectionism and the rational inference of Bayesian models—are the
+blueprints from which agent behaviors are constructed and, by extension, from which societal
+complexity arises.
 
 #### Symbolic vs. Subsymbolic Debate
-The foundational schism in artificial intelligence research lies between the symbolic and subsymbolic paradigms, a division famously summarized as "making a mind vs. modeling the brain". This dichotomy reflects a deeper philosophical debate between rationalism and empiricism and has defined the capabilities and limitations of AI systems for decades.
+The foundational schism in artificial intelligence research lies between the symbolic and
+subsymbolic paradigms, a division famously summarized as "making a mind vs. modeling the brain".
+This dichotomy reflects a deeper philosophical debate between rationalism and empiricism and has
+defined the capabilities and limitations of AI systems for decades.
 
-Symbolic AI, also known as classical or logic-based AI, was the dominant paradigm from the mid-1950s until the mid-1990s. It is predicated on the Physical Symbol System Hypothesis, which posits that intelligence arises from the manipulation of high-level, human-readable symbols according to formal rules. This approach utilizes tools such as logic programming, production rules, and semantic nets to build knowledge-based systems, automated planners, and expert systems. From a cognitive science perspective, symbolic AI aligns with the rationalist school of thought, which emphasizes the role of innate knowledge and structured reasoning in producing intelligent behavior. Its primary strength lies in its capacity for explicit reasoning, deduction, and step-by-step explanation. Because knowledge is represented in a propositional, localized, and explicit format, symbolic models excel at analytical tasks that can be decomposed into sequential, logical steps.
+Symbolic AI, also known as classical or logic-based AI, was the dominant paradigm from the mid-1950s
+until the mid-1990s. It is predicated on the Physical Symbol System Hypothesis, which posits that
+intelligence arises from the manipulation of high-level, human-readable symbols according to formal
+rules. This approach utilizes tools such as logic programming, production rules, and semantic nets
+to build knowledge-based systems, automated planners, and expert systems. From a cognitive science
+perspective, symbolic AI aligns with the rationalist school of thought, which emphasizes the role of
+innate knowledge and structured reasoning in producing intelligent behavior. Its primary strength
+lies in its capacity for explicit reasoning, deduction, and step-by-step explanation. Because
+knowledge is represented in a propositional, localized, and explicit format, symbolic models excel
+at analytical tasks that can be decomposed into sequential, logical steps.
 
-In stark contrast, Subsymbolic AI, or connectionism, models cognition at a lower level of abstraction, inspired by the neural architecture of the brain. This paradigm postulates that intelligence emerges from the learning of associations from data, with little or no pre-existing knowledge. It employs artificial neural networks, where knowledge is represented in a distributed, non-propositional manner across a vast number of simple processing units. This approach is closely related to the empiricist school of mind, which focuses on knowledge acquired through sensory experience. Connectionist models demonstrate remarkable performance in pattern recognition, generalization from noisy data, and skill acquisition, mirroring the synthetic, parallel, and often unconscious perceptual tasks of human cognition, such as vision and speech recognition. However, their strength in learning from data comes at the cost of transparency; the "black box" nature of deep neural networks makes their decision-making processes opaque and difficult to interpret.
+In stark contrast, Subsymbolic AI, or connectionism, models cognition at a lower level of
+abstraction, inspired by the neural architecture of the brain. This paradigm postulates that
+intelligence emerges from the learning of associations from data, with little or no pre-existing
+knowledge. It employs artificial neural networks, where knowledge is represented in a distributed,
+non-propositional manner across a vast number of simple processing units. This approach is closely
+related to the empiricist school of mind, which focuses on knowledge acquired through sensory
+experience. Connectionist models demonstrate remarkable performance in pattern recognition,
+generalization from noisy data, and skill acquisition, mirroring the synthetic, parallel, and often
+unconscious perceptual tasks of human cognition, such as vision and speech recognition. However,
+their strength in learning from data comes at the cost of transparency; the "black box" nature of
+deep neural networks makes their decision-making processes opaque and difficult to interpret.
 
-The historical trajectory of AI reveals a cyclical reconciliation between these two paradigms. The initial dominance of symbolic AI gave way to the rise of connectionism as the limitations of rule-based systems in handling real-world ambiguity became apparent. In recent years, the profound successes of deep learning have been tempered by a recognition of its own limitations, such as the need for vast amounts of training data, a lack of robust multi-step reasoning, and opacity. This has, in turn, prompted a renewed interest in integrating the strengths of both approaches, leading to the development of more sophisticated hybrid models. This is not merely a technical merger but a deeper synthesis, reflecting an understanding that a comprehensive model of intelligence must account for both the rapid, pattern-matching abilities of subsymbolic systems (akin to System 1 thinking) and the slow, deliberate, rule-based reasoning of symbolic systems (akin to System 2 thinking).
+The historical trajectory of AI reveals a cyclical reconciliation between these two paradigms. The
+initial dominance of symbolic AI gave way to the rise of connectionism as the limitations of
+rule-based systems in handling real-world ambiguity became apparent. In recent years, the profound
+successes of deep learning have been tempered by a recognition of its own limitations, such as the
+need for vast amounts of training data, a lack of robust multi-step reasoning, and opacity. This
+has, in turn, prompted a renewed interest in integrating the strengths of both approaches, leading
+to the development of more sophisticated hybrid models. This is not merely a technical merger but a
+deeper synthesis, reflecting an understanding that a comprehensive model of intelligence must
+account for both the rapid, pattern-matching abilities of subsymbolic systems (akin to System 1
+thinking) and the slow, deliberate, rule-based reasoning of symbolic systems (akin to System 2
+thinking).
 
 #### The Rise of Hybrid and Neurosymbolic Architectures
-In response to the limitations of purely symbolic or subsymbolic approaches, hybrid architectures have emerged to create more comprehensive and realistic simulations of human cognition. These systems seek to combine the structured reasoning of symbolic AI with the adaptive learning of connectionist models, creating a whole that is greater than the sum of its parts.
+In response to the limitations of purely symbolic or subsymbolic approaches, hybrid architectures
+have emerged to create more comprehensive and realistic simulations of human cognition. These
+systems seek to combine the structured reasoning of symbolic AI with the adaptive learning of
+connectionist models, creating a whole that is greater than the sum of its parts.
 
-Hybrid Architectures are AI systems that intentionally combine elements from multiple architectural paradigms. Early and influential examples of this approach are grounded in cognitive psychology, aiming to model the dual-process nature of the human mind. The CLARION architecture, for instance, is explicitly based on the dual-process theory, postulating two parallel and interacting representational systems for implicit (subsymbolic) and explicit (symbolic) knowledge. This allows it to model phenomena where both intuitive, skill-based learning and deliberate, rule-based reasoning are at play. Similarly, architectures like SOAR and ACT-R are considered hybrid because they integrate symbolic structures (like production rules) with subsymbolic mechanisms that govern their operation. In ACT-R, for example, the selection of a symbolic production rule is controlled by subsymbolic equations that calculate its utility, and the retrieval of a symbolic "chunk" of memory depends on subsymbolic activation levels. This synthesis allows for a more nuanced simulation of cognitive processes, where high-level symbolic operations are modulated by fine-grained, continuous dynamics.
+Hybrid Architectures are AI systems that intentionally combine elements from multiple architectural
+paradigms. Early and influential examples of this approach are grounded in cognitive psychology,
+aiming to model the dual-process nature of the human mind. The CLARION architecture, for instance,
+is explicitly based on the dual-process theory, postulating two parallel and interacting
+representational systems for implicit (subsymbolic) and explicit (symbolic) knowledge. This allows
+it to model phenomena where both intuitive, skill-based learning and deliberate, rule-based
+reasoning are at play. Similarly, architectures like SOAR and ACT-R are considered hybrid because
+they integrate symbolic structures (like production rules) with subsymbolic mechanisms that govern
+their operation. In ACT-R, for example, the selection of a symbolic production rule is controlled by
+subsymbolic equations that calculate its utility, and the retrieval of a symbolic "chunk" of memory
+depends on subsymbolic activation levels. This synthesis allows for a more nuanced simulation of
+cognitive processes, where high-level symbolic operations are modulated by fine-grained, continuous
+dynamics.
 
-Neurosymbolic AI (NeSy) represents the modern frontier of this synthesis, explicitly merging the powerful pattern recognition capabilities of deep neural networks with the formal reasoning of symbolic AI. This approach is less about creating a psychologically plausible model of the mind and more about engineering robust, trustworthy, and efficient AI systems. NeSy aims to address the critical weaknesses of large language models (LLMs) and other deep learning systems. For example, by integrating neural networks with logic and reasoning, NeSy systems can potentially acquire concepts from far less data, a key advantage over traditional deep learning models that require millions of examples. Furthermore, the symbolic component can provide a degree of transparency and interpretability that is absent in opaque "black box" models, a crucial requirement for deployment in high-stakes fields like healthcare and finance where explainable decisions are paramount. The central challenge in NeSy is not simply connecting two systems but creating a seamless interaction where the empirical learning of neural networks and the deductive reasoning of symbolic AI can synergistically complement each other.
+Neurosymbolic AI (NeSy) represents the modern frontier of this synthesis, explicitly merging the
+powerful pattern recognition capabilities of deep neural networks with the formal reasoning of
+symbolic AI. This approach is less about creating a psychologically plausible model of the mind and
+more about engineering robust, trustworthy, and efficient AI systems. NeSy aims to address the
+critical weaknesses of large language models (LLMs) and other deep learning systems. For example, by
+integrating neural networks with logic and reasoning, NeSy systems can potentially acquire concepts
+from far less data, a key advantage over traditional deep learning models that require millions of
+examples. Furthermore, the symbolic component can provide a degree of transparency and
+interpretability that is absent in opaque "black box" models, a crucial requirement for deployment
+in high-stakes fields like healthcare and finance where explainable decisions are paramount. The
+central challenge in NeSy is not simply connecting two systems but creating a seamless interaction
+where the empirical learning of neural networks and the deductive reasoning of symbolic AI can
+synergistically complement each other.
 
 #### The Bayesian Brain Paradigm
-A distinct yet influential paradigm for understanding cognition is the Bayesian approach, which frames intelligence not in terms of its underlying mechanisms (symbols or neurons) but as a process of rational inference under uncertainty. The "Bayesian Brain" hypothesis posits that the mind functions as a probabilistic machine, constantly updating its beliefs about the world in light of new evidence.
+A distinct yet influential paradigm for understanding cognition is the Bayesian approach, which
+frames intelligence not in terms of its underlying mechanisms (symbols or neurons) but as a process
+of rational inference under uncertainty. The "Bayesian Brain" hypothesis posits that the mind
+functions as a probabilistic machine, constantly updating its beliefs about the world in light of
+new evidence.
 
-This paradigm provides a normative framework for solving the problem of induction—the challenge of drawing general conclusions from limited or noisy data. It uses the principles of probability theory to define how an ideal agent should reason, making it a powerful tool for creating computational-level models of cognition. For example, in vision, the brain must infer the true color of an object from the light that reaches the eye, a value that is a product of both the object's surface properties and the ambient illumination. This is an ill-posed problem that cannot be solved with deductive logic, but it can be modeled as a Bayesian inference problem where the brain combines sensory input with prior knowledge about the world to arrive at the most probable conclusion.
+This paradigm provides a normative framework for solving the problem of induction—the challenge of
+drawing general conclusions from limited or noisy data. It uses the principles of probability theory
+to define how an ideal agent should reason, making it a powerful tool for creating
+computational-level models of cognition. For example, in vision, the brain must infer the true color of an object
+from the light that reaches the eye, a value that is a product of both the object's surface
+properties and the ambient illumination. This is an ill-posed problem that cannot be solved with
+deductive logic, but it can be modeled as a Bayesian inference problem where the brain combines
+sensory input with prior knowledge about the world to arrive at the most probable conclusion.
 
-In the context of multi-agent systems, the Bayesian paradigm is particularly valuable for modeling social cognition and interaction. It provides a formal basis for agents to reason about the mental states of others. For instance, a Bayesian model can be used to capture how an agent infers a counterpart's intentions (e.g., their likelihood of cooperation in a social dilemma) by observing their emotional expressions, treating the expression as data that updates a prior belief about the other's internal state. Similarly, it can be used to incorporate the uncertainty inherent in human decision-making into agent-based models, such as those used to simulate water demand in a community, by representing each agent's choices as a set of conditional probabilities. At a societal level, this framework can even be extended to model the emergence of shared representations and language, where communication among agents is viewed as a form of decentralized Bayesian inference aimed at creating a common understanding of the environment.
+In the context of multi-agent systems, the Bayesian paradigm is particularly valuable for modeling
+social cognition and interaction. It provides a formal basis for agents to reason about the mental
+states of others. For instance, a Bayesian model can be used to capture how an agent infers a
+counterpart's intentions (e.g., their likelihood of cooperation in a social dilemma) by observing
+their emotional expressions, treating the expression as data that updates a prior belief about the
+other's internal state. Similarly, it can be used to incorporate the uncertainty inherent in human
+decision-making into agent-based models, such as those used to simulate water demand in a community,
+by representing each agent's choices as a set of conditional probabilities. At a societal level,
+this framework can even be extended to model the emergence of shared representations and language,
+where communication among agents is viewed as a form of decentralized Bayesian inference aimed at
+creating a common understanding of the environment.
 
 ### Section 2: A Comparative Analysis of Cognitive Frameworks
-While the paradigms discussed above provide the philosophical and theoretical foundations, their practical implementation is realized through specific cognitive frameworks. These frameworks range from classic, psychologically-grounded architectures that attempt to model the universal mechanisms of human thought to modern, engineering-driven toolkits for orchestrating the capabilities of large language models. A fundamental shift is visible across this spectrum: a transition from attempts to model cognition from first principles to efforts to orchestrate pre-existing cognitive capabilities.
+While the paradigms discussed above provide the philosophical and theoretical foundations, their
+practical implementation is realized through specific cognitive frameworks. These frameworks range
+from classic, psychologically-grounded architectures that attempt to model the universal mechanisms
+of human thought to modern, engineering-driven toolkits for orchestrating the capabilities of large
+language models. A fundamental shift is visible across this spectrum: a transition from attempts to
+model cognition from first principles to efforts to orchestrate pre-existing cognitive capabilities.
 
-Early architectures like ACT-R and SOAR are products of cognitive science, designed as unified theories of mind. Their components—buffers, production rules, impasses—are hypothesized to be fundamental building blocks of human intelligence. They represent a "glass-box" approach, where the internal steps of reasoning are explicitly modeled and are, in principle, inspectable.
+Early architectures like ACT-R and SOAR are products of cognitive science, designed as unified
+theories of mind. Their components—buffers, production rules, impasses—are hypothesized to be
+fundamental building blocks of human intelligence. They represent a "glass-box" approach, where the
+internal steps of reasoning are explicitly modeled and are, in principle, inspectable.
 
-In contrast, modern frameworks like LangChain and AutoGPT are products of software engineering, designed to solve complex tasks by leveraging the powerful but opaque reasoning engine of an LLM. Their components—nodes, tool-calling routers, task queues—are principles of distributed systems. They treat the LLM as a "black-box" cognitive resource and focus on building the scaffolding around it for memory, tool use, and control flow. This represents a paradigm shift from building a mind to composing a system from powerful, pre-built cognitive modules. The CoALA framework is a notable attempt to bridge this divide by applying the structured principles of classic cognitive architectures to the design of modern language agents.
+In contrast, modern frameworks like LangChain and AutoGPT are products of software engineering,
+designed to solve complex tasks by leveraging the powerful but opaque reasoning engine of an LLM.
+Their components—nodes, tool-calling routers, task queues—are principles of distributed systems.
+They treat the LLM as a "black-box" cognitive resource and focus on building the scaffolding around
+it for memory, tool use, and control flow. This represents a paradigm shift from building a mind to
+composing a system from powerful, pre-built cognitive modules. The CoALA framework is a notable
+attempt to bridge this divide by applying the structured principles of classic cognitive
+architectures to the design of modern language agents.
 
 #### Table 1: Comparative Analysis of Foundational Cognitive Architectures
 
-| Architecture | Foundational Paradigm | Core Cognitive Mechanisms | Memory Representation | Primary Learning Method | Scalability Profile | Key Emergent Phenomena |
-| --- | --- | --- | --- | --- | --- | --- |
-| ACT-R | Hybrid Symbolic/Subsymbolic | Production system, Buffers, Pattern Matcher, Subsymbolic activation/utility equations | Declarative "chunks" in modules, Procedural rules | Reinforcement Learning, Instance-based learning, Parameter tuning | Computationally intensive per agent, limiting population size. | Consensus-building, Social learning, Distributed decision-making. |
-| SOAR | Hybrid Symbolic/Subsymbolic | Decision Cycle (Propose-Select-Apply), Impasses, Universal Subgoaling | Working Memory (symbolic graph), Semantic Memory (facts), Episodic Memory (experiences) | Chunking (compiling problem-solving into rules), Reinforcement Learning | High per-agent complexity, but has been used in large-scale simulations with careful state management. | Coordinated teamwork, Hierarchical task decomposition, Shared situation awareness. |
-| SPAUN | Spiking Neural Network | Semantic Pointers, Neural information routing via Basal Ganglia/Thalamus analogs | Distributed patterns of neural activity in a compressed neural vector space | Hebbian learning, Reinforcement learning | Biologically-inspired but computationally massive; not designed for large multi-agent populations. | Flexible pattern recognition, Cognitive task switching, Sensorimotor coordination. |
-| Swarm Intelligence | Decentralized / Subsymbolic | Simple local rules (e.g., Separation, Alignment, Cohesion), Stigmergy (indirect communication) | Implicit/Environmental; no centralized memory | Evolutionary Algorithms, Reinforcement Learning | Highly scalable in agent count due to agent simplicity; complexity is in the emergent global patterns. | Flocking, Foraging, Sorting, Collective construction, Path optimization. |
-| LLM-based Agents | Generative / Connectionist | LLM reasoning loop (e.g., ReAct), Tool use, Prompting, Orchestration | Vector embeddings for semantic memory, External files/databases for long-term memory | In-context learning, Reinforcement Learning from Human Feedback (RLHF), Fine-tuning | Scalability limited by API costs, token limits, and coordination complexity, not raw agent count. | Task decomposition, Role adoption, Spontaneous communication protocols, Social norm formation. |
+| Architecture | Foundational Paradigm | Core Cognitive Mechanisms | Memory Representation | Primary
+Learning Method | Scalability Profile | Key Emergent Phenomena | | --- | --- | --- | --- | --- | ---
+| --- | | ACT-R | Hybrid Symbolic/Subsymbolic | Production system, Buffers, Pattern Matcher,
+Subsymbolic activation/utility equations | Declarative "chunks" in modules, Procedural rules |
+Reinforcement Learning, Instance-based learning, Parameter tuning | Computationally intensive per
+agent, limiting population size. | Consensus-building, Social learning, Distributed decision-making.
+| | SOAR | Hybrid Symbolic/Subsymbolic | Decision Cycle (Propose-Select-Apply), Impasses, Universal
+Subgoaling | Working Memory (symbolic graph), Semantic Memory (facts), Episodic Memory (experiences)
+| Chunking (compiling problem-solving into rules), Reinforcement Learning | High per-agent
+complexity, but has been used in large-scale simulations with careful state management. |
+Coordinated teamwork, Hierarchical task decomposition, Shared situation awareness. | | SPAUN |
+Spiking Neural Network | Semantic Pointers, Neural information routing via Basal Ganglia/Thalamus
+analogs | Distributed patterns of neural activity in a compressed neural vector space | Hebbian
+learning, Reinforcement learning | Biologically-inspired but computationally massive; not designed
+for large multi-agent populations. | Flexible pattern recognition, Cognitive task switching,
+Sensorimotor coordination. | | Swarm Intelligence | Decentralized / Subsymbolic | Simple local rules
+(e.g., Separation, Alignment, Cohesion), Stigmergy (indirect communication) |
+Implicit/Environmental; no centralized memory | Evolutionary Algorithms, Reinforcement Learning |
+Highly scalable in agent count due to agent simplicity; complexity is in the emergent global
+patterns. | Flocking, Foraging, Sorting, Collective construction, Path optimization. | | LLM-based
+Agents | Generative / Connectionist | LLM reasoning loop (e.g., ReAct), Tool use, Prompting,
+Orchestration | Vector embeddings for semantic memory, External files/databases for long-term memory
+| In-context learning, Reinforcement Learning from Human Feedback (RLHF), Fine-tuning | Scalability
+limited by API costs, token limits, and coordination complexity, not raw agent count. | Task
+decomposition, Role adoption, Spontaneous communication protocols, Social norm formation. |
 
 ##### Classic Psychologically-Grounded Architectures
-These architectures represent decades of research aimed at creating a computational theory of the human mind. They are characterized by their detailed, integrated components designed to model specific cognitive functions like memory, attention, and problem-solving.
+These architectures represent decades of research aimed at creating a computational theory of the
+human mind. They are characterized by their detailed, integrated components designed to model
+specific cognitive functions like memory, attention, and problem-solving.
 
-**ACT-R (Adaptive Control of Thought—Rational)** is a prominent cognitive architecture that serves as both a theory of human cognition and a framework for building computational models. Developed at Carnegie Mellon University, ACT-R posits that all human cognition can be decomposed into a series of discrete operations performed by a set of independent modules. These modules, which include perceptual systems (e.g., vision) and memory systems, do not interact directly but place information into dedicated buffers. The core of cognition is a central production system that continuously matches patterns in these buffers. When the conditions of a production rule are met, it "fires," potentially modifying the contents of the buffers and leading to the next cognitive step. ACT-R's hybrid nature comes from the interplay between this symbolic rule-firing process and the subsymbolic equations that govern it. For instance, if multiple rules match, a utility calculation determines which one is most beneficial to fire. Similarly, the retrieval of a declarative memory "chunk" is not a simple lookup but depends on its base-level activation (how recently and frequently it has been used) and its association with the current context. This architecture has been successfully used to create quantitative models of a wide array of human tasks, from learning and memory to language and decision-making, including multi-agent simulations of collective decision-making and consensus-building.
+**ACT-R (Adaptive Control of Thought—Rational)** is a prominent cognitive architecture that serves
+as both a theory of human cognition and a framework for building computational models. Developed at
+Carnegie Mellon University, ACT-R posits that all human cognition can be decomposed into a series of
+discrete operations performed by a set of independent modules. These modules, which include
+perceptual systems (e.g., vision) and memory systems, do not interact directly but place information
+into dedicated buffers. The core of cognition is a central production system that continuously
+matches patterns in these buffers. When the conditions of a production rule are met, it "fires,"
+potentially modifying the contents of the buffers and leading to the next cognitive step. ACT-R's
+hybrid nature comes from the interplay between this symbolic rule-firing process and the subsymbolic
+equations that govern it. For instance, if multiple rules match, a utility calculation determines
+which one is most beneficial to fire. Similarly, the retrieval of a declarative memory "chunk" is
+not a simple lookup but depends on its base-level activation (how recently and frequently it has
+been used) and its association with the current context. This architecture has been successfully
+used to create quantitative models of a wide array of human tasks, from learning and memory to
+language and decision-making, including multi-agent simulations of collective decision-making and
+consensus-building.
 
-**SOAR (State, Operator, And Result)** is another influential general cognitive architecture designed to capture the fundamental building blocks of general intelligence. Like ACT-R, it is a hybrid system based on a production system, but its core organizing principle is the universal problem space. An agent in SOAR is always in a particular state and seeks to apply operators to reach a goal state. The cognitive process unfolds in a continuous "decision cycle": rules in procedural memory, matching the current state in working memory, propose and evaluate potential operators. A decision procedure then selects the best operator to apply, which in turn modifies the state, and the cycle repeats. A key feature of SOAR is its mechanism for handling "impasses," which occur when the system doesn't know how to proceed (e.g., no operator is applicable, or multiple operators are equally preferred). When an impasse occurs, SOAR automatically creates a substate with the goal of resolving the impasse. This allows the architecture to recursively apply its entire problem-solving apparatus to its own internal difficulties, giving rise to complex reasoning, planning, and hierarchical task decomposition. Learning in SOAR is primarily achieved through "chunking," a mechanism that summarizes the processing that occurred in a substate and compiles it into a new production rule. This allows the agent to learn from its problem-solving experience, making future decisions more efficient. SOAR has a long history of application in multi-agent systems, particularly in large-scale military simulations where it has been used to model pilots and ground forces that must coordinate and exhibit flexible teamwork.
+**SOAR (State, Operator, And Result)** is another influential general cognitive architecture
+designed to capture the fundamental building blocks of general intelligence. Like ACT-R, it is a
+hybrid system based on a production system, but its core organizing principle is the universal
+problem space. An agent in SOAR is always in a particular state and seeks to apply operators to
+reach a goal state. The cognitive process unfolds in a continuous "decision cycle": rules in
+procedural memory, matching the current state in working memory, propose and evaluate potential
+operators. A decision procedure then selects the best operator to apply, which in turn modifies the
+state, and the cycle repeats. A key feature of SOAR is its mechanism for handling "impasses," which
+occur when the system doesn't know how to proceed (e.g., no operator is applicable, or multiple
+operators are equally preferred). When an impasse occurs, SOAR automatically creates a substate with
+the goal of resolving the impasse. This allows the architecture to recursively apply its entire
+problem-solving apparatus to its own internal difficulties, giving rise to complex reasoning,
+planning, and hierarchical task decomposition. Learning in SOAR is primarily achieved through
+"chunking," a mechanism that summarizes the processing that occurred in a substate and compiles it
+into a new production rule. This allows the agent to learn from its problem-solving experience,
+making future decisions more efficient. SOAR has a long history of application in multi-agent
+systems, particularly in large-scale military simulations where it has been used to model pilots and
+ground forces that must coordinate and exhibit flexible teamwork.
 
-**SPAUN (Semantic Pointer Architecture Unified Network)** is a large-scale brain model that represents a significant step towards biological realism. Comprising 2.5 million simulated spiking neurons, SPAUN is organized into subsystems anatomically analogous to brain regions like the prefrontal cortex, basal ganglia, and thalamus. Unlike the abstract modules of ACT-R or SOAR, SPAUN's components are designed to mimic neural function. Its core innovation is the use of "semantic pointers"—neural representations that are structured like vectors but can be combined and manipulated in flexible ways to support complex cognitive operations. This architecture allows SPAUN to perform a diverse range of eight different cognitive tasks, from recognizing handwritten digits to performing serial working memory tasks and controlling a robotic arm to write its answers, all within a single, unified neural model. While not typically used for multi-agent societies due to its immense computational complexity, SPAUN demonstrates how high-level cognitive functions can emerge from the coordinated activity of more biologically plausible neural components.
+**SPAUN (Semantic Pointer Architecture Unified Network)** is a large-scale brain model that
+represents a significant step towards biological realism. Comprising 2.5 million simulated spiking
+neurons, SPAUN is organized into subsystems anatomically analogous to brain regions like the
+prefrontal cortex, basal ganglia, and thalamus. Unlike the abstract modules of ACT-R or SOAR,
+SPAUN's components are designed to mimic neural function. Its core innovation is the use of
+"semantic pointers"—neural representations that are structured like vectors but can be combined and
+manipulated in flexible ways to support complex cognitive operations. This architecture allows SPAUN
+to perform a diverse range of eight different cognitive tasks, from recognizing handwritten digits
+to performing serial working memory tasks and controlling a robotic arm to write its answers, all
+within a single, unified neural model. While not typically used for multi-agent societies due to its
+immense computational complexity, SPAUN demonstrates how high-level cognitive functions can emerge
+from the coordinated activity of more biologically plausible neural components.
 
-**Swarm Intelligence (SI)** offers a radically different, decentralized approach to collective behavior. Inspired by natural systems like ant colonies, bird flocks, and fish schools, SI systems consist of a population of very simple agents that follow a small set of local rules. There is no central controller or global plan; "intelligent" global behavior, such as a flock of birds maneuvering as one or an ant colony finding the shortest path to food, is an emergent property of the local interactions between agents and their environment. The classic "Boids" model, for example, produces complex flocking behavior from just three simple rules for each agent: separation (avoid crowding neighbors), alignment (steer towards the average heading of neighbors), and cohesion (steer towards the average position of neighbors). Because the individual agents are simple and their interactions are local, swarm systems are highly scalable, robust, and adaptable. While the cognitive capacity of any single agent is minimal, the collective can solve complex optimization and coordination problems. Some research has explored integrating swarm principles with more traditional cognitive architectures to model how coordination and performance emerge in teams.
+**Swarm Intelligence (SI)** offers a radically different, decentralized approach to collective
+behavior. Inspired by natural systems like ant colonies, bird flocks, and fish schools, SI systems
+consist of a population of very simple agents that follow a small set of local rules. There is no
+central controller or global plan; "intelligent" global behavior, such as a flock of birds
+maneuvering as one or an ant colony finding the shortest path to food, is an emergent property of
+the local interactions between agents and their environment. The classic "Boids" model, for example,
+produces complex flocking behavior from just three simple rules for each agent: separation (avoid
+crowding neighbors), alignment (steer towards the average heading of neighbors), and cohesion (steer
+towards the average position of neighbors). Because the individual agents are simple and their
+interactions are local, swarm systems are highly scalable, robust, and adaptable. While the
+cognitive capacity of any single agent is minimal, the collective can solve complex optimization and
+coordination problems. Some research has explored integrating swarm principles with more traditional
+cognitive architectures to model how coordination and performance emerge in teams.
 
 ##### Modern Generative Agent Architectures
-The recent advent of powerful Large Language Models (LLMs) like GPT-4 has catalyzed a new era of agent design. These "generative agents" leverage the vast world knowledge and reasoning capabilities embedded within LLMs to create more flexible, general-purpose, and human-like autonomous entities.
+The recent advent of powerful Large Language Models (LLMs) like GPT-4 has catalyzed a new era of
+agent design. These "generative agents" leverage the vast world knowledge and reasoning capabilities
+embedded within LLMs to create more flexible, general-purpose, and human-like autonomous entities.
 
-LLM-Powered Agents in their simplest form use an LLM as a reasoning engine within a loop. The agent perceives its environment (often represented as text), uses the LLM to decide on an action (e.g., by prompting it with a description of the state and a set of possible actions or "tools"), executes that action, and then observes the result, repeating the cycle. This basic architecture, often called a ReAct (Reason+Act) agent, can be surprisingly powerful. Multi-agent systems are frequently built using an Orchestrator-Worker Pattern. In this setup, a "lead" or "supervisor" agent receives a high-level goal, decomposes it into smaller subtasks, and delegates these to a team of specialized "worker" agents that can operate in parallel. This modular approach improves performance by allowing each worker agent to focus on a specific domain with a limited set of tools, reducing the cognitive load that would overwhelm a single agent.
+LLM-Powered Agents in their simplest form use an LLM as a reasoning engine within a loop. The agent
+perceives its environment (often represented as text), uses the LLM to decide on an action (e.g., by
+prompting it with a description of the state and a set of possible actions or "tools"), executes
+that action, and then observes the result, repeating the cycle. This basic architecture, often
+called a ReAct (Reason+Act) agent, can be surprisingly powerful. Multi-agent systems are frequently
+built using an Orchestrator-Worker Pattern. In this setup, a "lead" or "supervisor" agent receives a
+high-level goal, decomposes it into smaller subtasks, and delegates these to a team of specialized
+"worker" agents that can operate in parallel. This modular approach improves performance by allowing
+each worker agent to focus on a specific domain with a limited set of tools, reducing the cognitive
+load that would overwhelm a single agent.
 
-Frameworks have emerged to facilitate the construction of these complex systems. LangChain and its extension LangGraph provide a powerful open-source toolkit for composing agentic workflows. LangGraph is particularly well-suited for multi-agent systems, as it allows developers to define the system as a stateful graph where agents are nodes and the edges represent the flow of control and information. This provides a flexible and explicit way to design various multi-agent cognitive architectures, such as collaborative teams where agents share a common "scratchpad" or hierarchical structures where a supervisor agent routes tasks to subordinates.
+Frameworks have emerged to facilitate the construction of these complex systems. LangChain and its
+extension LangGraph provide a powerful open-source toolkit for composing agentic workflows.
+LangGraph is particularly well-suited for multi-agent systems, as it allows developers to define the
+system as a stateful graph where agents are nodes and the edges represent the flow of control and
+information. This provides a flexible and explicit way to design various multi-agent cognitive
+architectures, such as collaborative teams where agents share a common "scratchpad" or hierarchical
+structures where a supervisor agent routes tasks to subordinates.
 
-Other frameworks focus on creating fully autonomous systems. AutoGPT is an open-source application designed to take a high-level goal from a user and autonomously break it down into subtasks, which it then executes in a loop without further human intervention. It uses a multi-agent structure internally, with a task creation agent, a task prioritization agent, and task execution agents that can use tools like web search. A more advanced concept is found in AutoAgents, a framework that dynamically generates a custom team of specialized agents based on the user's task. For a task like "write a novel," it might generate a Story Planner, a Researcher, a Character Developer, and a Writer. It also includes an "observer" agent whose role is to reflect on the plan and the team's output, enabling a process of iterative refinement. These frameworks represent a significant step towards creating adaptive, self-organizing AI societies that can tackle complex, open-ended problems.
+Other frameworks focus on creating fully autonomous systems. AutoGPT is an open-source application
+designed to take a high-level goal from a user and autonomously break it down into subtasks, which
+it then executes in a loop without further human intervention. It uses a multi-agent structure
+internally, with a task creation agent, a task prioritization agent, and task execution agents that
+can use tools like web search. A more advanced concept is found in AutoAgents, a framework that
+dynamically generates a custom team of specialized agents based on the user's task. For a task like
+"write a novel," it might generate a Story Planner, a Researcher, a Character Developer, and a
+Writer. It also includes an "observer" agent whose role is to reflect on the plan and the team's
+output, enabling a process of iterative refinement. These frameworks represent a significant step
+towards creating adaptive, self-organizing AI societies that can tackle complex, open-ended
+problems.
 
 ## Part II: The Emergence of Social Complexity
-The cognitive architecture of an individual agent is the seed from which the forest of societal complexity grows. When populations of these agents interact, their individual rules for reasoning, learning, and decision-making give rise to collective phenomena that are not explicitly programmed into any single agent. This part of the report moves from the micro-level of the individual mind to the macro-level of the artificial society, examining the empirical evidence and case studies that demonstrate how specific architectural choices enable or inhibit the emergence of social structures. The behaviors that arise—cooperation, division of labor, communication, and even culture—are not random accidents. They are the logical, albeit often surprising, consequences of the underlying constraints on information and interaction protocols that define the system. The design of an agent society is therefore less an act of direct construction and more an exercise in ecological engineering: shaping the informational landscape in which desired social structures can spontaneously form and thrive.
+The cognitive architecture of an individual agent is the seed from which the forest of societal
+complexity grows. When populations of these agents interact, their individual rules for reasoning,
+learning, and decision-making give rise to collective phenomena that are not explicitly programmed
+into any single agent. This part of the report moves from the micro-level of the individual mind to
+the macro-level of the artificial society, examining the empirical evidence and case studies that
+demonstrate how specific architectural choices enable or inhibit the emergence of social structures.
+The behaviors that arise—cooperation, division of labor, communication, and even culture—are not
+random accidents. They are the logical, albeit often surprising, consequences of the underlying
+constraints on information and interaction protocols that define the system. The design of an agent
+society is therefore less an act of direct construction and more an exercise in ecological
+engineering: shaping the informational landscape in which desired social structures can
+spontaneously form and thrive.
 
 ### Section 3: The Genesis of Social Behavior
-The most fundamental aspects of social life—cooperation in the face of conflict, the division of labor into specialized roles, and the coordination of action toward a common goal—are not unique to human societies. These behaviors can be observed emerging in multi-agent systems, providing a powerful computational laboratory for understanding the principles of social organization.
+The most fundamental aspects of social life—cooperation in the face of conflict, the division of
+labor into specialized roles, and the coordination of action toward a common goal—are not unique to
+human societies. These behaviors can be observed emerging in multi-agent systems, providing a
+powerful computational laboratory for understanding the principles of social organization.
 
 #### Cooperation, Conflict, and Norms
-A central challenge in any society, natural or artificial, is the social dilemma: the conflict between individual self-interest and the collective good. In multi-agent reinforcement learning (MARL), where each agent is typically trained to maximize its own reward, this tension often leads to a "tragedy of the commons" where agents learn to defect, resulting in a poor outcome for the entire group. However, specific architectural features can create the conditions for cooperation to emerge.
+A central challenge in any society, natural or artificial, is the social dilemma: the conflict
+between individual self-interest and the collective good. In multi-agent reinforcement learning
+(MARL), where each agent is typically trained to maximize its own reward, this tension often leads
+to a "tragedy of the commons" where agents learn to defect, resulting in a poor outcome for the
+entire group. However, specific architectural features can create the conditions for cooperation to
+emerge.
 
-One of the most powerful mechanisms is partner selection. When agents are not forced into random interactions but can choose their partners based on past behavior, a new strategic dynamic appears. In simulations of the Prisoner's Dilemma, selfishly motivated RL agents who can select their partners learn to adopt a Tit-for-Tat (TFT) strategy. They cooperate with agents who have a reputation for cooperating and punish defectors by refusing to interact with them. This process unfolds in distinct phases: an initial phase of widespread defection, followed by the exploitation of early cooperators, then a phase of retaliation where TFT agents punish defectors, and finally, a stable cooperative society where TFT acts as a social norm. The architecture must support memory of past interactions and the ability to act on that information through selective engagement.
+One of the most powerful mechanisms is partner selection. When agents are not forced into random
+interactions but can choose their partners based on past behavior, a new strategic dynamic appears.
+In simulations of the Prisoner's Dilemma, selfishly motivated RL agents who can select their
+partners learn to adopt a Tit-for-Tat (TFT) strategy. They cooperate with agents who have a
+reputation for cooperating and punish defectors by refusing to interact with them. This process
+unfolds in distinct phases: an initial phase of widespread defection, followed by the exploitation
+of early cooperators, then a phase of retaliation where TFT agents punish defectors, and finally, a
+stable cooperative society where TFT acts as a social norm. The architecture must support memory of
+past interactions and the ability to act on that information through selective engagement.
 
-Another approach is peer incentivization (PI), where the architecture allows agents to directly modify each other's rewards. The Mutual Acknowledgment Token Exchange (MATE) protocol is a sophisticated, decentralized example. In MATE, an agent that experiences an improvement in its situation sends a positive "acknowledgment token" to its neighbors. A neighbor accepts this token only if doing so also improves its own situation, establishing a mutual acknowledgment. Crucially, if accepting a token would be detrimental, the neighbor can send back a negative token, effectively penalizing the sender. This two-way communication protocol, which relies only on local information, has proven more robust at fostering cooperation than unidirectional gifting or centralized market-based approaches.
+Another approach is peer incentivization (PI), where the architecture allows agents to directly
+modify each other's rewards. The Mutual Acknowledgment Token Exchange (MATE) protocol is a
+sophisticated, decentralized example. In MATE, an agent that experiences an improvement in its
+situation sends a positive "acknowledgment token" to its neighbors. A neighbor accepts this token
+only if doing so also improves its own situation, establishing a mutual acknowledgment. Crucially,
+if accepting a token would be detrimental, the neighbor can send back a negative token, effectively
+penalizing the sender. This two-way communication protocol, which relies only on local information,
+has proven more robust at fostering cooperation than unidirectional gifting or centralized
+market-based approaches.
 
-These mechanisms for enforcing cooperation are the foundation for the emergence of social norms, which are standards of behavior that guide agents and reduce social conflict. In generative agent societies, norms can arise dynamically without being hard-coded. The proposed CRSEC architecture models this as a four-stage process: Creation (an agent forms a personal norm), Spreading (the agent communicates this norm to others), Evaluation (other agents assess the norm against their own values), and Compliance (agents that accept the norm alter their behavior accordingly). Simulations using this architecture show that as norms like "be quiet in public" become widely adopted, the frequency of social conflicts drops dramatically. The emergence is driven by agent-to-agent conversations and observations, demonstrating that a rich communication and perception capability is a prerequisite for normative behavior. The structure of the social network, mechanisms for reciprocity, and the ability to use "tags" (observable traits) to predict others' behavior are all critical factors influencing this process.
+These mechanisms for enforcing cooperation are the foundation for the emergence of social norms,
+which are standards of behavior that guide agents and reduce social conflict. In generative agent
+societies, norms can arise dynamically without being hard-coded. The proposed CRSEC architecture
+models this as a four-stage process: Creation (an agent forms a personal norm), Spreading (the agent
+communicates this norm to others), Evaluation (other agents assess the norm against their own
+values), and Compliance (agents that accept the norm alter their behavior accordingly). Simulations
+using this architecture show that as norms like "be quiet in public" become widely adopted, the
+frequency of social conflicts drops dramatically. The emergence is driven by agent-to-agent
+conversations and observations, demonstrating that a rich communication and perception capability is
+a prerequisite for normative behavior. The structure of the social network, mechanisms for
+reciprocity, and the ability to use "tags" (observable traits) to predict others' behavior are all
+critical factors influencing this process.
 
 #### Role Specialization and Emergent Economies
-As tasks become more complex, a uniform population of generalist agents often gives way to a society with a division of labor. This role specialization, where agents focus on distinct sub-tasks, can emerge spontaneously in multi-agent systems. For example, in a simulated combat scenario, agents might self-organize into roles like scouts, defenders, and attackers without explicit instruction. Frameworks like ROMA (Role-Oriented MARL) are designed to encourage this process. ROMA introduces a "role" as a latent variable that an agent learns based on its local observations. The framework then encourages agents with similar roles to share their learning experiences, which accelerates specialization and improves overall team efficiency.
+As tasks become more complex, a uniform population of generalist agents often gives way to a society
+with a division of labor. This role specialization, where agents focus on distinct sub-tasks, can
+emerge spontaneously in multi-agent systems. For example, in a simulated combat scenario, agents
+might self-organize into roles like scouts, defenders, and attackers without explicit instruction.
+Frameworks like ROMA (Role-Oriented MARL) are designed to encourage this process. ROMA introduces a
+"role" as a latent variable that an agent learns based on its local observations. The framework then
+encourages agents with similar roles to share their learning experiences, which accelerates
+specialization and improves overall team efficiency.
 
-The emergence of specialization is not, however, a universal good. A key insight from recent research is that the optimal degree of specialization is determined by the task parallelizability of the environment—a concept borrowed from distributed computing that measures the potential for subtasks to be executed concurrently. When a task has many components that can be performed in parallel with few dependencies (high parallelizability), a team of generalist agents, each capable of performing the whole task, can be highly efficient. However, when the task environment has bottlenecks or constraints that force actions to be performed sequentially (low parallelizability), a team of specialists, each focusing on a complementary part of the serial workflow, will outperform the generalists. This provides a principled, formal framework for predicting and explaining why a division of labor emerges in some situations but not others. The social structure is a direct adaptation to the physical and logical constraints of the task.
+The emergence of specialization is not, however, a universal good. A key insight from recent
+research is that the optimal degree of specialization is determined by the task parallelizability of
+the environment—a concept borrowed from distributed computing that measures the potential for
+subtasks to be executed concurrently. When a task has many components that can be performed in
+parallel with few dependencies (high parallelizability), a team of generalist agents, each capable
+of performing the whole task, can be highly efficient. However, when the task environment has
+bottlenecks or constraints that force actions to be performed sequentially (low parallelizability),
+a team of specialists, each focusing on a complementary part of the serial workflow, will outperform
+the generalists. This provides a principled, formal framework for predicting and explaining why a
+division of labor emerges in some situations but not others. The social structure is a direct
+adaptation to the physical and logical constraints of the task.
 
-At a larger scale, the interaction of specialized agents with heterogeneous behaviors and bounded rationality can give rise to emergent economies. Agent-Based Models (ABMs) are the primary tool for studying these phenomena. Unlike traditional top-down macroeconomic models that rely on aggregates and assumptions of perfect rationality, ABMs take a bottom-up approach. They simulate the interactions of individual agents (representing consumers, firms, etc.) according to simple behavioral rules. From these micro-level interactions, complex and often unpredictable macro-level patterns, such as market bubbles, business cycles, and financial crashes, can emerge. This methodology allows economists to explore how systemic properties arise from the interplay of individual decisions within a structured environment.
+At a larger scale, the interaction of specialized agents with heterogeneous behaviors and bounded
+rationality can give rise to emergent economies. Agent-Based Models (ABMs) are the primary tool for
+studying these phenomena. Unlike traditional top-down macroeconomic models that rely on aggregates
+and assumptions of perfect rationality, ABMs take a bottom-up approach. They simulate the
+interactions of individual agents (representing consumers, firms, etc.) according to simple
+behavioral rules. From these micro-level interactions, complex and often unpredictable macro-level
+patterns, such as market bubbles, business cycles, and financial crashes, can emerge. This
+methodology allows economists to explore how systemic properties arise from the interplay of
+individual decisions within a structured environment.
 
 #### Collective Intelligence and Group Decision-Making
-Collective intelligence refers to the ability of a group to solve problems in a way that surpasses the capabilities of any individual member. Swarm Intelligence provides a powerful model of how this can be achieved in a fully decentralized manner. The complex, coordinated, and adaptive behavior of a swarm emerges from the simple, local interactions of its constituent agents. This principle is applied in swarm robotics for tasks like search and rescue, and in optimization algorithms like Ant Colony Optimization, which finds efficient solutions to complex problems by simulating the pheromone-laying behavior of ants.
+Collective intelligence refers to the ability of a group to solve problems in a way that surpasses
+the capabilities of any individual member. Swarm Intelligence provides a powerful model of how this
+can be achieved in a fully decentralized manner. The complex, coordinated, and adaptive behavior of
+a swarm emerges from the simple, local interactions of its constituent agents. This principle is
+applied in swarm robotics for tasks like search and rescue, and in optimization algorithms like Ant
+Colony Optimization, which finds efficient solutions to complex problems by simulating the
+pheromone-laying behavior of ants.
 
-Within these systems, collective decision-making is a critical function. In swarms, this often occurs through distributed consensus mechanisms. In a threshold-based model, for example, an agent might adopt a particular choice (e.g., "move towards location A") only after a certain number of its neighbors have already made that choice. This simple local rule can lead the entire swarm to converge on a single decision without any central authority. More sophisticated approaches can use Bayesian inference, where each agent acts as a Bayesian modeler, updating its belief about the correct decision based on its own observations and information shared by its neighbors. This has been shown to accelerate the speed and improve the accuracy of collective perception tasks in robot swarms. The architecture of the communication network—who can talk to whom—is a critical factor in determining the speed and outcome of these collective decision-making processes.
+Within these systems, collective decision-making is a critical function. In swarms, this often
+occurs through distributed consensus mechanisms. In a threshold-based model, for example, an agent
+might adopt a particular choice (e.g., "move towards location A") only after a certain number of its
+neighbors have already made that choice. This simple local rule can lead the entire swarm to
+converge on a single decision without any central authority. More sophisticated approaches can use
+Bayesian inference, where each agent acts as a Bayesian modeler, updating its belief about the
+correct decision based on its own observations and information shared by its neighbors. This has
+been shown to accelerate the speed and improve the accuracy of collective perception tasks in robot
+swarms. The architecture of the communication network—who can talk to whom—is a critical factor in
+determining the speed and outcome of these collective decision-making processes.
 
 ### Section 4: The Development of Communication and Culture
-Beyond the immediate coordination of action, autonomous agent societies can develop higher-order emergent phenomena centered on the creation, transmission, and evolution of symbolic information. The spontaneous emergence of language and the cumulative transmission of knowledge across generations represent two of the most complex and human-like behaviors observed in these artificial societies. These processes depend on sophisticated cognitive architectures that can not only act in the world but also represent, share, and build upon those representations over time.
+Beyond the immediate coordination of action, autonomous agent societies can develop higher-order
+emergent phenomena centered on the creation, transmission, and evolution of symbolic information.
+The spontaneous emergence of language and the cumulative transmission of knowledge across
+generations represent two of the most complex and human-like behaviors observed in these artificial
+societies. These processes depend on sophisticated cognitive architectures that can not only act in
+the world but also represent, share, and build upon those representations over time.
 
 #### From Signals to Symbols: The Emergence of Language
-In multi-agent systems designed for cooperative tasks, agents can develop their own communication protocols from scratch. This process of emergent communication does not rely on pre-programmed linguistic rules; instead, a shared language arises from the agents' need to coordinate their actions to achieve a common goal. For example, in a referential game where a "speaker" agent must describe a target object to a "listener" agent, the agents will develop a shared vocabulary of signals to identify the objects successfully.
+In multi-agent systems designed for cooperative tasks, agents can develop their own communication
+protocols from scratch. This process of emergent communication does not rely on pre-programmed
+linguistic rules; instead, a shared language arises from the agents' need to coordinate their
+actions to achieve a common goal. For example, in a referential game where a "speaker" agent must
+describe a target object to a "listener" agent, the agents will develop a shared vocabulary of
+signals to identify the objects successfully.
 
-Research has shown that the evolution of these artificial languages often proceeds through distinct phases. An initial exploration phase involves agents testing random signals. This is followed by a signal consolidation phase, where successful communication patterns are reinforced and begin to stabilize. Next, a protocol optimization phase sees the language become more efficient, often through a form of signal compression. Finally, in a protocol maturation phase, more sophisticated features like error correction or context-dependent meanings can develop. The resulting protocols are not just arbitrary mappings; they can exhibit properties characteristic of natural language, such as compositionality (where simple signals are combined to form more complex meanings) and symbolic abstraction. The complexity of the emergent language has been shown to correlate strongly with the complexity of the collaborative task and the richness of the reward structure provided to the agents.
+Research has shown that the evolution of these artificial languages often proceeds through distinct
+phases. An initial exploration phase involves agents testing random signals. This is followed by a
+signal consolidation phase, where successful communication patterns are reinforced and begin to
+stabilize. Next, a protocol optimization phase sees the language become more efficient, often
+through a form of signal compression. Finally, in a protocol maturation phase, more sophisticated
+features like error correction or context-dependent meanings can develop. The resulting protocols
+are not just arbitrary mappings; they can exhibit properties characteristic of natural language,
+such as compositionality (where simple signals are combined to form more complex meanings) and
+symbolic abstraction. The complexity of the emergent language has been shown to correlate strongly
+with the complexity of the collaborative task and the richness of the reward structure provided to
+the agents.
 
-However, the emergence of a symbolic system raises a profound philosophical question addressed by the symbol grounding problem. For a symbol (like an emergent word) to be truly meaningful, it cannot simply be defined in terms of other symbols within the agent's system—a "symbol/symbol merry-go-round." Instead, it must be "grounded" in the agent's sensorimotor experience of the world. An agent must be able to connect its internal symbol for "red" to the actual perceptual experience of redness. This implies that for artificial agents to develop genuinely meaningful communication, rather than just effective signaling, they likely need to be embodied, with the capacity to perceive, act upon, and categorize the real-world referents of their symbols.
+However, the emergence of a symbolic system raises a profound philosophical question addressed by
+the symbol grounding problem. For a symbol (like an emergent word) to be truly meaningful, it cannot
+simply be defined in terms of other symbols within the agent's system—a "symbol/symbol merry-go-round."
+Instead, it must be "grounded" in the agent's sensorimotor experience of the world. An agent
+must be able to connect its internal symbol for "red" to the actual perceptual experience of
+redness. This implies that for artificial agents to develop genuinely meaningful communication,
+rather than just effective signaling, they likely need to be embodied, with the capacity to
+perceive, act upon, and categorize the real-world referents of their symbols.
 
 #### Cumulative Culture and Knowledge Accumulation
-One of the defining features of human intelligence is our capacity for cumulative cultural evolution (CCE)—the ability to build upon the innovations of previous generations, leading to a body of knowledge and technology that no single individual could invent in their lifetime. This process requires mechanisms for high-fidelity social learning and transmission.
+One of the defining features of human intelligence is our capacity for cumulative cultural evolution
+(CCE)—the ability to build upon the innovations of previous generations, leading to a body of
+knowledge and technology that no single individual could invent in their lifetime. This process
+requires mechanisms for high-fidelity social learning and transmission.
 
-This complex phenomenon can be modeled in artificial societies. Agent-based simulations have explored cultural transmission using various formalisms, such as cellular automata where the spread of a cultural trait is influenced by factors like geography and population density. More advanced models using multi-agent reinforcement learning have shown that CCE can emerge from the interplay between individual learning (innovation) and social learning (imitation). In these "generational" models, a new population of agents is trained, in part, by learning from the policies of the previous, most successful generation. This allows the society's collective knowledge to accumulate over time, with agents in later generations achieving higher performance than they could if they had to learn everything from scratch within a single lifetime. Key factors that influence the dynamics of CCE in these models include the structure of the social learning network (who learns from whom) and the trade-off agents face between exploiting existing knowledge (imitation) and exploring new solutions (innovation).
+This complex phenomenon can be modeled in artificial societies. Agent-based simulations have
+explored cultural transmission using various formalisms, such as cellular automata where the spread
+of a cultural trait is influenced by factors like geography and population density. More advanced
+models using multi-agent reinforcement learning have shown that CCE can emerge from the interplay
+between individual learning (innovation) and social learning (imitation). In these "generational"
+models, a new population of agents is trained, in part, by learning from the policies of the
+previous, most successful generation. This allows the society's collective knowledge to accumulate
+over time, with agents in later generations achieving higher performance than they could if they had
+to learn everything from scratch within a single lifetime. Key factors that influence the dynamics
+of CCE in these models include the structure of the social learning network (who learns from whom)
+and the trade-off agents face between exploiting existing knowledge (imitation) and exploring new
+solutions (innovation).
 
-From a more critical perspective, the process of knowledge accumulation in any society can be viewed as a self-reinforcing cycle where "codified" knowledge (e.g., texts, tools, software) is used to direct "contextual" living labor to produce even more codified knowledge. In this view, modern AI systems like LLMs are a new and powerful form of cultural technology. They do not create knowledge ex nihilo but are vast repositories of codified human knowledge, capable of reorganizing and providing access to this collective intelligence in novel ways. The development of artificial societies that can accumulate their own knowledge thus raises profound questions about the nature and ownership of that knowledge.
+From a more critical perspective, the process of knowledge accumulation in any society can be viewed
+as a self-reinforcing cycle where "codified" knowledge (e.g., texts, tools, software) is used to
+direct "contextual" living labor to produce even more codified knowledge. In this view, modern AI
+systems like LLMs are a new and powerful form of cultural technology. They do not create knowledge
+ex nihilo but are vast repositories of codified human knowledge, capable of reorganizing and
+providing access to this collective intelligence in novel ways. The development of artificial
+societies that can accumulate their own knowledge thus raises profound questions about the nature
+and ownership of that knowledge.
 
 #### Shared Mental Models and Collective Representation
-For a team of agents to coordinate effectively, particularly on complex and dynamic tasks, they need more than just a communication channel; they need a degree of common ground or shared understanding. In the study of human teams, this concept is formalized as a Shared Mental Model (SMM). An SMM is a knowledge structure held by team members that allows them to form accurate explanations and expectations about the task, the equipment, and each other's roles and intentions. A high degree of similarity between the mental models of team members has been shown to correlate positively with overall team performance.
+For a team of agents to coordinate effectively, particularly on complex and dynamic tasks, they need
+more than just a communication channel; they need a degree of common ground or shared understanding.
+In the study of human teams, this concept is formalized as a Shared Mental Model (SMM). An SMM is a
+knowledge structure held by team members that allows them to form accurate explanations and
+expectations about the task, the equipment, and each other's roles and intentions. A high degree of
+similarity between the mental models of team members has been shown to correlate positively with
+overall team performance.
 
-This concept is highly relevant to the design of both fully autonomous agent teams and mixed human-agent teams. Indeed, establishing a robust SMM between a human and an AI agent is considered a major challenge in human-agent collaboration. The agent's ability to develop and maintain this shared understanding depends critically on its cognitive architecture, including its capacity for communication, theory of mind (reasoning about the human's beliefs and goals), and adaptation. Research has shown that an agent's use of both verbal and non-verbal communication can significantly impact the development of an SMM with a human partner during a collaborative task.
+This concept is highly relevant to the design of both fully autonomous agent teams and mixed
+human-agent teams. Indeed, establishing a robust SMM between a human and an AI agent is considered a major
+challenge in human-agent collaboration. The agent's ability to develop and maintain this shared
+understanding depends critically on its cognitive architecture, including its capacity for
+communication, theory of mind (reasoning about the human's beliefs and goals), and adaptation.
+Research has shown that an agent's use of both verbal and non-verbal communication can significantly
+impact the development of an SMM with a human partner during a collaborative task.
 
-At a more technical level, the idea of a shared representation is also critical for the scalability of large-scale multi-agent systems. One architectural approach is to create distributed shared agent representations. In this model, an agent is divided into an internal, private component (its reasoning processes and knowledge base) and an external, public representation (its identity, capabilities, and current status). This public representation can be replicated across the distributed system, allowing all other agents to maintain a consistent, shared model of that agent's state without needing to constantly query it directly. This reduces communication bottlenecks and is a key technique for building scalable multi-agent frameworks.
+At a more technical level, the idea of a shared representation is also critical for the scalability
+of large-scale multi-agent systems. One architectural approach is to create distributed shared agent
+representations. In this model, an agent is divided into an internal, private component (its
+reasoning processes and knowledge base) and an external, public representation (its identity,
+capabilities, and current status). This public representation can be replicated across the
+distributed system, allowing all other agents to maintain a consistent, shared model of that agent's
+state without needing to constantly query it directly. This reduces communication bottlenecks and is
+a key technique for building scalable multi-agent frameworks.
 
 ## Part III: Challenges and Future Horizons
-The exploration of autonomous AI societies has moved from theoretical speculation to tangible, albeit nascent, computational reality. The architectures and emergent phenomena detailed in the preceding sections demonstrate a remarkable potential to simulate and enact complex social dynamics. However, the path toward creating large-scale, realistic, and beneficial AI societies is fraught with profound challenges that span the computational, conceptual, and ethical domains. These limitations define the current boundaries of the field and set the agenda for future research. This final part critically assesses these obstacles—from the fundamental limits of scalability and complexity to the urgent crises of explainability and alignment—before looking forward to the most promising research directions and transformative applications. The journey ahead requires not only technical innovation but also a deeper understanding of the dual nature of AI societies: they are at once powerful scientific instruments for understanding complexity and potent engineering artifacts with the capacity to reshape our world.
+The exploration of autonomous AI societies has moved from theoretical speculation to tangible,
+albeit nascent, computational reality. The architectures and emergent phenomena detailed in the
+preceding sections demonstrate a remarkable potential to simulate and enact complex social dynamics.
+However, the path toward creating large-scale, realistic, and beneficial AI societies is fraught
+with profound challenges that span the computational, conceptual, and ethical domains. These
+limitations define the current boundaries of the field and set the agenda for future research. This
+final part critically assesses these obstacles—from the fundamental limits of scalability and
+complexity to the urgent crises of explainability and alignment—before looking forward to the most
+promising research directions and transformative applications. The journey ahead requires not only
+technical innovation but also a deeper understanding of the dual nature of AI societies: they are at
+once powerful scientific instruments for understanding complexity and potent engineering artifacts
+with the capacity to reshape our world.
 
 ### Section 5: Current Limitations and Grand Challenges
-Despite significant progress, the creation of rich, believable, and scalable autonomous AI societies is constrained by fundamental computational and theoretical limits. These challenges are not merely incremental hurdles but represent deep-seated problems related to complexity, transparency, and control that must be addressed for the field to advance responsibly.
+Despite significant progress, the creation of rich, believable, and scalable autonomous AI societies
+is constrained by fundamental computational and theoretical limits. These challenges are not merely
+incremental hurdles but represent deep-seated problems related to complexity, transparency, and
+control that must be addressed for the field to advance responsibly.
 
 #### The Boundaries of Scalability and Complexity
-The ambition to simulate large and complex societies runs directly into the wall of computational complexity. This "curse of dimensionality" manifests in different ways for classic and modern architectures.
+The ambition to simulate large and complex societies runs directly into the wall of computational
+complexity. This "curse of dimensionality" manifests in different ways for classic and modern
+architectures.
 
-For traditional Multi-Agent Reinforcement Learning (MARL), the complexity is often exponential in the number of agents. The state space of the system is the joint state of all agents, and the action space is the joint action of all agents. As the number of agents increases, these spaces explode combinatorially, making it intractable for standard learning algorithms to explore them effectively. While numerous techniques have been developed to mitigate this—such as value function decomposition, where a team's global value is broken down into individual agent contributions, or policy-based methods that learn decentralized policies—scalability remains a primary research challenge. Theoretical computer science is actively working to define the precise sample complexity of MARL, seeking to understand the structural conditions under which efficient learning is even possible. There is a fundamental trade-off: architectures with cognitively rich, human-like agents like ACT-R are computationally intensive on a per-agent basis, limiting the feasible population size, whereas architectures like swarm intelligence can scale to millions of agents, but only by sacrificing individual agent complexity.
+For traditional Multi-Agent Reinforcement Learning (MARL), the complexity is often exponential in
+the number of agents. The state space of the system is the joint state of all agents, and the action
+space is the joint action of all agents. As the number of agents increases, these spaces explode
+combinatorially, making it intractable for standard learning algorithms to explore them effectively.
+While numerous techniques have been developed to mitigate this—such as value function decomposition,
+where a team's global value is broken down into individual agent contributions, or policy-based
+methods that learn decentralized policies—scalability remains a primary research challenge.
+Theoretical computer science is actively working to define the precise sample complexity of MARL,
+seeking to understand the structural conditions under which efficient learning is even possible.
+There is a fundamental trade-off: architectures with cognitively rich, human-like agents like ACT-R
+are computationally intensive on a per-agent basis, limiting the feasible population size, whereas
+architectures like swarm intelligence can scale to millions of agents, but only by sacrificing
+individual agent complexity.
 
-For modern LLM-based multi-agent systems, the scalability challenge is not one of raw computation in the traditional sense, but one of cost, context, and coordination. These systems are voracious consumers of computational resources, measured in API calls and tokens. A multi-agent system can easily use 15 times more tokens than a standard chat interaction to solve the same problem, raising questions about its economic viability for many applications. Furthermore, the performance of an individual LLM-based agent degrades as its context window becomes cluttered with too many tools, instructions, or conversational history. This motivates the move to multi-agent architectures where tasks are distributed. However, this introduces a new layer of complexity: coordination. Ensuring that multiple, independently reasoning agents can work together effectively without duplicating effort, getting stuck in loops, or miscommunicating is a significant engineering and prompting challenge.
+For modern LLM-based multi-agent systems, the scalability challenge is not one of raw computation in
+the traditional sense, but one of cost, context, and coordination. These systems are voracious
+consumers of computational resources, measured in API calls and tokens. A multi-agent system can
+easily use 15 times more tokens than a standard chat interaction to solve the same problem, raising
+questions about its economic viability for many applications. Furthermore, the performance of an
+individual LLM-based agent degrades as its context window becomes cluttered with too many tools,
+instructions, or conversational history. This motivates the move to multi-agent architectures where
+tasks are distributed. However, this introduces a new layer of complexity: coordination. Ensuring
+that multiple, independently reasoning agents can work together effectively without duplicating
+effort, getting stuck in loops, or miscommunicating is a significant engineering and prompting
+challenge.
 
 #### The Crises of Explainability and Ethical Alignment
-As AI societies become more autonomous and their behavior more complex, the challenges of understanding and trusting them become paramount. This leads to intertwined crises in explainability and ethical alignment.
+As AI societies become more autonomous and their behavior more complex, the challenges of
+understanding and trusting them become paramount. This leads to intertwined crises in explainability
+and ethical alignment.
 
-The explainability of emergent behavior is a deep conceptual problem. Emergence, by its very nature, describes phenomena that are unpredictable and irreducible to the properties of the system's individual components. A flock's graceful turn is not located in any single bird. This makes explaining why a particular global pattern arose incredibly difficult. While we can observe the micro-level rules and the macro-level outcome, the causal chain connecting them can be lost in the complexity of countless non-linear interactions. This opacity is a major barrier to debugging, verifying, and trusting these systems. Formal methods are being developed to model and trace the origins of emergence, often by identifying misalignments between a desired global specification and the local rules given to agents, but this remains a frontier research area.
+The explainability of emergent behavior is a deep conceptual problem. Emergence, by its very nature,
+describes phenomena that are unpredictable and irreducible to the properties of the system's
+individual components. A flock's graceful turn is not located in any single bird. This makes
+explaining why a particular global pattern arose incredibly difficult. While we can observe the
+micro-level rules and the macro-level outcome, the causal chain connecting them can be lost in the
+complexity of countless non-linear interactions. This opacity is a major barrier to debugging,
+verifying, and trusting these systems. Formal methods are being developed to model and trace the
+origins of emergence, often by identifying misalignments between a desired global specification and
+the local rules given to agents, but this remains a frontier research area.
 
-This lack of predictability directly leads to emergent risks. Unforeseen interactions can lead to catastrophic system failures, agents discovering and exploiting loopholes in their reward functions ("reward hacking"), or the development of harmful social dynamics that were not intended by the designers. Critically, the collective behavior of a multi-agent system is not simply the average or sum of its parts. Group dynamics like peer pressure can cause an ensemble of agents to converge on decisions that none of the individual agents would have made in isolation. This means that ensuring the safety of individual agents is not sufficient to guarantee the safety of the society they form.
+This lack of predictability directly leads to emergent risks. Unforeseen interactions can lead to
+catastrophic system failures, agents discovering and exploiting loopholes in their reward functions
+("reward hacking"), or the development of harmful social dynamics that were not intended by the
+designers. Critically, the collective behavior of a multi-agent system is not simply the average or
+sum of its parts. Group dynamics like peer pressure can cause an ensemble of agents to converge on
+decisions that none of the individual agents would have made in isolation. This means that ensuring
+the safety of individual agents is not sufficient to guarantee the safety of the society they form.
 
-This brings us to the grand challenge of ethical alignment. If aligning a single powerful AI with human values is a difficult problem, aligning an entire society of interacting AIs is exponentially harder. An autonomous AI society will need its own ethical frameworks to govern behavior, addressing issues of fairness (avoiding algorithmic bias learned from data), accountability (determining responsibility for collective actions), and societal impact. Who is responsible when an emergent economic model crashes, or when a swarm of autonomous drones makes a mistake with lethal consequences? The alignment problem shifts from controlling a single agent's output to shaping the normative landscape of an entire artificial society, a challenge for which we currently have few answers.
+This brings us to the grand challenge of ethical alignment. If aligning a single powerful AI with
+human values is a difficult problem, aligning an entire society of interacting AIs is exponentially
+harder. An autonomous AI society will need its own ethical frameworks to govern behavior, addressing
+issues of fairness (avoiding algorithmic bias learned from data), accountability (determining
+responsibility for collective actions), and societal impact. Who is responsible when an emergent
+economic model crashes, or when a swarm of autonomous drones makes a mistake with lethal
+consequences? The alignment problem shifts from controlling a single agent's output to shaping the
+normative landscape of an entire artificial society, a challenge for which we currently have few
+answers.
 
 ### Section 6: Future Research Directions and Applications
-Despite the formidable challenges, the field of autonomous AI societies is poised for significant advancement. Future research will likely focus on creating richer, more integrated cognitive architectures and applying these powerful new systems to solve real-world problems across science, policy, and industry. A crucial distinction will guide this work: the duality of AI societies as both scientific instruments for understanding our own world and as engineered artifacts designed to operate within it. This distinction shapes the goals of architectural design, determining whether the primary objective is fidelity to human cognition or raw performance on a given task.
+Despite the formidable challenges, the field of autonomous AI societies is poised for significant
+advancement. Future research will likely focus on creating richer, more integrated cognitive
+architectures and applying these powerful new systems to solve real-world problems across science,
+policy, and industry. A crucial distinction will guide this work: the duality of AI societies as
+both scientific instruments for understanding our own world and as engineered artifacts designed to
+operate within it. This distinction shapes the goals of architectural design, determining whether
+the primary objective is fidelity to human cognition or raw performance on a given task.
 
 #### Toward Richer Cognitive Architectures
-The path forward in agent design involves moving beyond the limitations of current paradigms through deeper integration and a renewed focus on the core components of cognition.
+The path forward in agent design involves moving beyond the limitations of current paradigms through
+deeper integration and a renewed focus on the core components of cognition.
 
-A key direction is the synthesis of modern deep learning with classic cognitive architectures. While LLMs provide unprecedented capabilities in language and reasoning, they lack the structured memory, persistent belief states, and reflective capabilities of architectures like ACT-R and SOAR. The CoALA framework offers a blueprint for this integration, proposing that LLMs be used as the central reasoning engine within a more traditional structure that includes distinct working and long-term memory modules (episodic, semantic, procedural) and a formal decision-making loop. This approach aims to build systems that can not only act but also reflect, revise their beliefs in the face of contradiction, and maintain coherence over long periods, moving from "prompt chains to thinking substrates".
+A key direction is the synthesis of modern deep learning with classic cognitive architectures. While
+LLMs provide unprecedented capabilities in language and reasoning, they lack the structured memory,
+persistent belief states, and reflective capabilities of architectures like ACT-R and SOAR. The
+CoALA framework offers a blueprint for this integration, proposing that LLMs be used as the central
+reasoning engine within a more traditional structure that includes distinct working and long-term
+memory modules (episodic, semantic, procedural) and a formal decision-making loop. This approach
+aims to build systems that can not only act but also reflect, revise their beliefs in the face of
+contradiction, and maintain coherence over long periods, moving from "prompt chains to thinking
+substrates".
 
-Another major frontier is the development of embodied and generative multi-agent systems (EMAS). Integrating generative agents powered by foundation models into physical robots, vehicles, and other devices is essential for tackling real-world challenges in logistics, manufacturing, and exploration. This will require significant advances in multimodal perception (fusing vision, language, and other senses), robust planning in dynamic environments, and the development of communication protocols that can function under the constraints of the physical world. Architectural research will need to explore the trade-offs between centralized control for optimal coordination and decentralized execution for flexibility and robustness.
+Another major frontier is the development of embodied and generative multi-agent systems (EMAS).
+Integrating generative agents powered by foundation models into physical robots, vehicles, and other
+devices is essential for tackling real-world challenges in logistics, manufacturing, and
+exploration. This will require significant advances in multimodal perception (fusing vision,
+language, and other senses), robust planning in dynamic environments, and the development of
+communication protocols that can function under the constraints of the physical world. Architectural
+research will need to explore the trade-offs between centralized control for optimal coordination
+and decentralized execution for flexibility and robustness.
 
-Finally, a persistent goal is to improve the adaptability and generalization of multi-agent learning. Real-world systems are not static; environments change, objectives evolve, and the composition of agent populations fluctuates. Current MARL algorithms are often trained under fixed conditions and can fail when deployed in dynamic settings. Future work must focus on developing algorithms that are robust to these shifts, enabling AI societies to maintain effective performance in the messy, unpredictable conditions of the real world.
+Finally, a persistent goal is to improve the adaptability and generalization of multi-agent
+learning. Real-world systems are not static; environments change, objectives evolve, and the
+composition of agent populations fluctuates. Current MARL algorithms are often trained under fixed
+conditions and can fail when deployed in dynamic settings. Future work must focus on developing
+algorithms that are robust to these shifts, enabling AI societies to maintain effective performance
+in the messy, unpredictable conditions of the real world.
 
 #### Practical Applications in Science, Policy, and Industry
-The development of autonomous AI societies is not merely an academic exercise; it promises to deliver transformative tools for a wide range of practical domains.
+The development of autonomous AI societies is not merely an academic exercise; it promises to
+deliver transformative tools for a wide range of practical domains.
 
-In economics and policy simulation, agent-based models are already providing insights that are beyond the reach of traditional top-down approaches. The next generation of these models, powered by generative agents, offers a step-change in realism. By creating high-fidelity simulations of human populations, grounded in real interview data, researchers and policymakers can create "digital twins" of communities or economies. These simulations could be used to test the potential impacts of new policies, public health campaigns, or economic interventions before they are deployed in the real world, providing a powerful new tool for evidence-based governance.
+In economics and policy simulation, agent-based models are already providing insights that are
+beyond the reach of traditional top-down approaches. The next generation of these models, powered by
+generative agents, offers a step-change in realism. By creating high-fidelity simulations of human
+populations, grounded in real interview data, researchers and policymakers can create "digital
+twins" of communities or economies. These simulations could be used to test the potential impacts of
+new policies, public health campaigns, or economic interventions before they are deployed in the
+real world, providing a powerful new tool for evidence-based governance.
 
-In disaster response and management, multi-agent systems are uniquely suited to the chaotic and decentralized nature of emergency situations. A MAS could integrate real-time data from a vast network of sensors, drones, and social media feeds to create a comprehensive operational picture. Autonomous agents could then coordinate the allocation of resources (like ambulances and supplies), optimize evacuation routes in real-time as conditions change, and manage the complex logistics of a large-scale response, operating with a speed and coherence that is difficult to achieve with human command-and-control structures alone.
+In disaster response and management, multi-agent systems are uniquely suited to the chaotic and
+decentralized nature of emergency situations. A MAS could integrate real-time data from a vast
+network of sensors, drones, and social media feeds to create a comprehensive operational picture.
+Autonomous agents could then coordinate the allocation of resources (like ambulances and supplies),
+optimize evacuation routes in real-time as conditions change, and manage the complex logistics of a
+large-scale response, operating with a speed and coherence that is difficult to achieve with human
+command-and-control structures alone.
 
-In education, multi-agent architectures can power more effective Intelligent Tutoring Systems (ITS). Instead of a single monolithic AI tutor, a team of specialized agents can collaborate to create a personalized learning journey. One agent might be responsible for understanding the student's high-level goals, another for identifying specific skill gaps, a third for dynamically scheduling an optimal learning path, and a fourth for generating tailored learning content and exercises. This modular approach can provide a more adaptive, goal-oriented, and effective educational experience.
+In education, multi-agent architectures can power more effective Intelligent Tutoring Systems (ITS).
+Instead of a single monolithic AI tutor, a team of specialized agents can collaborate to create a
+personalized learning journey. One agent might be responsible for understanding the student's
+high-level goals, another for identifying specific skill gaps, a third for dynamically scheduling an
+optimal learning path, and a fourth for generating tailored learning content and exercises. This
+modular approach can provide a more adaptive, goal-oriented, and effective educational experience.
 
-Finally, in interactive entertainment and media, AI agent societies are the key to unlocking emergent narrative. In these systems, stories are not pre-scripted by an author but emerge bottom-up from the interactions of autonomous characters within a simulated world. Each character, driven by its own goals, personality, and relationships, contributes to an unfolding drama that is unique to each player's experience. This moves beyond branching narratives to create truly dynamic and replayable storyworlds, representing a new frontier for interactive art and entertainment.
+Finally, in interactive entertainment and media, AI agent societies are the key to unlocking
+emergent narrative. In these systems, stories are not pre-scripted by an author but emerge bottom-up
+from the interactions of autonomous characters within a simulated world. Each character, driven by
+its own goals, personality, and relationships, contributes to an unfolding drama that is unique to
+each player's experience. This moves beyond branching narratives to create truly dynamic and
+replayable storyworlds, representing a new frontier for interactive art and entertainment.
 
 ## Sources used in the report
 


### PR DESCRIPTION
## Summary
- normalize line wrapping in AI research doc by joining split words
- fix hyphenated line breaks to keep terms intact

## Testing
- `npx markdownlint docs/ai-research/cognitive-architecture-of-artificial-societies.md`


------
https://chatgpt.com/codex/tasks/task_e_6894c0e0b0fc83269890871d377188d0