### PR TITLE
Add trailing whitespace check to research docs linter

### DIFF
--- a/scripts/lint_research_docs.py
+++ b/scripts/lint_research_docs.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Scan Markdown files for mid-word line splits.
+"""Scan Markdown files for mid-word line splits and trailing whitespace.
 
-This script checks Markdown files in a given directory for lines that end
-with a letter when the following line begins with a letter. Such patterns often
-indicate a word that was accidentally split across lines.
+This script checks Markdown files in a given directory for common formatting
+issues. It flags lines that end with a letter when the following line begins
+with a letter (a sign of a word accidentally split across lines) and lines that
+contain extraneous trailing spaces.
 
 Usage:
     python scripts/lint_research_docs.py [--path PATH]
@@ -22,8 +23,10 @@ def find_splits(path: Path) -> List[str]:
     """Return a list of lint error messages for ``path``."""
     errors: List[str] = []
     lines = path.read_text(encoding="utf-8").splitlines()
-    for idx, line in enumerate(lines[:-1]):
-        if line and line[-1].isalpha():
+    for idx, line in enumerate(lines):
+        if line.rstrip() != line:
+            errors.append(f"{path}:{idx + 1}: trailing whitespace")
+        if idx < len(lines) - 1 and line and line[-1].isalpha():
             next_line = lines[idx + 1]
             if next_line and next_line[0].isalpha():
                 errors.append(f"{path}:{idx + 1}: possible mid-word split")

--- a/tests/test_lint_research_docs.py
+++ b/tests/test_lint_research_docs.py
@@ -31,3 +31,14 @@ def test_linter_passes_clean_file(tmp_path):
     result = run_linter(target)
     assert result.returncode == 0
     assert result.stdout == ""
+
+
+def test_linter_detects_trailing_whitespace(tmp_path):
+    target = tmp_path / "docs" / "ai-research"
+    target.mkdir(parents=True)
+    (target / "sample.md").write_text("line with space \nnext\n")
+
+    result = run_linter(target)
+    assert result.returncode == 1
+    assert "sample.md:1" in result.stdout
+    assert "trailing whitespace" in result.stdout


### PR DESCRIPTION
## Summary
- flag trailing whitespace in research Markdown docs
- document new check and extend linter tests

## Testing
- `flake8 scripts/lint_research_docs.py tests/test_lint_research_docs.py`
- `pytest tests/test_lint_research_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_68969b4286b88326bb5bddd75f25f72f