### PR TITLE
Wrap versioning API example lines at 80 chars

### DIFF
--- a/docs/versioning-api.md
+++ b/docs/versioning-api.md
@@ -49,6 +49,10 @@ from versioning.client import DocsClient
 client = DocsClient("http://localhost:8000", token="secrettoken")
 client.create_comment("doc1", "L1", "user1", "Nice!", correlation_id="c-1")
 client.update_document(
-    "doc1", " more text", author_id="agent1", summary="edit", correlation_id="c-2"
+    "doc1",
+    " more text",
+    author_id="agent1",
+    summary="edit",
+    correlation_id="c-2",
 )
 ```


### PR DESCRIPTION
## Summary
- wrap `client.update_document` example arguments to respect 80-character line limit

## Testing
- `npx markdownlint --enable MD013 -- docs/versioning-api.md`


------
https://chatgpt.com/codex/tasks/task_e_689a8796d5a48326aa34828d0e21bf5c