### PR TITLE
docs: add part two of Thiel report

### DIFF
--- a/docs/architect-of-disruption-peter-thiel.md
+++ b/docs/architect-of-disruption-peter-thiel.md
@@ -722,3 +722,1047 @@ Ultimately, Peter Thiel represents a new and formidable model of power in the 21
 - conversationswithtyler.com
 - Peter Thiel on Political Theology (Ep. 210) | Conversations with Tyler
 - Opens in a new window
+## Part II: The Thielian Playbook: Deconstructing an Operator and Investor
+
+*Venture Capital Analyst: Strategic Intelligence Desk*  
+*Report Date: August 14, 2025*  
+*Subject: Analysis of Peter Thiel's Operational and Investment Strategies*
+
+### Part I: The Operator as Architect: Building Sovereign Systems
+
+Peter Thiel’s career is marked by two seminal operational roles at PayPal and Palantir Technologies. These ventures are not merely successful businesses; they are foundational case studies in his strategic worldview. They represent deliberate, ideologically driven projects to build technological systems that either circumvent or augment core functions of the modern state. PayPal was conceived as a tool to liberate individuals from the state’s monopoly on currency, while Palantir was created to empower the state’s intelligence and security apparatus. Analyzing these two companies reveals the origins of the strategic motifs—network effects, creative monopoly, and the cultivation of elite networks—that would come to define his investment playbook.
+
+#### 1.1 PayPal: Forging a New Currency and a New Elite
+
+The story of PayPal begins not with a desire to simplify online payments, but with a radical libertarian ambition. In 1998, Peter Thiel, alongside Max Levchin and Luke Nosek, founded Confinity with the explicit mission to create a "new world currency" that would be immune to government control, inflation, and devaluation. Thiel viewed state-issued fiat currency as a primary tool of oppression, and envisioned a global, peer-to-peer payment system as a technological weapon for individual liberation. The initial product, focused on beaming money between PalmPilot handheld devices, was the first step toward this grander vision.
+
+This ambitious project quickly collided with another, led by Elon Musk. His online financial services company, X.com, was pursuing a similar, albeit broader, goal of disrupting the banking industry. By late 1999, Confinity's PayPal service and X.com were locked in a fierce, cash-burning battle for customer growth, particularly among users of the eBay auction platform. Recognizing the mutually destructive nature of their competition, the two companies agreed to a 50-50 merger in March 2000, a strategic necessity that combined Confinity's superior payment technology with X.com's larger capital base.
+
+The merged entity, however, was fraught with internal conflict. Disagreements over branding—Musk favored the all-encompassing X.com, while the Confinity team championed the already popular PayPal name—and technology stacks (Microsoft versus Unix) created deep divisions. This tension culminated in a boardroom coup in September 2000. While Musk was away on his honeymoon, the board removed him and installed Thiel as CEO. Thiel immediately pivoted the company, rebranding it as PayPal in 2001 and narrowing its focus to dominate the online payments niche where it had a clear product-market fit. This strategic discipline was critical. Under Thiel's leadership, PayPal went public in February 2002 and was acquired by eBay just eight months later, in October, for approximately $1.5 billion in stock. At the time of the sale, Thiel's 3.7% stake was valued at $55 million.
+
+The financial windfall, while significant, was arguably the secondary outcome of the PayPal exit. The primary outcome was the creation and validation of the "PayPal Mafia"—the tight-knit group of founders and early employees including Thiel, Musk, Reid Hoffman, David Sacks, and Ken Howery. This was not an accidental byproduct of success but the culmination of a network-building strategy Thiel had honed since his time at Stanford. Just as he had founded The Stanford Review as an ideological "startup" populated by a cadre of like-minded contrarians to challenge the campus monoculture, he built PayPal's core around a high-trust, high-IQ network of outsiders. This group was bonded by the "existential battles" fought against fraud, regulators, and competitors, forging a level of loyalty and operational cohesion that would become legendary. The eBay acquisition did not just make them wealthy; it provided the capital and credibility to deploy this network across Silicon Valley, where they would go on to found or fund a generation of iconic companies, including LinkedIn, YouTube, Yelp, SpaceX, and Facebook. This experience directly shaped Thiel's subsequent investment philosophy, which places a premium on the quality, vision, and cohesion of founder-led teams—a lesson he learned not from a textbook, but by building it himself.
+
+#### 1.2 Palantir Technologies: From State Disruption to State Empowerment
+
+If PayPal was Thiel's libertarian project to weaken the state, Palantir Technologies represents his post-9/11 pivot to empower it. Founded in 2003 and named after the "all-seeing stones" from J.R.R. Tolkien's *The Lord of the Rings*, Palantir was conceived as a private-sector solution to the government's most pressing national security challenge: making sense of vast, disconnected datasets to identify and neutralize terrorist threats. Thiel's role as co-founder and Chairman of the Board since its inception underscores his deep involvement in the company's strategic direction. The company's mission reflects a profound shift in Thiel's thinking, aligning with the arguments he laid out in his 2004 essay "The Straussian Moment," which called for a more robust response to existential threats.
+
+Palantir's trajectory was irrevocably shaped by a single, crucial early investment. While most venture capitalists were wary of its niche, government-focused model, the CIA's venture capital arm, In-Q-Tel, invested approximately $2 million in the company starting in 2005. This funding was catalytic, providing not just essential capital but, more importantly, unparalleled credibility and direct access to the U.S. intelligence community. This established a pattern of deep government partnership that remains the bedrock of Palantir's business, creating a powerful moat against potential competitors.
+
+Palantir's strategy is built on two primary software platforms that serve distinct markets:
+
+* **Palantir Gotham:** The company's original offering, Gotham is an AI-ready operating system designed for the defense, intelligence, and law enforcement sectors. It integrates disparate data sources—from signals intelligence to informant reports—to create a unified analytical environment, supporting everything from counter-terrorism operations and military mission planning to controversial predictive policing systems.
+* **Palantir Foundry:** Developed to expand into the private sector, Foundry serves as a central operating system for large commercial enterprises. It allows companies like Airbus, Merck KGaA, and Ferrari to integrate and analyze complex data for use cases ranging from supply chain optimization and manufacturing efficiency to financial fraud detection.
+
+Initially dependent almost entirely on government contracts, Palantir has strategically pushed to grow its commercial business with Foundry, aiming to diversify its revenue streams and mitigate political risks. The company went public via a direct listing in September 2020 at a valuation near $21 billion, a move that brought greater transparency to its government-heavy business model.
+
+Palantir's success is a masterclass in applying the "creative monopoly" thesis to the defense and intelligence market. Thiel's core belief is that "competition is for losers" and that the goal of any great business is to build a monopoly. Palantir achieved this not in a consumer market, but in the highly regulated, high-barrier world of government contracting. It identified a critical problem that government agencies could not solve on their own—integrating siloed, complex data—and built a unique, deeply embedded technological solution. The early and intimate partnership with the CIA via In-Q-Tel gave it a decisive first-mover advantage in a market where trust and security clearances are paramount. The nature of its work and the high switching costs associated with its integrated platforms created an almost insurmountable competitive moat. Palantir is therefore not just another defense contractor; it is a durable, state-sanctioned monopoly for a specific and critical class of data analysis. This playbook—building a proprietary technology stack to become an indispensable partner to the government—would become a cornerstone of Founders Fund's later investments, most notably in Anduril.
+
+### Part II: The Investor as Sovereign: An Arsenal of Capital and Ideas
+
+Following the sale of PayPal, Peter Thiel transitioned from a full-time operator to one of Silicon Valley's most influential and philosophically driven investors. His activities are not confined to a single entity but are spread across a constellation of funds, each with a distinct thesis, yet all reflecting his core strategic worldview. This section deconstructs the primary vehicles through which he deploys capital and extracts the recurring motifs that constitute his investment playbook.
+
+#### 2.1 An Arsenal of Capital: The Fund Vehicles
+
+Thiel's investment empire is composed of several distinct firms, each targeting different stages, sectors, and geographies.
+
+**Founders Fund (2005-Present): The Contrarian Flagship**
+
+Co-founded in 2005 with PayPal alumni Ken Howery and Luke Nosek, Founders Fund is the primary vehicle for Thiel's venture capital strategy. Its investment thesis, articulated in a 2017 manifesto, is a direct rebuke of the prevailing VC model. The firm explicitly rejects incrementalism, which it argues "broke venture capital" by focusing on "features, widgets, [and] irrelevances" instead of paradigm-shifting breakthroughs. Founders Fund seeks to back visionary founders building "transformational technologies" that move the world from "zero to one." The firm's philosophy is to make "smart contrarian" bets on audacious ideas, believing that companies pursuing radical change are paradoxically more likely to succeed due to their ability to create strong technological moats and attract the world's best talent. Its portfolio is a testament to this thesis, including being the first institutional investor in SpaceX and Palantir, and an early backer of Facebook, Stripe, Airbnb, and Anduril, with a clear orientation towards "hard tech," aerospace, AI, and defense.
+
+**Clarium Capital (2002–c. 2011): A Case Study in Macro Conviction**
+
+Founded immediately after the PayPal sale, Clarium Capital was Thiel's foray into the world of global macro hedge funds. Its strategy was to make high-conviction, directional bets on fundamental economic themes that were underappreciated by the broader market. Clarium achieved spectacular success with a massive bet on rising oil prices, driven by a "peak oil" thesis, which saw its assets under management swell from a few million to nearly $8 billion by mid-2008. However, the fund's fortunes reversed dramatically during the global financial crisis. A series of ill-timed bets, most notably a large position against the U.S. dollar just as it became the world's safe-haven currency, led to catastrophic losses. The fund was down 25% in 2009 and 23% in 2010, and after massive client redemptions, its assets plummeted to around $350 million by 2011, at which point it effectively wound down its external operations. The experience at Clarium appears to have reinforced Thiel's preference for long-term, illiquid venture investments, where his thesis-driven, contrarian style is better suited than to the volatile timing of public markets.
+
+**Valar Ventures & Mithril Capital: Specialized Arms**
+
+To pursue more targeted strategies, Thiel co-founded two other firms:
+
+* **Valar Ventures (2010-Present):** Co-founded with Andrew McCormack and James Fitzgerald, Valar Ventures is built on the thesis that transformative technology companies are increasingly being started outside of Silicon Valley. The firm focuses specifically on early-stage financial technology (fintech) startups, with a global mandate that has led to significant investments in Europe and North America. Its portfolio includes international successes like Wise (formerly TransferWise), the German neobank N26, and the micro-investing app Stash, validating its belief in emerging tech hubs.
+* **Mithril Capital (2012-Present):** Co-founded with Ajay Royan, Mithril Capital is a growth-stage fund that targets technology companies in "industries long overdue for change." Its mission is to partner with teams that are navigating critical inflection points as they scale. This focus has led to investments in capital-intensive and scientifically complex sectors like biotechnology (Fractyl Health), robotics (GreyOrange), and fusion energy (Helion), areas often overlooked by more conventional growth funds.
+
+#### 2.2 The Core Playbook: Recurring Strategic Motifs
+
+Across his various investment vehicles, a consistent set of strategic principles emerges, forming a coherent and powerful playbook.
+
+**The Pursuit of "Creative Monopoly"**
+
+The cornerstone of Thiel's philosophy is that "competition is for losers." He argues that in a competitive market, profits are driven to zero, leaving no resources for long-term planning or ambitious innovation. The goal, therefore, is not to compete but to create a "creative monopoly"—a business so unique and superior in its category that it has no direct rivals. This allows a company to generate durable, long-term profits, which are the lifeblood of innovation. The path to monopoly, according to Thiel, is to "start small and monopolize." A startup should identify and dominate a small, specific niche market where it can establish a strong foothold before gradually expanding into adjacent, broader markets. Facebook's initial domination of the Harvard student network before expanding to other colleges is a canonical example of this strategy in action.
+
+**Portfolio Construction and the Power Law**
+
+Thiel's portfolio strategy is a direct application of the power law of venture capital, which posits that the returns in a VC portfolio are not normally distributed but are instead dominated by a very small number of outlier investments. He famously stated, "The biggest secret in venture capital is that the best investment in a successful fund equals or outperforms the entire rest of the fund combined." This leads to two clear rules for investing. First, "only invest in companies that have the potential to return the value of the entire fund." Second, because that first rule is so restrictive, there can be no other rules. This philosophy mandates a strategy of making concentrated, high-conviction bets on companies with truly asymmetric upside, rather than building a diversified portfolio of moderately ambitious, "safe" companies that are unlikely to produce grand-slam returns.
+
+**Network Effects as a Moat**
+
+A key characteristic Thiel seeks in potential investments is strong network effects, where a product or service becomes more valuable to each user as more people join the network. This is distinct from mere virality, which is a growth mechanism; network effects are a value-creation mechanism that builds a powerful competitive moat. PayPal is a prime example: the service is useless to the first user, but its value grows exponentially as more people and merchants join, making it the default payment system and creating extremely high switching costs for users embedded in the ecosystem. Facebook is the quintessential network effects business, where the entire value proposition is predicated on the presence of one's social graph on the platform.
+
+**The State as Counterparty: The Defense-Tech Tilt**
+
+A clear evolution in Thiel's strategy, particularly through Founders Fund, is an increasing focus on companies whose primary customer is the U.S. government and its allies. This began with his operational role at Palantir and has been institutionalized through massive, early investments in companies like SpaceX (reusable rockets for NASA and DoD missions) and Anduril Industries (autonomous defense systems). This strategy applies the "creative monopoly" framework to the defense industrial base, an industry characterized by long sales cycles, high regulatory barriers, and enormous contracts. By backing startups with superior, software-defined technology, the goal is to displace legacy prime contractors and build new, durable monopolies within the national security apparatus.
+
+The 2017 investment in Anduril Industries represents the ultimate synthesis of the entire Thielian playbook. It is a "zero to one" company founded to disrupt the stagnant defense industry with a software-first approach to military hardware. It is a quintessential power-law bet, as success in the multi-trillion-dollar defense market would easily return the entire fund many times over. The investment was deeply contrarian, made at a time when most of Silicon Valley was averse to building weapons systems. The company's structure embodies the "PayPal Mafia" network model: it was co-founded by a Founders Fund partner, Trae Stephens, and seeded by the fund, demonstrating a tight integration of capital and talent. Finally, with the U.S. Department of Defense as its primary customer, Anduril is the most explicit and ambitious execution of the defense-tech tilt. It is not merely another portfolio company; it is the most complete expression of Thiel's entire strategic framework in a single entity, marking the culmination of his evolution from disrupting the state to arming it.
+
+### Part III: Portfolio Analysis and Synthesis
+
+An examination of Peter Thiel's operational history and investment portfolio provides concrete evidence of the strategic principles that have guided his career. The following tables and analysis synthesize this data, illustrating the application and evolution of his playbook from PayPal to his current role at the helm of Founders Fund.
+
+#### 3.1 Company Dossier and Investment Matrix
+
+The following tables provide a structured overview of Thiel's most significant operational roles and investments, quantifying their outcomes and mapping them to his core strategic motifs.
+
+**Table 1: Company Dossier: Peter Thiel's Operational Roles**
+
+| Entity | Founded | Thiel's Role(s) | Initial Mission | Key Strategic Pivot/Event | Notable Metrics/Outcome | Key Sources |
+| --- | --- | --- | --- | --- | --- | --- |
+| Confinity / PayPal | 1998 | Co-Founder, Chairman, CEO | Create a new digital currency free from government control and inflation. | March 2000 merger with X.com; Thiel becomes CEO in Sept. 2000; pivots to focus exclusively on dominating online payments on eBay. | IPO in Feb. 2002; Acquired by eBay for $1.5 billion in Oct. 2002. Thiel's 3.7% stake was worth ~$55M. Forged the "PayPal Mafia" network. | — |
+| Palantir Technologies | 2003 | Co-Founder, Chairman | Provide data analysis software to U.S. intelligence agencies to combat terrorism, leveraging lessons from PayPal's anti-fraud tech. | Expansion from government-only (Gotham platform) to the commercial sector (Foundry platform) in the 2010s. | Received early funding from CIA's In-Q-Tel. Went public via Direct Listing in 2020 at a ~$21B valuation. Key contractor for DoD, CIA, DHS, and NHS (UK). | — |
+
+**Table 2: Iconic Investment Matrix: Personal & Founders Fund**
+
+| Company | Sector | Investment Vehicle(s) | Stage/Date of First Investment | Strategic Motif | Notable Outcome/Status | Key Sources |
+| --- | --- | --- | --- | --- | --- | --- |
+| Facebook | Social Media | Personal | Seed / Aug 2004 | Network Effects, Creative Monopoly | First outside investor ($500k for 10.2%). Exited majority of stake for >$1B. | — |
+| SpaceX | Aerospace / Defense | Founders Fund | Series A / Aug 2008 | Transformational Tech, Defense-Tech Tilt, Creative Monopoly | First institutional investor. Company valued at ~$350B (2025). | — |
+| Anduril Industries | Defense Tech | Founders Fund | Seed / 2017 | Defense-Tech Tilt, Creative Monopoly, Power Law Bet | Led multiple rounds. Company valued at $30.5B (2025). | — |
+| Stripe | Fintech | Founders Fund | Series I / 2023 (Lead) | Payments Infrastructure, Creative Monopoly | Valued at $65B (2024). | — |
+| Airbnb | Consumer Internet | Founders Fund | Series C / 2013 | Network Effects, Marketplace Monopoly | IPO in 2020 with valuation over $100B. | — |
+| LinkedIn | Professional Network | Personal / Founders Fund | Early | Network Effects | Acquired by Microsoft for $26.2B in 2016. | — |
+| Yelp | Consumer Internet | Personal / Founders Fund | Early | Network Effects, Marketplace | IPO in 2012. | — |
+| Wise (TransferWise) | Fintech | Valar Ventures | Series A / 2013 | Global Fintech, Disruption | Publicly listed in London (2021). | — |
+| N26 | Fintech | Valar Ventures | Series A / 2016 | Global Fintech, Disruption | Leading European neobank. | — |
+| Helion | Energy | Mithril Capital | Growth | Transformational Tech, Power Law Bet | Nuclear fusion technology. | — |
+| DeepMind | Artificial Intelligence | Founders Fund | Early | Transformational Tech | Acquired by Google in 2014. | — |
+| Ramp | Fintech | Founders Fund | Growth | B2B Disruption, Creative Monopoly | Corporate card and finance automation. | — |
+| OpenAI | Artificial Intelligence | Founders Fund | Growth | Transformational Tech, Power Law Bet | Leading AI research and deployment company. | — |
+
+#### 3.2 Synthesis: The Evolution of a Worldview in Practice
+
+Peter Thiel's career as an operator and investor reveals a clear and coherent strategic evolution over three distinct phases. His journey is not one of random successes but of a methodical application and refinement of a core philosophical worldview, moving from disrupting the state to ultimately becoming one of its most crucial technological architects.
+
+**The Early Phase (1998-2004): The Libertarian Disruptor**
+
+This period is defined by the founding and scaling of PayPal. The strategy was explicitly anti-statist, aiming to use technology to create systems outside of government control, particularly its monopoly on currency. The core strategic motifs were harnessing network effects to build an inescapable payment ecosystem and cultivating a high-trust, ideologically aligned network—the "PayPal Mafia"—capable of winning a brutal market war. The successful $1.5 billion exit to eBay validated this model and provided the capital and human network to launch the next phase of his career.
+
+**The Transitional Phase (2004-2012): The Pragmatic Sovereign**
+
+This phase begins with the simultaneous founding of Palantir and Founders Fund, alongside his iconic seed investment in Facebook. It marks a critical evolution from pure anti-statism to a more complex, pragmatic understanding of power. He recognized that technology could not only circumvent the state but also empower it, leading to the creation of Palantir as a tool for national security. His Facebook investment was a masterstroke in identifying the power of network effects to create a new kind of "creative monopoly" in the digital realm. During this time, his investment playbook solidified around the twin pillars of seeking monopolies and making concentrated "power law" bets. The dramatic failure of his global macro fund, Clarium Capital, which lost billions on ill-timed currency and commodity bets, served as a crucial lesson, reinforcing his focus on long-term, illiquid venture capital where his thesis-driven, contrarian approach could be applied without the punishing whims of market timing.
+
+**The Mature Phase (2013-Present): The Kingmaker and Defense Industrialist**
+
+In his current phase, Thiel's strategy has fully embraced the defense-tech tilt, viewing the U.S. government and its allies as the ultimate customer. The major investments by Founders Fund into SpaceX and, most significantly, Anduril Industries, demonstrate a clear thesis: the next great technological monopolies will be built within the American defense industrial base. His investment vehicles are mature and specialized, and his political activity—backing disruptive candidates like Donald Trump and his protégé J.D. Vance—has become an explicit extension of his investment strategy. He seeks to fund political "founders" who can act as a "wrecking ball" to clear the regulatory and political path for his technological vision. The Anduril investment is the capstone of this era, a perfect synthesis of every element of his playbook: a contrarian, power-law bet on a founder-led team aiming to build a creative monopoly by becoming the software-defined prime contractor for the Pentagon. The evolution is complete: from fighting the state, to advising the state, to building the state's future arsenal.
+
+### Sources used in the report
+
+Thiel: Biography and Influences Analysis
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+capital-commerce.com
+Innovation, Expansion, and Independence: The PayPal Saga ...
+Opens in a new window
+
+quartr.com
+The PayPal Story: Online Payment Pioneers - Quartr
+Opens in a new window
+
+yuobserver.org
+PayPal's Origins and the Modern Silicon Valley - The YU Observer
+Opens in a new window
+
+mentorist.app
+The Founders: The Story of Paypal and the Entrepreneurs Who ...
+Opens in a new window
+
+en.wikipedia.org
+X.com (bank) - Wikipedia
+Opens in a new window
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+mentorist.app
+The Founders: The Story of Paypal and the Entrepreneurs Who ...
+Opens in a new window
+
+capital-commerce.com
+Innovation, Expansion, and Independence: The PayPal Saga ...
+Opens in a new window
+
+quartr.com
+The PayPal Story: Online Payment Pioneers - Quartr
+Opens in a new window
+
+mentorist.app
+The Founders: The Story of Paypal and the Entrepreneurs Who ...
+Opens in a new window
+
+medium.com
+The Musk Revolution: How X.com, PayPal, and a $1.5 Billion Exit ...
+Opens in a new window
+
+corporate.findlaw.com
+Agreement and Plan of Merger - X.com Corp. and Confinity Inc. - Corporate Counsel
+Opens in a new window
+
+en.wikipedia.org
+X.com (bank) - Wikipedia
+Opens in a new window
+
+medium.com
+The Musk Revolution: How X.com, PayPal, and a $1.5 Billion Exit ...
+Opens in a new window
+
+en.wikipedia.org
+X.com (bank) - Wikipedia
+Opens in a new window
+
+medium.com
+The Musk Revolution: How X.com, PayPal, and a $1.5 Billion Exit ...
+Opens in a new window
+
+medium.com
+1998: Max Levchin, Peter Thiel, and Luke Nosek founded Confinity, which would later develop the PayPal service. 1999: Elon Musk co-founded X.com, an online banking company. 2000 - Medium
+Opens in a new window
+
+capital-commerce.com
+Innovation, Expansion, and Independence: The PayPal Saga ...
+Opens in a new window
+
+yuobserver.org
+PayPal's Origins and the Modern Silicon Valley - The YU Observer
+Opens in a new window
+
+medium.com
+The Musk Revolution: How X.com, PayPal, and a $1.5 Billion Exit ...
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+en.wikipedia.org
+PayPal - Wikipedia
+Opens in a new window
+
+sec.gov
+eBay Completes PayPal Acquisition - SEC.gov
+Opens in a new window
+
+cnet.com
+eBay picks up PayPal for $1.5 billion - CNET
+Opens in a new window
+
+britannica.com
+PayPal | History, Description, & Facts | Britannica Money
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+mastersofscale.com
+Peter Thiel on Masters of Scale
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+corporate.findlaw.com
+Agreement and Plan of Merger - X.com Corp. and Confinity Inc. - Corporate Counsel
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+Thiel: Biography and Influences Analysis
+
+mastersofscale.com
+Peter Thiel on Masters of Scale
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+britannica.com
+Peter Thiel | Biography & Facts | Britannica Money
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+investors.palantir.com
+Board of Directors - Palantir Investor Relations
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+bytebridge.medium.com
+Palantir Technologies: Comprehensive Analysis and Market ...
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+builtin.com
+What Is Palantir? The Company Behind Government AI Tools | Built In
+Opens in a new window
+
+medium.com
+Palantir's Growth Story: How the Magic of Data Analysis Is Changing ...
+Opens in a new window
+
+freetrade.io
+Palantir, the CIA-funded tech firm, is going public - Freetrade
+Opens in a new window
+
+reddit.com
+Palantir's History + Gotham (Part 2 DD) : r/PLTR - Reddit
+Opens in a new window
+
+medium.com
+Palantir's Growth Story: How the Magic of Data Analysis Is Changing ...
+Opens in a new window
+
+freetrade.io
+Palantir, the CIA-funded tech firm, is going public - Freetrade
+Opens in a new window
+
+palantir.com
+Palantir Platforms
+Opens in a new window
+
+en.wikipedia.org
+Palantir Technologies - Wikipedia
+Opens in a new window
+
+bytebridge.medium.com
+Palantir Technologies: Comprehensive Analysis and Market ...
+Opens in a new window
+
+builtin.com
+What Is Palantir? The Company Behind Government AI Tools | Built In
+Opens in a new window
+
+en.wikipedia.org
+Palantir Technologies - Wikipedia
+Opens in a new window
+
+reddit.com
+What does Palantir do? : r/Palantir_Investors - Reddit
+Opens in a new window
+
+palantir.com
+Gotham | Palantir
+Opens in a new window
+
+bytebridge.medium.com
+Palantir Technologies: Comprehensive Analysis and Market ...
+Opens in a new window
+
+en.wikipedia.org
+Palantir Technologies - Wikipedia
+Opens in a new window
+
+reddit.com
+What does Palantir do? : r/Palantir_Investors - Reddit
+Opens in a new window
+
+designgurus.io
+What are Palantir products? - Design Gurus
+Opens in a new window
+
+businessmodelanalyst.com
+Palantir Business Model
+Opens in a new window
+
+graniteshares.com
+What Does Palantir Technologies Do? | GraniteShares
+Opens in a new window
+
+bytebridge.medium.com
+Palantir Technologies: Comprehensive Analysis and Market ...
+Opens in a new window
+
+freetrade.io
+Palantir, the CIA-funded tech firm, is going public - Freetrade
+Opens in a new window
+
+builtin.com
+What Is Palantir? The Company Behind Government AI Tools | Built In
+Opens in a new window
+
+medium.com
+Palantir's Growth Story: How the Magic of Data Analysis Is Changing ...
+Opens in a new window
+
+forbes.com
+Peter Thiel - Forbes
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+capitaly.vc
+Peter Thiel's Investment Strategy: 5 Lessons from a Billionaire ...
+Opens in a new window
+
+startupbell.net
+The Smartest Monopoly Strategy? Never Admit You Are One by Peter Thiel - Startup Bell
+Opens in a new window
+
+bytebridge.medium.com
+Palantir Technologies: Comprehensive Analysis and Market ...
+Opens in a new window
+
+blog.palantir.com
+Palantir is Not a Data Company (Palantir Explained, #1)
+Opens in a new window
+
+freetrade.io
+Palantir, the CIA-funded tech firm, is going public - Freetrade
+Opens in a new window
+
+reddit.com
+Palantir's History + Gotham (Part 2 DD) : r/PLTR - Reddit
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+en.wikipedia.org
+Founders Fund - Wikipedia
+Opens in a new window
+
+foundersfund.com
+What happened to the future? – Founders Fund
+Opens in a new window
+
+foundersfund.com
+What happened to the future? – Founders Fund
+Opens in a new window
+
+foundersfund.com
+Peter Thiel - Founders Fund
+Opens in a new window
+
+fs.blog
+Eight Things I Learned from Peter Thiel's Zero To One - Farnam Street
+Opens in a new window
+
+firstround.com
+First Round: Home
+Opens in a new window
+
+medium.com
+Contrarian Cycles: Uncovering the Anti-Consensus Advantage in Venture Capital. Why I Wrote This Book — And Why You Should Read It | by Ahmad Takatkah | VCpreneur | Medium
+Opens in a new window
+
+gsb.stanford.edu
+Founders Fund: Every Moment Happens Once | Stanford Graduate ...
+Opens in a new window
+
+en.wikipedia.org
+Founders Fund - Wikipedia
+Opens in a new window
+
+foundersfund.com
+Founders Fund
+Opens in a new window
+
+foundersfund.com
+Founders Fund
+Opens in a new window
+
+pitchbook.com
+Founders Fund investment portfolio | PitchBook
+Opens in a new window
+
+everythingstartups.com
+Founders Fund - Everything Startup - New VC Funds
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+en.wikipedia.org
+Clarium Capital - Wikipedia
+Opens in a new window
+
+pitchbook.com
+pitchbook.com
+Opens in a new window
+
+pitchbook.com
+Clarium Capital Management Profile: Commitments & Mandates | PitchBook
+Opens in a new window
+
+en.wikipedia.org
+Clarium Capital - Wikipedia
+Opens in a new window
+
+hedgefundinsight.org
+The Limits to Fundamental Conviction – Clarium Capital | Hedge Fund Insight
+Opens in a new window
+
+news.ycombinator.com
+Don't forget about Clarium Capital - at it's peak $8b under management - but the... | Hacker News
+Opens in a new window
+
+en.wikipedia.org
+Clarium Capital - Wikipedia
+Opens in a new window
+
+forbes.com
+Life After Facebook - Forbes
+Opens in a new window
+
+en.wikipedia.org
+Clarium Capital - Wikipedia
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+bankingembedded.com
+Valar Ventures | Banking Embedded
+Opens in a new window
+
+en.wikipedia.org
+Valar Ventures - Wikipedia
+Opens in a new window
+
+preqin.com
+Valar Private Equity Firm Profile - Preqin
+Opens in a new window
+
+pitchbook.com
+Valar Ventures investment portfolio | PitchBook
+Opens in a new window
+
+en.wikipedia.org
+Valar Ventures - Wikipedia
+Opens in a new window
+
+valar.com
+Valar Ventures
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+mithril.com
+Our Companies - Mithril Capital
+Opens in a new window
+
+mithril.com
+Discover our approach - Mithril Capital
+Opens in a new window
+
+en.wikipedia.org
+Mithril Capital - Wikipedia
+Opens in a new window
+
+mithril.com
+Our Companies - Mithril Capital
+Opens in a new window
+
+pitchbook.com
+Mithril Capital Management investment portfolio - PitchBook
+Opens in a new window
+
+tracxn.com
+Mithril - 2025 Investor Profile, Portfolio & Team - Tracxn
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+startupbell.net
+The Smartest Monopoly Strategy? Never Admit You Are One by Peter Thiel - Startup Bell
+Opens in a new window
+
+netzpolitik.org
+Peter Thiel: Monopoly's fiercest advocate - netzpolitik.org
+Opens in a new window
+
+capitaly.vc
+Peter Thiel's Investment Strategy: 5 Lessons from a Billionaire ...
+Opens in a new window
+
+davidcummings.org
+Creative Monopolies on the Mind - David Cummings on Startups
+Opens in a new window
+
+truthonthemarket.com
+Peter Thiel on the Virtues of Monopoly - Truth on the Market
+Opens in a new window
+
+startupbell.net
+The Smartest Monopoly Strategy? Never Admit You Are One by Peter Thiel - Startup Bell
+Opens in a new window
+
+medium.com
+Zero to One · Peter Thiel · 2015 - Medium
+Opens in a new window
+
+medium.com
+Peter Thiel's 4 Essential Rules for Creating a Dominant Company | by Joe Antenucci
+Opens in a new window
+
+bipventures.vc
+Explainer: What is the Venture Capital Power Law
+Opens in a new window
+
+bipevergreenfunds.com
+Explainer: Understanding the Venture Capital Power Law
+Opens in a new window
+
+medium.com
+How to Win in Venture Capital: Focus on the Fat Tails | by The ...
+Opens in a new window
+
+christopherwink.com
+The Power Law: Venture Capital and the Making of the New Future - Christopher Wink
+Opens in a new window
+
+medium.com
+How to Win in Venture Capital: Focus on the Fat Tails | by The ...
+Opens in a new window
+
+goodreads.com
+Quote by Peter Thiel: “The power law means that differences between co...” - Goodreads
+Opens in a new window
+
+youtube.com
+Ep 476 | Peter Thiel's "Power Law" and How to Use it to Your Advantage - YouTube
+Opens in a new window
+
+medium.com
+Zero to One · Peter Thiel · 2015 - Medium
+Opens in a new window
+
+thevcfactory.com
+Network Effects: What VCs Really Look For (With Case Studies) - The VC Factory
+Opens in a new window
+
+youexec.com
+How does the theory of network effects in Zero to One challenge e - You Exec
+Opens in a new window
+
+medium.com
+Peter Thiel's 4 Essential Rules for Creating a Dominant Company | by Joe Antenucci
+Opens in a new window
+
+youexec.com
+How does the theory of network effects in Zero to One challenge e - You Exec
+Opens in a new window
+
+vermillionprivatewealth.com
+The Facebook Phenomenon: Fueled By Network Effects - Vermillion Private Wealth
+Opens in a new window
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+foundersfund.com
+What happened to the future? – Founders Fund
+Opens in a new window
+
+citybiz.co
+Peter Thiel's Founders Fund Led Whopping $2.5 Billion Round for Defense Tech Startup Anduril | citybiz
+Opens in a new window
+
+en.wikipedia.org
+Anduril Industries - Wikipedia
+Opens in a new window
+
+en.wikipedia.org
+Anduril Industries - Wikipedia
+Opens in a new window
+
+citybiz.co
+Peter Thiel's Founders Fund Led Whopping $2.5 Billion Round for Defense Tech Startup Anduril | citybiz
+Opens in a new window
+
+privateequitywire.co.uk
+Founders Fund leads $2.5bn Anduril funding round as valuation doubles to $30.5bn
+Opens in a new window
+
+Thiel: Biography and Influences Analysis
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+quartr.com
+The PayPal Story: Online Payment Pioneers - Quartr
+Opens in a new window
+
+yuobserver.org
+PayPal's Origins and the Modern Silicon Valley - The YU Observer
+Opens in a new window
+
+sec.gov
+eBay Completes PayPal Acquisition - SEC.gov
+Opens in a new window
+
+en.wikipedia.org
+en.wikipedia.org
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+investors.palantir.com
+Board of Directors - Palantir Investor Relations
+Opens in a new window
+
+bytebridge.medium.com
+Palantir Technologies: Comprehensive Analysis and Market ...
+Opens in a new window
+
+builtin.com
+What Is Palantir? The Company Behind Government AI Tools | Built In
+Opens in a new window
+
+en.wikipedia.org
+Peter Thiel - Wikipedia
+Opens in a new window
+
+forbes.com
+Life After Facebook - Forbes
+Opens in a new window
+
+startuparchive.org
+Peter Thiel explains how he became the first investor in Facebook
+Opens in a new window
+
+en.wikipedia.org
+Founders Fund - Wikipedia
+Opens in a new window
+
+foundersfund.com
+What happened to the future? – Founders Fund
+Opens in a new window
+
+foundersfund.com
+SpaceX - Founders Fund
+Opens in a new window
+
+tsginvest.com
+Invest in SpaceX: Private Investment Guide
+Opens in a new window
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+citybiz.co
+Peter Thiel's Founders Fund Led Whopping $2.5 Billion Round for Defense Tech Startup Anduril | citybiz
+Opens in a new window
+
+en.wikipedia.org
+Anduril Industries - Wikipedia
+Opens in a new window
+
+cosmico.org
+Anduril raises $2.5B at $30.5B valuation, led by Founders Fund - Cosmico
+Opens in a new window
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+en.wikipedia.org
+Founders Fund - Wikipedia
+Opens in a new window
+
+foundersfund.com
+Stripe - Founders Fund
+Opens in a new window
+
+clay.com
+How Much Did Stripe Raise? Funding & Key Investors - Clay
+Opens in a new window
+
+finovate.com
+Stripe Lands $6.5 Billion in Funding at $50 Billion Valuation - Finovate
+Opens in a new window
+
+en.wikipedia.org
+Founders Fund - Wikipedia
+Opens in a new window
+
+en.wikipedia.org
+Airbnb - Wikipedia
+Opens in a new window
+
+foundersfund.com
+Airbnb - Founders Fund
+Opens in a new window
+
+eqvista.com
+Airbnb IPO: All you need to know - Eqvista
+Opens in a new window
+
+foundersfund.com
+Peter Thiel - Founders Fund
+Opens in a new window
+
+smu.edu
+Peter Thiel - SMU
+Opens in a new window
+
+en.wikipedia.org
+Valar Ventures - Wikipedia
+Opens in a new window
+
+en.wikipedia.org
+Founders Fund - Wikipedia
+Opens in a new window
+
+quora.com
+Why did Peter Thiel invest in Facebook and not Google? - Quora
+Opens in a new window
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+en.wikipedia.org
+Founders Fund - Wikipedia
+Opens in a new window
+
+spokesman.com
+'PayPal Mafia': How power trio of Musk, Thiel and Sacks rode Silicon Valley startup success into Trump White House - The Spokesman-Review
+Opens in a new window
+
+pitchbook.com
+Founders Fund investment portfolio | PitchBook
+Opens in a new window
+
+Sources read but not used in the report
+
+en.wikipedia.org
+Confinity - Wikipedia
+Opens in a new window
+
+independent.org
+Peter A. Thiel - Independent Institute
+Opens in a new window
+
+binance.com
+1. PayPal (formerly Confinity and X.com) Who came up with t | BTOcoin on Binance Square
+Opens in a new window
+
+en.wikipedia.org
+eBay - Wikipedia
+Opens in a new window
+
+fintechmagazine.com
+The Story of PayPal: The World's Most Valuable Fintech Firm
+Opens in a new window
+
+en.wikipedia.org
+In-Q-Tel - Wikipedia
+Opens in a new window
+
+blog.palantir.com
+From Last Supper to First Breakfast: The Defense Tech Ecosystem - Palantir Blog
+Opens in a new window
+
+theguardian.com
+Peter Thiel's Palantir poses a grave threat to Americans | Robert Reich | The Guardian
+Opens in a new window
+
+reddit.com
+Palantir CEO says working at his $430 billion software company is better than a degree from Harvard or Yale: 'No one cares about the other stuff' : r/technology - Reddit
+Opens in a new window
+
+palantir.com
+Palantir Offerings
+Opens in a new window
+
+bstrategyhub.com
+Deconstructing Palantir Business Model
+Opens in a new window
+
+reddit.com
+Palantir's Money-Printing Strategy: Not Customers, But Industries : r/PLTR - Reddit
+Opens in a new window
+
+massinvestordatabase.com
+Mithril Capital Management - Massinvestor Venture Capital and Private Equity Database
+Opens in a new window
+
+vc-mapping.gilion.com
+Mithril Capital Management – Info, Investments & Portfolio - VC Mapping
+Opens in a new window
+
+hustlefund.vc
+Evolving your fund's investment thesis - Hustle Fund
+Opens in a new window
+
+waveup.com
+Ultimate Guide on Investment Thesis For Investors and Founders - Waveup
+Opens in a new window
+
+enlyft.com
+Clarium Capital Technologies Stack and Company Profile - Enlyft
+Opens in a new window
+
+reddit.com
+TIL that the first major investor in Facebook, Peter Thiel, made over $1 Billion from his original $500000 investment by selling his shares. A 200000% return on his investment. - Reddit
+Opens in a new window
+
+carta.com
+How to Write an Investment Thesis - Carta
+Opens in a new window
+
+northzone.com
+Clarium - Northzone multi-stage venture capital fund
+Opens in a new window
+
+privateequityinternational.com
+Valar Ventures | Institution Profile - Private Equity International
+Opens in a new window
+
+fintel.io
+Founders Fund Growth Management, LLC Portfolio Holdings - Fintel
+Opens in a new window
+
+rootdata.com
+Founders fund Overview: Portfolio, Team and News - RootData
+Opens in a new window
+
+app.dealroom.co
+Founders Fund investor portfolio, rounds & team | Dealroom.co
+Opens in a new window
+
+hedgefollow.com
+Founders Fund V Management LLC 13F Portfolio - HedgeFollow
+Opens in a new window
+
+contrarianthinking.co
+Our 2023 Annual Investment Letter - Contrarian Thinking
+Opens in a new window
+
+buzzacott.co.uk
+Four funding lessons from the founding of Facebook - Buzzacott
+Opens in a new window
+
+hello-tomorrow.org
+The Deep Tech Investment Paradox: a call to redesign the investor model - Hello Tomorrow
+Opens in a new window
+
+alexanderjarvis.com
+Nine Critical Lessons from Peter Thiel by Joe Lonsdale - AlexanderJarvis.com
+Opens in a new window
+
+observer.com
+Peter Thiel Puts Tons of Money Where His Mouth Is - Observer
+Opens in a new window
+
+opensecrets.org
+Clarium Capital Management Profile: Summary - OpenSecrets
+Opens in a new window
+
+fintechweekly.com
+Anduril Secures $2.5B in Oversubscribed Round, Valuation Soars to $30.5B
+Opens in a new window
+
+wellfound.com
+SpaceX Funding Information - Wellfound
+Opens in a new window
+
+youtube.com
+Mega Funding Round Makes Anduril Cofounder A Billionaire - YouTube
+Opens in a new window
+
+chicagobooth.edu
+Peter Thiel on Entrepreneurship: Three Contrarian Ideas for Going from 'Zero to One'
+Opens in a new window
+
+openviewpartners.com
+6 Contrarian Business Views from Peter Thiel | @OpenViewVenture
+Opens in a new window
+
+stripe.com
+Equity for founders - Stripe
+Opens in a new window
+
+josephnoone.com
+A Contrarian's view to start-up success -from Zero to One by Peter Thiel | OneWorld
+Opens in a new window
+
+stripe.com
+Stripe has raised a new round of funding to accelerate momentum in Europe and reinforce enterprise leadership
+Opens in a new window
+
+alleywatch.com
+Contrarian Thinking for Startups: Lessons from Peter Thiel - AlleyWatch
+Opens in a new window
+
+zfellows.com
+Peter Thiel's management framework, networking, and landing pages | Z Fellows
+Opens in a new window
+
+fintel.io
+Mithril II GP LP Portfolio Holdings - Fintel
+Opens in a new window
+
+rootdata.com
+Valar Ventures Overview: Portfolio, Team and News - RootData
+Opens in a new window
+
+app.dealroom.co
+Valar Ventures investor portfolio, rounds & team - Dealroom.co
+Opens in a new window
+
+en.wikipedia.org
+SpaceX - Wikipedia
+Opens in a new window
+
+tracxn.com
+2025 Funding Rounds & List of Investors - SpaceX - Tracxn
+Opens in a new window
+
+bitget.com
+How Did SpaceX, Facebook, and Founders Fund Conquer the VC Industry with a Contrarian Philosophy? | Bitget News
+Opens in a new window
+
+reddit.com
+I studied how AirBnB went from zero to a $98 billion company. : r/ycombinator - Reddit
+Opens in a new window
+
+sequoiacap.com
+Airbnb IPO: Embracing the Adventure - Sequoia Capital
+Opens in a new window
+
+getpaidforyourpad.com
+Airbnb Founder Story: From Selling Cereals To A $25B Company - Get Paid For Your Pad
+Opens in a new window
+
+Thoughts


### PR DESCRIPTION
## Summary
- append Part II to Peter Thiel report detailing operational case studies of PayPal and Palantir
- outline Thiel's investment vehicles and recurring motifs
- add portfolio tables and extended source list

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_689b5671a6588326930fddf4ad352ebb