### PR TITLE
Add GitHub links and advanced search support

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: Tino Docs Hub
 site_description: Central hub for project documentation
+repo_url: https://github.com/d0tTino/docs-
+edit_uri: edit/main/docs/
 theme:
   name: material
   palette:
@@ -14,11 +16,12 @@ theme:
 # Documentation directory
 docs_dir: docs
 # Custom 404 page lives at docs/404.md and is automatically used by MkDocs
-plugins:
-  - search
-  - monorepo
-  - sitemap
-  - mermaid2
+  plugins:
+    - search:
+        lang: en
+    - monorepo
+    - sitemap
+    - mermaid2
 markdown_extensions:
   - toc:
       permalink: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ mkdocs-material
 mkdocs-monorepo-plugin
 mkdocs-mermaid2-plugin
 pymdown-extensions
+lunr[languages]
 pytest
 flake8
 fastapi

--- a/scripts/kv_capacity.py
+++ b/scripts/kv_capacity.py
@@ -107,7 +107,9 @@ def plot_table(df: pd.DataFrame, output: str) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Compute KV cache memory usage")
     parser.add_argument("--plot", action="store_true", help="Generate a bar chart")
-    parser.add_argument("--output", default="kv_cache_chart.png", help="Plot output file")
+    parser.add_argument(
+        "--output", default="kv_cache_chart.png", help="Plot output file"
+    )
     return parser.parse_args()
 
 
@@ -116,9 +118,27 @@ def main() -> None:
 
     # Define model configurations.  These are approximate and can be adjusted.
     models = [
-        ModelConfig(name="Llama-7B (fp16)", layers=32, heads=32, head_dim=128, dtype_bytes=2),
-        ModelConfig(name="Llama-13B (fp16)", layers=40, heads=40, head_dim=128, dtype_bytes=2),
-        ModelConfig(name="Llama-70B (fp16)", layers=80, heads=64, head_dim=128, dtype_bytes=2),
+        ModelConfig(
+            name="Llama-7B (fp16)",
+            layers=32,
+            heads=32,
+            head_dim=128,
+            dtype_bytes=2,
+        ),
+        ModelConfig(
+            name="Llama-13B (fp16)",
+            layers=40,
+            heads=40,
+            head_dim=128,
+            dtype_bytes=2,
+        ),
+        ModelConfig(
+            name="Llama-70B (fp16)",
+            layers=80,
+            heads=64,
+            head_dim=128,
+            dtype_bytes=2,
+        ),
         # Add more models as needed
     ]
     # Sequence lengths to evaluate
@@ -126,7 +146,12 @@ def main() -> None:
 
     df = compute_table(models, lengths)
     pd.set_option("display.max_rows", None)
-    print(df.to_string(index=False, formatters={"MB": "{:,.2f}".format, "GB": "{:,.2f}".format}))
+    print(
+        df.to_string(
+            index=False,
+            formatters={"MB": "{:,.2f}".format, "GB": "{:,.2f}".format},
+        )
+    )
 
     if args.plot:
         plot_table(df, args.output)


### PR DESCRIPTION
## Summary
- link documentation site to GitHub and enable direct editing
- configure search plugin with language support using `lunr[languages]`
- clean up KV cache helper script to satisfy flake8

## Testing
- `pip install "lunr[languages]"`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd3cb6344832689bc0de5dba0e0ad