### PR TITLE
docs: improve readability in audit intro

### DIFF
--- a/docs/audit-of-an-oracle.md
+++ b/docs/audit-of-an-oracle.md
@@ -11,10 +11,31 @@ updated: 2025-07-28
 
 ### 1.1. Introduction: The Challenge of Auditing a Futurist
 
-Ray Kurzweil occupies a unique and polarizing position in the landscape of technology forecasting. As an inventor, author, and Director of Engineering at Google, his visions of an exponentially accelerating future have profoundly influenced Silicon Valley, the fields of artificial intelligence and biotechnology, and the public imagination.[^1] His central thesis, the "Law of Accelerating Returns" (LOAR), posits that technological progress is not linear but exponential, leading inexorably to a "Singularity"—a point, which he dates to 2045, where machine intelligence will vastly surpass all human intelligence combined, merging with humanity and irreversibly transforming our existence.[^3]
-Assessing the validity of such a grand vision requires a rigorous audit of its foundational claims. Yet, evaluations of Kurzweil's predictive track record vary to an extraordinary degree. Kurzweil himself, in a self-audit of predictions made in his 1999 book The Age of Spiritual Machines, claimed a remarkable 86% accuracy rate for the year 2009, a figure widely cited by supporters.[^2] This figure combines predictions he deemed "entirely correct" and "essentially correct".[^7] Conversely, independent critical analyses have arrived at far more sobering conclusions, with some estimating his accuracy to be as low as 7%.[^12]
-This vast discrepancy—a nearly 80-point gap—is itself a significant finding. It suggests that the evaluation of foresight is highly sensitive to methodology, interpretation, and the definition of "correctness." The ambiguity inherent in many prophetic statements allows for confirmation bias, where both proponents and critics can selectively interpret evidence to fit their narrative.[^9] The purpose of this report is to move beyond these dueling anecdotes and conduct a systematic, transparent, and empirical audit of Kurzweil's dated, quantitative predictions. By constructing a comprehensive database from his four seminal works—
-The Age of Intelligent Machines (1990), The Age of Spiritual Machines (1999), The Singularity Is Near (2005), and his latest, The Singularity Is Nearer (2024)—this analysis seeks to establish a verifiable baseline of his performance.[^3] From this empirical foundation, the report will deconstruct his core methodology, the Law of Accelerating Returns, contrast it with alternative forecasting models, and derive durable lessons for the practice of strategic foresight.
+Ray Kurzweil occupies a unique and polarizing position in the landscape of technology forecasting.
+
+#### Kurzweil's Influence
+- Inventor, author, and Director of Engineering at Google.[^1]
+- His visions of an exponentially accelerating future have influenced Silicon Valley, the fields of artificial intelligence and biotechnology, and the broader public imagination.
+- Central thesis: the "Law of Accelerating Returns" posits that technological progress is exponential rather than linear.
+- Forecasts a 2045 Singularity where machine intelligence surpasses and merges with humanity, transforming human existence.[^3]
+
+#### Why Audit?
+- Evaluations of Kurzweil's predictive record vary wildly, underscoring the need for a rigorous audit.
+- Kurzweil's self-audit of 2009 predictions claimed 86% accuracy, widely cited by supporters, by counting both "entirely" and "essentially" correct predictions.[^2][^7]
+- Independent analyses estimate his accuracy as low as 7%.[^12]
+- The nearly 80-point gap shows how methodology and definitions of "correctness" can skew results.
+- Ambiguous prediction wording lets supporters and critics selectively justify their interpretations.[^9]
+
+#### Scope of This Report
+- Move beyond anecdotal claims and systematically audit his dated, quantitative predictions.
+- Compile a database of dated, falsifiable predictions across four seminal works:
+  - *The Age of Intelligent Machines* (1990)
+  - *The Age of Spiritual Machines* (1999)
+  - *The Singularity Is Near* (2005)
+  - *The Singularity Is Nearer* (2024)
+- Establish a transparent, verifiable baseline of his forecasting performance.[^3]
+- Examine the Law of Accelerating Returns against alternative models.
+- Derive lessons for strategic foresight practitioners.
 
 ### 1.2. Methodology: Constructing the Prediction Database
 


### PR DESCRIPTION
## Summary
- break up long introductory paragraphs in *Audit of an Oracle* into concise sections
- clarify rationale and scope with bullet lists for easier scanning while retaining original context

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6897bce295b88326b4b583e806e5b693