### PR TITLE
Add custom 404 page for missing docs

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,17 @@
+---
+title: "Page Not Found"
+tags: [404]
+project: docs-hub
+updated: 2025-08-12
+---
+
+# Page Not Found
+
+The requested page could not be located.
+
+- [Return to the home page](index.md)
+- Explore the [AI Research overview](ai-research/index.md)
+- Visit the [Culture Project](culture-project/index.md)
+- Review the [Security Threat Model](security/threat-model.md)
+
+If you believe this is an error, please report the broken link.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,9 @@ theme:
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
+# Documentation directory
 docs_dir: docs
+# Custom 404 page lives at docs/404.md and is automatically used by MkDocs
 plugins:
   - search
   - monorepo


### PR DESCRIPTION
## Summary
- add a docs/404.md page with links back to key sections of the docs
- note the custom 404 page in mkdocs.yml for easier discovery

## Testing
- no tests or linters were run

------
https://chatgpt.com/codex/tasks/task_e_689a87a55fdc832687f41fadcf37b47e