### PR TITLE
docs: add ChatGPT agent system to AI research nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - You Weren't Supposed to Invent Infinite Jest: ai-research/you-werent-supposed-to-invent-infinite-jest.md
       - Reverse Engineering GPT-o3: ai-research/reverse-engineering-gpt-o3.md
       - Reverse Engineering Storm: ai-research/reverse-engineering-storm.md
+      - Reverse Engineering ChatGPT Agent System: ai-research/reverse-engineering-chatgpt-agent-system.md
       - Seed Factory Feasibility Dossier: ai-research/seed-factory-feasibility-dossier.md
       - The Cognitive Architecture of Artificial Societies: ai-research/cognitive-architecture-of-artificial-societies.md
       - Democratizing Brain-Inspired AI Roadmap: ai-research/open-neuromorphic-roadmap.md


### PR DESCRIPTION
## Summary
- include reverse-engineering ChatGPT agent system page in AI Research docs navigation

## Testing
- `pytest`
- `flake8` *(fails: line too long in scripts/kv_capacity.py)*
- `yamllint mkdocs.yml` *(fails: multiple line-length warnings)*
- `mkdocs serve -f mkdocs.local.yml -a 0.0.0.0:8000 --no-livereload`

------
https://chatgpt.com/codex/tasks/task_e_689a87b450bc8326833a0914f3932329