### PR TITLE
docs: add reasoning loop diagrams

### DIFF
--- a/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
+++ b/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
@@ -34,6 +34,19 @@ Code Interpreter), a file retrieval system based on Retrieval-Augmented Generati
 State management is handled through a persistent, stateful conversation object (Thread), which serves as the agent's short-term memory. The system's asynchronous nature, evidenced by a client-side polling mechanism, indicates a backend architecture built on a distributed task queue, designed for handling long-running, computationally intensive operations.
 
 
+The reasoning loop and tool interactions can be visualized as:
+
+```mermaid
+flowchart TD
+    U[User Query] --> R[Agent Reasoning]
+    R --> T{Need Tool?}
+    T -- Yes --> I[Invoke Tool]
+    I --> R
+    T -- No --> A[Draft Response]
+    R --> A
+    A --> O[User Output]
+```
+
 ### 1.2 Legal Viability
 
 A thorough legal review concludes that the re-implementation of a functionally equivalent system is legally permissible under United States law, contingent upon strict adherence to a "clean room" development protocol. The legal strategy is anchored in two key tenets of copyright law. First, the "interoperability" exception of the Digital Millennium Copyright Act (DMCA), specifically 17 U.S.C. § 1201(f), provides a safe harbor for reverse engineering conducted for the sole purpose of enabling different computer programs to exchange and mutually use information. Second, the "fair use" doctrine, as affirmed in landmark federal court cases such as 

--- a/docs/ai-research/reverse-engineering-gpt-o3.md
+++ b/docs/ai-research/reverse-engineering-gpt-o3.md
@@ -31,6 +31,19 @@ An Integrated Retrieval-Augmented Generation (RAG) Pipeline: To ensure factual a
 
 The interaction between these three components—the MoE model as the computational core, the Context Engine as the state manager, and the RAG pipeline as the knowledge source—is what endows the system with its powerful and coherent multi-turn reasoning abilities.
 
+The reasoning loop and tool interactions can be visualized as:
+
+```mermaid
+flowchart TD
+    U[User Query] --> R[Agent Reasoning]
+    R --> T{Need Tool?}
+    T -- Yes --> I[Invoke Tool]
+    I --> R
+    T -- No --> A[Draft Response]
+    R --> A
+    A --> O[User Output]
+```
+
 ### 1.2. Core Capabilities Analysis
 
 The target system's state-of-the-art performance is a direct result of several key architectural and algorithmic choices. The MoE architecture is a strategic solution to the computational challenges of scaling dense Transformer models. By routing each token through only a small subset of specialized "expert" sub-networks, the system achieves a massive parameter count without a proportional increase in inference latency or cost.

--- a/docs/ai-research/reverse-engineering-grok4-heavy.md
+++ b/docs/ai-research/reverse-engineering-grok4-heavy.md
@@ -15,6 +15,19 @@ This report presents a detailed reverse-engineering analysis of the multi-agent 
 
 The system's primary operational modality involves decomposing complex user prompts into a structured graph of sub-tasks. These tasks are then distributed among a pool of specialized agents that work in parallel and collaboratively, sharing information to build upon each other's work. Public statements describe this as being analogous to a "study group" where agents can "solve a problem in parallel and compare answers," a mechanism designed to enhance reasoning and reduce errors. This collaborative approach is credited with significant performance gains, including a reported 40% faster problem-solving time on complex tasks and a reduction in model hallucination through cross-checking.
 
+The reasoning loop and tool interactions can be visualized as:
+
+```mermaid
+flowchart TD
+    U[User Query] --> R[Agent Reasoning]
+    R --> T{Need Tool?}
+    T -- Yes --> I[Invoke Tool]
+    I --> R
+    T -- No --> A[Draft Response]
+    R --> A
+    A --> O[User Output]
+```
+
 ### 1.2 Inferred Architecture at a Glance
 
 The inferred architecture of the Grok 4 Heavy framework is a hierarchical, multi-component system designed for parallelism, specialization, and high-bandwidth coordination. The primary components are:


### PR DESCRIPTION
## Summary
- add Mermaid reasoning loop diagrams near "Overview of Findings" in GPT-o3, ChatGPT agent system, and Grok 4 Heavy reports

## Testing
- `mkdocs serve -f /tmp/mkdocs-nositemap.yml`

------
https://chatgpt.com/codex/tasks/task_e_689a87973a148326bcdd9fd2f6c4b76f