### PR TITLE
docs: expand threat model diagram

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -15,9 +15,20 @@ updated: 2025-07-28
 
 ```mermaid
 flowchart LR
-    A[Repository] --> B[CI builds docs]
-    B --> C[Static site generated]
-    C --> D[Deploy to hosting]
+    subgraph Contributors["Trust Boundary: Contributors"]
+        D[Developers]
+        R[Repository]
+    end
+    subgraph Build["Trust Boundary: CI"]
+        C[CI builds docs]
+        S[Static site generated]
+    end
+    subgraph Public["Trust Boundary: Public"]
+        H[Hosting]
+        U[Users]
+    end
+
+    D --> R --> C --> S --> H --> U
 ```
 
 ## Potential Threats


### PR DESCRIPTION
## Summary
- expand threat model mermaid diagram with developers, CI, hosting, and users
- highlight trust boundaries with subgraphs

## Testing
- no tests run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_689a879f03608326812372caf6f8a190