### PR TITLE
docs: cross-link RAG and reverse engineering

### DIFF
--- a/docs/ai-research/logical-chunking.md
+++ b/docs/ai-research/logical-chunking.md
@@ -11,6 +11,8 @@ updated: 2025-08-09
 
 Large language models (LLMs) and embedding models have finite context windows, which means that long documents must be broken into smaller pieces before they can be embedded and searched in a retrieval‑augmented generation (RAG) system. Effective chunking is critical: it allows RAG pipelines to fit data into the context window of embedding models, preserve semantic continuity, improve retrieval accuracy, and reduce latency and cost[^1][^2]. A good chunking strategy ensures that chunks are large enough to capture complete ideas yet small enough to index efficiently. This section surveys factors to consider and common chunking methods, and provides guidelines for selecting chunk sizes and overlaps.
 
+For broader context window strategies, see [Context Windows Field Guide](context-windows-field-guide.md).
+
 ## Key Factors for Effective Chunking
 
 When designing a chunking strategy, several variables need to be considered[^1][^2]:
@@ -104,6 +106,13 @@ Selecting the right chunk size involves balancing context preservation with retr
 ## Conclusion
 
 Logical chunking is a foundational step in retrieval‑augmented generation systems. Thoughtful chunking improves recall, reduces hallucination risk and helps LLMs use context effectively. By considering the type of content, embedding model limits, downstream tasks and available tools, practitioners can choose or combine chunking strategies that best suit their application. Continuous experimentation and measurement are essential, since optimal chunk size and method often vary across domains. Adopting a flexible, evidence‑based approach to chunking will yield more accurate and efficient RAG pipelines.
+
+## See also
+
+- [Context Windows Field Guide](context-windows-field-guide.md)
+- [Context Windows Deep Dive](context-windows-deep-dive.md)
+- [Reverse-Engineering GPT-o3 Multi-Turn Reasoning](reverse-engineering-gpt-o3.md)
+
 [^1]: Grgoire Mialon et al., "Augmented Language Models: a Survey," arXiv, 2023. https://arxiv.org/abs/2302.07842
 [^2]: OpenAI, "Retrieval Augmented Generation," https://platform.openai.com/docs/guides/rag
 [^3]: Pinecone, "Chunking Strategies for LLM Applications," https://www.pinecone.io/learn/chunking-strategies/

--- a/docs/ai-research/reverse-engineering-gpt-o3.md
+++ b/docs/ai-research/reverse-engineering-gpt-o3.md
@@ -21,13 +21,13 @@ A Sparsely-Gated Mixture of Experts (MoE) Transformer: This serves as the founda
 
 A Dynamic Context & State Management Engine: This subsystem acts as the "operating system" for the conversational agent. It is responsible for maintaining state, managing the limited context window across extended dialogues, and ensuring conversational coherence. It employs a hierarchy of techniques including summarization, sliding windows, and vectorized long-term memory.
 
-An Integrated Retrieval-Augmented Generation (RAG) Pipeline: To ensure factual accuracy and provide up-to-date information, the system dynamically queries an external knowledge base. This RAG pipeline retrieves relevant information from a vector database and injects it into the model's context, grounding its responses in verifiable data.
+An Integrated [Retrieval-Augmented Generation (RAG) Pipeline](logical-chunking.md): To ensure factual accuracy and provide up-to-date information, the system dynamically queries an external knowledge base. This RAG pipeline retrieves relevant information from a vector database and injects it into the model's context, grounding its responses in verifiable data.
 
 - **Sparsely-Gated Mixture of Experts (MoE) Transformer**: This serves as the foundational generative model. Its architecture enables scaling to trillions of parameters while maintaining manageable inference costs through conditional computation, activating only a fraction of its total weights for any given input token.
 
 - **Dynamic Context & State Management Engine**: This subsystem acts as the "operating system" for the conversational agent. It is responsible for maintaining state, managing the limited context window across extended dialogues, and ensuring conversational coherence. It employs a hierarchy of techniques including summarization, sliding windows, and vectorized long-term memory.
 
-- **Integrated Retrieval-Augmented Generation (RAG) Pipeline**: To ensure factual accuracy and provide up-to-date information, the system dynamically queries an external knowledge base. This RAG pipeline retrieves relevant information from a vector database and injects it into the model's context, grounding its responses in verifiable data.
+- **Integrated [Retrieval-Augmented Generation (RAG) Pipeline](logical-chunking.md)**: To ensure factual accuracy and provide up-to-date information, the system dynamically queries an external knowledge base. This RAG pipeline retrieves relevant information from a vector database and injects it into the model's context, grounding its responses in verifiable data.
 
 The interaction between these three components—the MoE model as the computational core, the Context Engine as the state manager, and the RAG pipeline as the knowledge source—is what endows the system with its powerful and coherent multi-turn reasoning abilities.
 
@@ -622,6 +622,12 @@ This section would contain anonymized and condensed excerpts from dynamic analys
 ### 10.4. Full License Texts
 
 This section would contain the full, verbatim text of the Apache License, Version 2.0, and the MIT License. This is a legal requirement for distributing software that uses or is licensed under these terms and is included here for completeness and compliance.
+
+## See also
+
+- [Reverse-Engineering OpenAI Codex](reverse-engineering-codex.md)
+- [Reverse-Engineering ChatGPT Agent System](reverse-engineering-chatgpt-agent-system.md)
+- [Logical Chunking Strategies](logical-chunking.md)
 
 ## Sources used in the report
 


### PR DESCRIPTION
## Summary
- link logical chunking guide to context window resources
- reference chunking from GPT-o3 reverse-engineering report and add related docs

## Testing
- `mkdocs build -f mkdocs_build.yml`

------
https://chatgpt.com/codex/tasks/task_e_689a87933b388326b2f614f5001221e4