### PR TITLE
docs: add directory site map and navigation links

### DIFF
--- a/docs/img/site-map.svg
+++ b/docs/img/site-map.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" font-family="monospace" font-size="12">
+  <rect width="100%" height="100%" fill="white"/>
+  <text x="10" y="20">docs/</text>
+  <text x="10" y="40">├── ai-research/</text>
+  <text x="10" y="60">├── arduino/</text>
+  <text x="10" y="80">├── terminal-workflow/</text>
+  <text x="10" y="100">├── culture-project/</text>
+  <text x="10" y="120">├── _project-docs/</text>
+  <text x="10" y="140">├── scripts/</text>
+  <text x="10" y="160">├── playbooks/</text>
+  <text x="10" y="180">└── security/</text>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ updated: 2025-07-29
 
 This repository aggregates documentation and research across multiple projects.
 
+**Jump to:** [Quickstart](#quickstart) · [Installing Node Dependencies](#installing-node-dependencies) · [Directory Structure](#directory-structure) · [Research Docs](#research-docs) · [Project Documentation Submodules](#project-documentation-submodules) · [After Cloning](#after-cloning) · [Building the Docs](#building-the-docs) · [Setting Up Git Hooks](#setting-up-git-hooks) · [Invoking the Migration Script](#invoking-the-migration-script) · [Ingesting and Querying Markdown](#ingesting-and-querying-markdown) · [Legal](#legal) · [References](#references)
+
 ## Quickstart
 
 ```bash
@@ -29,18 +31,7 @@ npm install
 
 ## Directory Structure
 
-```mermaid
-flowchart LR
-    docs[docs/]
-    docs --> ai[ai-research/]
-    docs --> arduino[arduino/]
-    docs --> terminal[terminal-workflow/]
-    docs --> culture[culture-project/]
-    docs --> projects[_project-docs/]
-    docs --> scripts[scripts/]
-    docs --> playbooks[playbooks/]
-    docs --> security[security/]
-```
+![Site Map](img/site-map.svg)
 
 - `ai-research/` – AI and machine learning notes
 - `arduino/` – hardware and firmware references


### PR DESCRIPTION
## Summary
- add SVG directory tree diagram
- embed site map image in directory structure section
- add quick navigation links to major sections

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_689b55b10854832686cd81ee669f1a27