### PR TITLE
feat: enable theme palette toggle for docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,16 @@
 site_name: Tino Docs Hub
 site_description: Central hub for project documentation
-theme: material
+theme:
+  name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
 docs_dir: docs
 plugins:
   - search


### PR DESCRIPTION
## Summary
- add light/dark color schemes and toggle to MkDocs Material theme

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6897bcbde3148326b4abe2757cba00ed