### PR TITLE
Enable superfences extension in MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,8 @@ markdown_extensions:
       permalink: true
   - admonition
   - pymdownx.snippets
+  - pymdownx.highlight
+  - pymdownx.superfences
 nav:
   - Home: index.md
   - AI Research:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ markdown
 mkdocs
 mkdocs-material
 mkdocs-monorepo-plugin
+pymdown-extensions
 pytest
 flake8
 fastapi


### PR DESCRIPTION
## Summary
- enable `pymdownx.highlight` and `pymdownx.superfences` for improved code block styling
- add `pymdown-extensions` dependency for new Markdown extensions

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_689a87b1bb8c8326927d5ff20ae917d8