### PR TITLE
docs: move node dependencies near quickstart

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,14 @@ mkdocs serve
 ```
 Visit <http://127.0.0.1:8000> to preview the site locally.
 
+## Installing Node Dependencies
+
+Run `npm install` to download dev dependencies in `package.json` for tooling like Markdown linting.
+
+```bash
+npm install
+```
+
 ## Directory Structure
 
 - `ai-research/` – AI and machine learning notes
@@ -102,16 +110,6 @@ mkdocs serve
 Visit http://127.0.0.1:8000 to preview the site locally.
 
 The site automatically deploys via GitHub Actions whenever you push updates to Markdown files or `mkdocs.yml`.
-
-## Installing Node Dependencies
-
-Install Node packages for optional tooling such as markdown linting:
-
-```bash
-npm install
-```
-
-This installs development dependencies defined in `package.json`, such as `markdownlint-cli` for linting.
 
 ## Setting Up Git Hooks
 


### PR DESCRIPTION
## Summary
- relocate "Installing Node Dependencies" section just below Quickstart
- mention `npm install` to install dev tooling dependencies

## Testing
- no tests run; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_689a85c455d88326a7a0f5f9cccbf087