### PR TITLE
chore: add pre-commit hook for research docs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+name: Pre-commit
+
+on:
+  push:
+    paths:
+      - '**/*.md'
+      - '.pre-commit-config.yml'
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.pre-commit-config.yml'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - uses: pre-commit/action@v3.0.0
+

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lint-research-docs
+        name: Lint research docs for mid-word splits
+        entry: python scripts/lint_research_docs.py
+        language: system
+        types: [markdown]
+        files: ^docs/ai-research/.*\.md$

--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 This repository aggregates documentation and research across multiple projects.
 
 For setup instructions, directory overview, and detailed research listings, see [docs/index.md](docs/index.md).
+
+## Development
+
+Install [pre-commit](https://pre-commit.com/) hooks to automatically lint Markdown files:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hook runs `scripts/lint_research_docs.py` to catch mid-word line splits.
+


### PR DESCRIPTION
## Summary
- run lint_research_docs.py via pre-commit for research markdown
- document installing pre-commit hooks
- run pre-commit in CI for markdown changes

## Testing
- `pytest`
- `pre-commit run --files README.md --config .pre-commit-config.yml`


------
https://chatgpt.com/codex/tasks/task_e_68969b44db008326a0af1f0de4e23c71