### PR TITLE
Add ChatGPT agent reasoning loop diagram

### DIFF
--- a/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
+++ b/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
@@ -10,6 +10,16 @@ updated: 2025-07-29
 
 ## 1.0 Executive Summary
 
+```mermaid
+flowchart TD
+    RQ[User Request] --> AN[Analyze]
+    AN --> PL[Plan]
+    PL --> CD[Code]
+    CD --> TS[Test]
+    TS --> RV[Review]
+    RV --> AN
+```
+
 
 ### 1.1 Overview of Findings
 


### PR DESCRIPTION
## Summary
- replace binary image with inline Mermaid diagram illustrating ChatGPT agent reasoning loop
- embed the diagram directly under the "1.0 Executive Summary" heading in the reverse-engineering report

## Testing
- `npx markdownlint docs/ai-research/reverse-engineering-chatgpt-agent-system.md` *(warnings: trailing spaces, duplicate heading, missing space in heading)*

------
https://chatgpt.com/codex/tasks/task_e_6897bcc7f8388326b5da17652a6b8872