### PR TITLE
docs: add table of contents to chatgpt agent report

### DIFF
--- a/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
+++ b/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
@@ -7,6 +7,8 @@ updated: 2025-07-29
 
 # Reverse-Engineering Design Report: OpenAI ChatGPT Agent System
 
+[TOC]
+
 
 ## 1.0 Executive Summary
 


### PR DESCRIPTION
## Summary
- add TOC marker after main title in ChatGPT agent system report

## Testing
- `python -m markdown -x toc docs/ai-research/reverse-engineering-chatgpt-agent-system.md > /tmp/re.html && head -n 20 /tmp/re.html`


------
https://chatgpt.com/codex/tasks/task_e_6897bcd61cf4832681133586560e7761