### PR TITLE
docs: add descriptions for AI research links

### DIFF
--- a/docs/ai-research/index.md
+++ b/docs/ai-research/index.md
@@ -8,26 +8,26 @@ updated: 2025-08-12
 # AI Research
 
 ## Documents
-- [Agentic SWE Discontinuity Forecast](agentic-swe-discontinuity-forecast.md)
-- [Context Windows Appendix](context-windows-appendix.md)
-- [Context Windows Deep Dive](context-windows-deep-dive.md)
-- [Context Windows Field Guide](context-windows-field-guide.md)
-- [Democratizing Brain-Inspired AI: A Strategic Analysis and 5-Year Roadmap for an Open Neuromorphic Ecosystem](open-neuromorphic-roadmap.md)
-- [Evolving Perspectives on AGI: A Dialogue Between Francois Chollet and Dwarkesh Patel](evolving-perspectives-on-agi.md)
-- [Grok's Utilization of the X Ecosystem](grok-x-ecosystem-utilization.md)
-- [Logical Chunking Strategies](logical-chunking.md)
-- [Neurosymbolic Reasoning Dossier](neurosymbolic-reasoning-dossier.md)
-- [Peaks and Freezes: A Strategic Analysis of AI's 70-Year Hype Cycle and Lessons for the Next Decade](peaks-and-freezes.md)
-- [PRD: Discord 'Friend or Foe' AGI Chatbot](discord-friend-foe-prd.md)
-- [Reverse-Engineering Design Report: OpenAI ChatGPT Agent System](reverse-engineering-chatgpt-agent-system.md)
-- [Reverse-Engineering Design Report: stanford-oval/storm](reverse-engineering-storm.md)
-- [Reverse-Engineering GPT-o3 Multi-Turn Reasoning](reverse-engineering-gpt-o3.md)
-- [Reverse-Engineering Grok 4 Heavy](reverse-engineering-grok4-heavy.md)
-- [Reverse-Engineering OpenAI Codex](reverse-engineering-codex.md)
-- [Seed-Factory Feasibility Dossier](seed-factory-feasibility-dossier.md)
-- [Strategic R&D Roadmap for the DeepThought-ReThought Initiative](strategic-roadmap-deepthought.md)
-- [The Cognitive Architecture of Artificial Societies](cognitive-architecture-of-artificial-societies.md)
-- [The Energy-Efficient Swarm: A Playbook for High-Density, Multi-Agent LLM Deployment on Consumer GPUs](energy-efficient-swarm.md)
-- [The Thick Band of 21st-Century Possibilities](thick-band-of-21st-century-possibilities.md)
-- [You Weren't Supposed to Invent Infinite Jest](you-werent-supposed-to-invent-infinite-jest.md)
+- [Agentic SWE Discontinuity Forecast](agentic-swe-discontinuity-forecast.md) — Forecast of potential abrupt changes in agentic software engineering capabilities.
+- [Context Windows Appendix](context-windows-appendix.md) — Supplementary data on context window designs and usage.
+- [Context Windows Deep Dive](context-windows-deep-dive.md) — Detailed exploration of context window mechanics and scaling.
+- [Context Windows Field Guide](context-windows-field-guide.md) — Practical guidance for working with context windows across models.
+- [Democratizing Brain-Inspired AI: A Strategic Analysis and 5-Year Roadmap for an Open Neuromorphic Ecosystem](open-neuromorphic-roadmap.md) — Strategic roadmap for democratizing neuromorphic AI development.
+- [Evolving Perspectives on AGI: A Dialogue Between Francois Chollet and Dwarkesh Patel](evolving-perspectives-on-agi.md) — Conversation exploring evolving views on artificial general intelligence.
+- [Grok's Utilization of the X Ecosystem](grok-x-ecosystem-utilization.md) — Examination of how Grok leverages the X platform.
+- [Logical Chunking Strategies](logical-chunking.md) — Techniques for partitioning information into coherent chunks.
+- [Neurosymbolic Reasoning Dossier](neurosymbolic-reasoning-dossier.md) — Overview of approaches that blend neural and symbolic reasoning.
+- [Peaks and Freezes: A Strategic Analysis of AI's 70-Year Hype Cycle and Lessons for the Next Decade](peaks-and-freezes.md) — Lessons from historical AI hype cycles for future planning.
+- [PRD: Discord 'Friend or Foe' AGI Chatbot](discord-friend-foe-prd.md) — Product requirements for a Discord chatbot that distinguishes friend from foe.
+- [Reverse-Engineering Design Report: OpenAI ChatGPT Agent System](reverse-engineering-chatgpt-agent-system.md) — Insights from dissecting the ChatGPT agent architecture.
+- [Reverse-Engineering Design Report: stanford-oval/storm](reverse-engineering-storm.md) — Analysis of the design behind Stanford OVAL's Storm project.
+- [Reverse-Engineering GPT-o3 Multi-Turn Reasoning](reverse-engineering-gpt-o3.md) — Breakdown of GPT-o3's reasoning across multiple dialogue turns.
+- [Reverse-Engineering Grok 4 Heavy](reverse-engineering-grok4-heavy.md) — Examination of Grok 4 Heavy's internal architecture.
+- [Reverse-Engineering OpenAI Codex](reverse-engineering-codex.md) — Study of the mechanisms powering OpenAI Codex.
+- [Seed-Factory Feasibility Dossier](seed-factory-feasibility-dossier.md) — Assessment of the viability of self-replicating seed factories.
+- [Strategic R&D Roadmap for the DeepThought-ReThought Initiative](strategic-roadmap-deepthought.md) — Long-term research plan for the DeepThought-ReThought initiative.
+- [The Cognitive Architecture of Artificial Societies](cognitive-architecture-of-artificial-societies.md) — Analysis of cognitive structures in artificial societies.
+- [The Energy-Efficient Swarm: A Playbook for High-Density, Multi-Agent LLM Deployment on Consumer GPUs](energy-efficient-swarm.md) — Playbook for deploying many LLM agents efficiently on consumer hardware.
+- [The Thick Band of 21st-Century Possibilities](thick-band-of-21st-century-possibilities.md) — Vision of technological trajectories shaping the century.
+- [You Weren't Supposed to Invent Infinite Jest](you-werent-supposed-to-invent-infinite-jest.md) — Reflection on unexpected creative outcomes from AI systems.
 


### PR DESCRIPTION
## Summary
- expand AI research index with one-sentence descriptions for each document link

## Testing
- `pre-commit run --files docs/ai-research/index.md` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc126b6083268616f382a8346915