### PR TITLE
Add sitemap plugin to MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ docs_dir: docs
 plugins:
   - search
   - monorepo
+  - sitemap
 markdown_extensions:
   - toc:
       permalink: true


### PR DESCRIPTION
## Summary
- include the `sitemap` plugin in the MkDocs configuration so a sitemap is generated during builds

## Testing
- `pre-commit run --files mkdocs.yml --config .pre-commit-config.yml`
- `pytest`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6897bcbf601483269d252eb63c76fd4d