### PR TITLE
refactor: remove manual numbering from metaorganism headings

### DIFF
--- a/docs/metaorganism.md
+++ b/docs/metaorganism.md
@@ -11,7 +11,7 @@ updated: 2025-06-20
 
 For centuries, we have sought to understand human organizations through analogy, comparing them to machines, organisms, or even brains.1 While insightful, these metaphors remain partial, failing to capture the intricate fusion of human agents, intelligent technologies, and symbolic narratives that defines the 21st-century enterprise.4 This report proposes a new framework that moves beyond metaphor to model: the concept of the metaorganism. A metaorganism is a complex adaptive system whose emergent properties and evolutionary dynamics represent a distinct and higher level of organization, analogous to the major transitions in the history of life.6
 
-### 1.1 The Metaorganism Hypothesis: A Synthesis of System and Symbol
+### The Metaorganism Hypothesis: A Synthesis of System and Symbol
 
 A metaorganism is a complex adaptive system (CAS) composed of heterogeneous, interacting agents (individuals, teams, algorithms) and their non-human artifacts (capital, code, infrastructure) that collectively form an integrated whole.9 This entity exhibits emergent, organism-like properties, including a distinct identity, boundary maintenance, metabolic processes for resource conversion, and a fundamental drive for survival. This drive is powered by two interconnected forces: the pursuit of functional synergy and the propagation of a unifying collective consciousness.
 
@@ -23,7 +23,7 @@ This definition builds on several key biological and sociological concepts:
 
 Unlike Gareth Morgan's organizational metaphors, which offer different lenses to view an organization (as a machine, organism, brain, culture, etc.), the metaorganism framework posits that these are not separate perspectives but fused, interdependent realities.5 A modern company is a machine in its processes, an organism in its adaptation, a brain in its learning systems, and a culture in its narrative—all at once.14 The metaorganism is a synthesizing model that describes how these functions integrate into a single, cohesive whole.
 
-### 1.2 The Evolutionary Ladder: From Microorganism to Metaorganism
+### The Evolutionary Ladder: From Microorganism to Metaorganism
 
 The emergence of the metaorganism can be understood as a "leveling up" of organizational complexity, a process analogous to the major transitions in evolution identified by biologists John Maynard Smith and Eörs Szathmáry.8 These transitions occur when independent entities combine to form a new, higher-level individual, which then becomes a new unit of selection (e.g., from prokaryotic cells to eukaryotic cells, or from single-celled organisms to multicellular organisms).6 A key feature of these transitions is that the lower-level entities lose their ability to replicate independently, becoming functionally integrated into the whole.7
 
@@ -45,7 +45,7 @@ This "leveling up" is not merely about scale; it represents a fundamental shift 
 
 What forces drive the formation and persistence of these complex entities? The metaorganism's existence is governed by a dual logic, combining principles from evolutionary biology, sociology, and philosophy. It is simultaneously pushed by the functional advantages of cooperation and pulled together by the cohesive power of a shared reality.
 
-### 2.1 The Synergism Hypothesis: The Functional Advantage of Complexity
+### The Synergism Hypothesis: The Functional Advantage of Complexity
 
 A core driver of the evolution toward metaorganisms is the pursuit of synergy: the unique, combined effects produced by the cooperation of two or more agents or parts.21 Biologist Peter Corning's Synergism Hypothesis posits that these functional advantages have been a primary causal agency in the evolution of complexity at all levels.23 In essence, this is an economic theory of complexity: cooperative arrangements are selected for because the payoffs they generate are greater than the sum of the individual parts' efforts.25
 
@@ -57,7 +57,7 @@ This applies directly to organizations:
 
 These synergistic benefits—in innovation, efficiency, and influence—are the functional _payoffs_ that drive the formation and growth of metaorganisms.25 This constant search for synergistic advantage provides the positive, creative force that fuels organizational evolution.
 
-### 2.2 Collective Consciousness and Hyperreality: The Narrative Glue
+### Collective Consciousness and Hyperreality: The Narrative Glue
 
 While synergy explains why metaorganisms form, it doesn't fully explain how they cohere. The binding agent is a shared symbolic reality. This can be understood through two complementary frameworks:
 
@@ -71,13 +71,13 @@ Together, these concepts explain how a metaorganism maintains its coherence. The
 
 How do metaorganisms come into being, and how do they operate? Their functioning relies on principles of self-organization and resource management, and their very emergence can be seen as a critical transition in an organization's lifecycle.
 
-### 3.1 Emergence, Self-Organization, and the Fight Against Entropy
+### Emergence, Self-Organization, and the Fight Against Entropy
 
 A metaorganism's behavior is not dictated by a central controller but emerges from the local interactions of its constituent agents.42 This is a core tenet of complexity theory, which studies how simple, local rules can give rise to complex, unpredictable, and intelligent global patterns.44 In an organization, these "rules" are cultural norms, communication protocols, and operational heuristics. When enacted by thousands of agents, they produce emergent properties like an innovative culture or a resilient supply chain.47
 
 This emergent order is a constant struggle against organizational entropy, the natural tendency of any system to move toward disorder, inefficiency, and decay.48 Entropy in a business manifests as communication breakdown, process inefficiency, and the erosion of shared purpose.49 To counteract this, the metaorganism must engage in a form of metabolism: it must continuously import and process energy and resources (capital, information, human talent) to maintain its structure and function.52 Open organizations where information flows freely are better equipped to adapt and survive this entropic pull.54
 
-### 3.2 The Threshold of Emergence: The Founder's Dilemma
+### The Threshold of Emergence: The Founder's Dilemma
 
 When can we say an organization has crossed the threshold to become a true metaorganism? A key indicator is the point at which it can no longer be steered by the direct will of its founder. This transition is captured by the Founder's Dilemma.55
 
@@ -89,7 +89,7 @@ This transition marks the birth of the metaorganism. It is the moment the organi
 
 The metaorganism framework can be applied to a wide range of modern entities. The following cases illustrate its core principles in action.
 
-### 4.1 The Perpetual Startup: Amazon's "Day 1" Culture
+### The Perpetual Startup: Amazon's "Day 1" Culture
 
 Amazon serves as a prime archetype of a consciously managed metaorganism.
 
@@ -99,7 +99,7 @@ Metabolism and Synergy: The core metabolic process is "Customer Obsession," wher
 
 Emergence and Structure: The "two-pizza team" structure creates small, autonomous "cells" empowered to innovate locally.64 Successful experiments can then propagate through the network, leading to emergent, system-wide capabilities like Amazon Web Services (AWS) that were not centrally planned in their final form.68
 
-### 4.2 The Regulatory Holobiont: U.S. Federal Agencies
+### The Regulatory Holobiont: U.S. Federal Agencies
 
 The U.S. federal regulatory apparatus can be analyzed as a sprawling, loosely coupled metaorganism.
 
@@ -107,7 +107,7 @@ Structure: The system is not a monolith but a complex "patchwork" of agencies li
 
 Adaptation and Emergence: Policy often emerges from the complex interactions, negotiations, and conflicts among these different agencies as they adapt to new challenges like climate change or synthetic biology.9 The EPA's development of Climate Change Adaptation Plans, for instance, shows one part of the system attempting to self-organize and respond to external pressures to maintain regulatory homeostasis.76
 
-### 4.3 The Leaderless Swarm: Occupy Wall Street
+### The Leaderless Swarm: Occupy Wall Street
 
 Grassroots social movements like Occupy Wall Street (OWS) exemplify a radically decentralized metaorganism.
 
@@ -115,7 +115,7 @@ Collective Consciousness: The movement was unified by the simple but powerful sl
 
 Self-Organization and Emergence: OWS was famously "leaderless," with decisions made through consensus in open "General Assemblies".80 Its strategies and goals emerged from the bottom up, akin to the behavior of a swarm.83 The physical occupation of Zuccotti Park was a manifestation of this emergent collective will.85
 
-### 4.4 Digital Ecosystems: Emergent Governance in Open Source
+### Digital Ecosystems: Emergent Governance in Open Source
 
 Open-source software (OSS) communities, such as those managed by the Apache Foundation or the Linux Foundation, are a new breed of metaorganism where governance itself is an emergent property.
 
@@ -127,7 +127,7 @@ Metabolism and Boundaries: The "nutrients" are code contributions from a distrib
 
 The metaorganism model is not a utopian one. Its very strengths—cohesion, adaptability, and scale—give rise to unique vulnerabilities and complex power dynamics that have profound consequences for the individuals within it.
 
-### 5.1 Systemic Fragilities: Mission Drift and Collapse
+### Systemic Fragilities: Mission Drift and Collapse
 
 Complex adaptive systems are resilient but also prone to catastrophic failure, often arising from the unforeseen interaction of multiple small flaws.9
 
@@ -135,7 +135,7 @@ Mission Drift: This is a primary pathology, representing a gradual deviation fro
 
 Hyperreal Implosion: This is a catastrophic failure mode unique to the metaorganism. It occurs when the gap between the unifying hyperreal narrative (e.g., "We are changing the world") and the lived reality of its agents (e.g., a toxic or unethical workplace) becomes unsustainable. The narrative collapses, destroying the collective consciousness that motivates action and leading to mass disengagement, cynicism, and rapid organizational decay.
 
-### 5.2 The Individual Within the Whole: Power, Agency, and Marginalization
+### The Individual Within the Whole: Power, Agency, and Marginalization
 
 The metaorganism is a site of immense and complex power dynamics.
 
@@ -149,7 +149,7 @@ Marginalization: The creation of a strong, unifying narrative inherently creates
 
 To be a truly useful tool, the metaorganism concept must be grounded in empirical research. This requires a mixed-methods approach and a new set of metrics to assess metaorganismic health.
 
-### 6.1 A Triangulated Research Approach
+### A Triangulated Research Approach
 
 No single method can capture the metaorganism's complexity. A combination of quantitative and qualitative techniques is essential:
 
@@ -165,7 +165,7 @@ for agent in agents:
 
 Organizational Ethnography: This qualitative method involves deep immersion in an organization to understand its culture, rituals, and power dynamics from the members' perspective.89 Ethnography is uniquely capable of accessing the lived experience of the hyperreal narrative, revealing how it is interpreted, negotiated, and resisted on the ground.89
 
-### 6.2 Metrics for Metaorganismic Health
+### Metrics for Metaorganismic Health
 
 Beyond traditional financial indicators, we need new metrics to assess a metaorganism's vitality:
 


### PR DESCRIPTION
## Summary
- remove hard-coded section numbers in metaorganism document so Markdown generates automatic numbering
- ensure document builds cleanly without numbered headings

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689655adde008326a9e6c38580074516