### PR TITLE
Refine DeepThought executive summary

### DIFF
--- a/docs/ai-research/strategic-roadmap-deepthought.md
+++ b/docs/ai-research/strategic-roadmap-deepthought.md
@@ -10,29 +10,34 @@ updated: 2025-07-27
 Strategic R&D Roadmap for the DeepThought-ReThought Initiative: A Bayesian
 Synthesis for Maximizing Expected Value
 
-Executive Summary This report presents a strategic R&D roadmap for the
-DeepThought-ReThought project, derived from a Bayesian synthesis of all
-available project artifacts and external research. The objective is to provide a
-rigorously justified, actionable plan that maximizes the project's expected
-value by aligning development efforts with its core vision under conditions of
-uncertainty.
+## Executive Summary
+
+This report presents a strategic R&D roadmap for the DeepThought-ReThought
+project, derived from a Bayesian synthesis of all available project artifacts
+and external research.
+
+The roadmap provides a rigorously justified, actionable plan that maximizes the
+project's expected value by aligning development efforts with its core vision
+under conditions of uncertainty.
 
 DeepThought-ReThought is a technologically sophisticated experimental AI
-framework, distinguished by its event-driven architecture based on NATS
-JetStream 1 and its strategic focus on resource-efficient, fine-tuned small
-language models.1 The project's primary strategic objective is manifested in the
-"AGI Chatbot" for Discord, which aims for an unprecedented level of social
-intelligence and autonomous behavior.1
+framework distinguished by its event-driven architecture based on NATS
+JetStream 1.
 
-The project's core strategic challenge lies in a significant
-"vision-implementation gap." The ambitious goals for the AGI chatbot—including
-nuanced social modeling, long-term planning, and believable deception 1—are
-well-defined but are not yet supported by the current, more foundational,
-implementation. The existing codebase provides the architectural skeleton but
-lacks the sophisticated, unified cognitive and memory components required to
-realize this vision.
+It focuses on resource-efficient, fine-tuned small language models, and its
+primary strategic objective is the "AGI Chatbot" for Discord, which aims for an
+unprecedented level of social intelligence and autonomous behavior.1
 
-This report proposes a three-pronged strategic roadmap to bridge this gap:
+The project faces a significant "vision-implementation gap." The ambitious
+goals for the AGI chatbot—including nuanced social modeling, long-term planning,
+and believable deception 1—are well-defined but are not yet supported by the
+current foundational implementation.
+
+The existing codebase provides the architectural skeleton but lacks the
+sophisticated, unified cognitive and memory components required to realize this
+vision.
+
+This report proposes a three-pronged strategic roadmap to bridge the gap:
 
 1. Consolidate the Core: Prioritize the formalization and unification of the
    project's disparate memory and data backends into a cohesive "Cognitive Core"
@@ -47,9 +52,8 @@ This report proposes a three-pronged strategic roadmap to bridge this gap:
 The proposed roadmap is projected to increase the probability of achieving the
 project's core AGI chatbot vision from an estimated baseline of
 \(P\_\text{Success}^{\text{baseline}} = 0.35\) to a posterior probability of
-\(P\_\text{Success}^{\text{posterior}} = 0.75\). This is achieved by de-risking
-
-key architectural dependencies and aligning development effort directly with the
+\(P\_\text{Success}^{\text{posterior}} = 0.75\) by de-risking key
+architectural dependencies and aligning development effort directly with the
 highest-impact product features.
 
 Strategic Assessment and Core Value Proposition A thorough analysis of the


### PR DESCRIPTION
## Summary
- split the DeepThought roadmap's Executive Summary into focused one-idea paragraphs

## Testing
- No tests were run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_6897bcd0b09c8326a68bf00bf4ca56d6