### PR TITLE
docs: reorganize nav and add mermaid support

### DIFF
--- a/docs/misc/index.md
+++ b/docs/misc/index.md
@@ -1,0 +1,8 @@
+---
+title: Miscellaneous
+---
+
+# Miscellaneous
+
+Assorted documents that don't yet fit into a dedicated category.
+

--- a/docs/productivity/index.md
+++ b/docs/productivity/index.md
@@ -1,0 +1,8 @@
+---
+title: Productivity
+---
+
+# Productivity
+
+This section groups documents focused on tools and practices that enhance productivity.
+

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,0 +1,8 @@
+---
+title: Security
+---
+
+# Security
+
+Resources related to security practices and research.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ plugins:
   - search
   - monorepo
   - sitemap
+  - mermaid2
 markdown_extensions:
   - toc:
       permalink: true
@@ -48,25 +49,30 @@ nav:
       - Seed Factory Feasibility Dossier: ai-research/seed-factory-feasibility-dossier.md
       - The Cognitive Architecture of Artificial Societies: ai-research/cognitive-architecture-of-artificial-societies.md
       - Democratizing Brain-Inspired AI Roadmap: ai-research/open-neuromorphic-roadmap.md
-  - Arduino: arduino/index.md
-  - Terminal Workflow: terminal-workflow/index.md
-  - Culture Project: culture-project/index.md
-  - Cyberpunk Cookbook: cyberpunk-cookbook.md
-  - Netrunning Research: netrunning-fiction-reality.md
-  - "Wave 4: Money & Autonomy": wave4-money-autonomy.md
-  - Internet Anonymity Research: internet-anonymity-cyberpunk-response.md
-  - Gaze Research: gaze-research/gaze_research_compiled.md
-  - An Audit of an Oracle: audit-of-an-oracle.md
-  - Inspiring Figures: inspiring-figures.md
-  - Concrete Cognition Anthology: concrete-cognition-anthology.md
-  - High-Level Intelligence Qualia Atlas: high-level-intelligence-qualia-atlas.md
-  - From Qualia to Simulacra: from-qualia-to-simulacra.md
-  - The Metaorganism Framework: metaorganism.md
-  - Add Hours to Your Day?: add-hours-to-your-day.md
+      - Gaze Research: gaze-research/gaze_research_compiled.md
+      - An Audit of an Oracle: audit-of-an-oracle.md
+      - Concrete Cognition Anthology: concrete-cognition-anthology.md
+      - High-Level Intelligence Qualia Atlas: high-level-intelligence-qualia-atlas.md
+      - From Qualia to Simulacra: from-qualia-to-simulacra.md
+      - The Metaorganism Framework: metaorganism.md
+  - Productivity:
+      - Overview: productivity/index.md
+      - Arduino: arduino/index.md
+      - Terminal Workflow: terminal-workflow/index.md
+      - Culture Project: culture-project/index.md
+      - Add Hours to Your Day?: add-hours-to-your-day.md
+      - "Wave 4: Money & Autonomy": wave4-money-autonomy.md
+      - Versioning API: versioning-api.md
   - Security:
+      - Overview: security/index.md
       - Threat Model: security/threat-model.md
-  - Wise Payouts with Idempotency Keys: wise-payouts-idempotency.md
-  - Friendly Face of Power: friendly-face-of-power.md
-  - Versioning API: versioning-api.md
-  - "GPT-5 Launch Backlash": gpt5-backlash.md
+      - Internet Anonymity Research: internet-anonymity-cyberpunk-response.md
+      - Netrunning Research: netrunning-fiction-reality.md
+      - Cyberpunk Cookbook: cyberpunk-cookbook.md
+      - Wise Payouts with Idempotency Keys: wise-payouts-idempotency.md
+  - Miscellaneous:
+      - Overview: misc/index.md
+      - Friendly Face of Power: friendly-face-of-power.md
+      - Inspiring Figures: inspiring-figures.md
+      - "GPT-5 Launch Backlash": gpt5-backlash.md
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ markdown
 mkdocs
 mkdocs-material
 mkdocs-monorepo-plugin
+mkdocs-mermaid2-plugin
 pymdown-extensions
 pytest
 flake8


### PR DESCRIPTION
## Summary
- enable Mermaid diagrams via `mermaid2` plugin
- group documentation into AI Research, Productivity, Security, and Misc sections
- add index pages for new documentation categories

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689bcfd15de0832693e63bc5ec8e020f