### PR TITLE
feat: add auto-fix to research doc linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This repository aggregates documentation and research across multiple projects.
 
 For setup instructions, directory overview, and detailed research listings, see [docs/index.md](docs/index.md).
+
+## Lint research docs
+
+Use `scripts/lint_research_docs.py` to scan Markdown files for mid-word line
+splits. Run the script with file or directory paths to check; add `--fix` to
+rewrite files in place and automatically join detected splits.

--- a/scripts/lint_research_docs.py
+++ b/scripts/lint_research_docs.py
@@ -3,12 +3,14 @@
 
 This script checks Markdown files in a given directory for lines that end
 with a letter when the following line begins with a letter. Such patterns often
-indicate a word that was accidentally split across lines.
+indicate a word that was accidentally split across lines. An optional ``--fix``
+flag rewrites files in place to automatically join the split words.
 
 Usage:
-    python scripts/lint_research_docs.py [--path PATH]
+    python scripts/lint_research_docs.py [--fix] [PATH ...]
 
-The command exits with status 1 if any potential issues are found.
+The command exits with status 1 if any potential issues are found (unless
+``--fix`` is specified).
 """
 
 from __future__ import annotations
@@ -18,32 +20,57 @@ from pathlib import Path
 from typing import Iterable, List
 
 
-def find_splits(path: Path) -> List[str]:
-    """Return a list of lint error messages for ``path``."""
+def find_splits(path: Path, fix: bool = False) -> List[str]:
+    """Return a list of lint error messages for ``path``.
+
+    If ``fix`` is True, detected splits are joined and the file is rewritten.
+    """
+
     errors: List[str] = []
-    lines = path.read_text(encoding="utf-8").splitlines()
-    for idx, line in enumerate(lines[:-1]):
-        if line and line[-1].isalpha():
-            next_line = lines[idx + 1]
-            if next_line and next_line[0].isalpha():
-                errors.append(f"{path}:{idx + 1}: possible mid-word split")
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    ends_with_newline = text.endswith("\n")
+
+    idx = 0
+    while idx < len(lines) - 1:
+        line = lines[idx]
+        next_line = lines[idx + 1]
+        if line and line[-1].isalpha() and next_line and next_line[0].isalpha():
+            errors.append(f"{path}:{idx + 1}: possible mid-word split")
+            if fix:
+                lines[idx] = line + next_line
+                del lines[idx + 1]
+                continue  # re-check same index in case of multiple splits
+        idx += 1
+
+    if fix and errors:
+        new_text = "\n".join(lines)
+        if ends_with_newline:
+            new_text += "\n"
+        path.write_text(new_text, encoding="utf-8")
+
     return errors
 
 
-def scan_paths(paths: Iterable[Path]) -> List[str]:
+def scan_paths(paths: Iterable[Path], fix: bool = False) -> List[str]:
     """Scan the provided paths for issues."""
     errors: List[str] = []
     for path in paths:
         if path.is_file() and path.suffix == ".md":
-            errors.extend(find_splits(path))
+            errors.extend(find_splits(path, fix=fix))
         elif path.is_dir():
             for md_file in path.rglob("*.md"):
-                errors.extend(find_splits(md_file))
+                errors.extend(find_splits(md_file, fix=fix))
     return errors
 
 
 def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Rewrite files in place to join detected mid-word splits",
+    )
     parser.add_argument(
         "paths",
         nargs="*",
@@ -53,8 +80,8 @@ def main(argv: Iterable[str] | None = None) -> int:
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    errors = scan_paths(args.paths)
-    if errors:
+    errors = scan_paths(args.paths, fix=args.fix)
+    if errors and not args.fix:
         print("\n".join(errors))
         return 1
     return 0

--- a/tests/test_lint_research_docs.py
+++ b/tests/test_lint_research_docs.py
@@ -5,12 +5,12 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "lint_research_docs.py"
 
 
-def run_linter(path: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["python", str(SCRIPT), str(path)],
-        capture_output=True,
-        text=True,
-    )
+def run_linter(path: Path, fix: bool = False) -> subprocess.CompletedProcess:
+    cmd = ["python", str(SCRIPT)]
+    if fix:
+        cmd.append("--fix")
+    cmd.append(str(path))
+    return subprocess.run(cmd, capture_output=True, text=True)
 
 
 def test_linter_detects_split(tmp_path):
@@ -31,3 +31,17 @@ def test_linter_passes_clean_file(tmp_path):
     result = run_linter(target)
     assert result.returncode == 0
     assert result.stdout == ""
+
+
+def test_linter_fixes_split(tmp_path):
+    target = tmp_path / "docs" / "ai-research"
+    target.mkdir(parents=True)
+    sample = target / "sample.md"
+    sample.write_text("mod\nel\n")
+
+    result = run_linter(target, fix=True)
+    assert result.returncode == 0
+    assert sample.read_text() == "model\n"
+
+    result = run_linter(target)
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- add `--fix` option to research document linter to auto-join mid-word splits
- cover detection and fix behavior with new tests
- document linter usage and fix flag in README

## Testing
- `python -m flake8 scripts/lint_research_docs.py tests/test_lint_research_docs.py`
- `pytest tests/test_lint_research_docs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68969b3fa5fc83269baf3cf65863b817