### PR TITLE
Integrate mkdocs-bibtex for citation support

### DIFF
--- a/docs/ai-research/index.md
+++ b/docs/ai-research/index.md
@@ -2,16 +2,16 @@
 title: "AI Research"
 tags: [research, docs]
 project: "ai-research"
-updated: 2025-08-12
+updated: 2025-08-13
 ---
 
 # AI Research
 
 ## Documents
 - [Agentic SWE Discontinuity Forecast](agentic-swe-discontinuity-forecast.md)
-- [Context Windows Appendix](context-windows-appendix.md)
 - [Context Windows Deep Dive](context-windows-deep-dive.md)
 - [Context Windows Field Guide](context-windows-field-guide.md)
+- [Context Windows Field Guide — Appendix](context-windows-appendix.md)
 - [Democratizing Brain-Inspired AI: A Strategic Analysis and 5-Year Roadmap for an Open Neuromorphic Ecosystem](open-neuromorphic-roadmap.md)
 - [Evolving Perspectives on AGI: A Dialogue Between Francois Chollet and Dwarkesh Patel](evolving-perspectives-on-agi.md)
 - [Grok's Utilization of the X Ecosystem](grok-x-ecosystem-utilization.md)
@@ -30,4 +30,3 @@ updated: 2025-08-12
 - [The Energy-Efficient Swarm: A Playbook for High-Density, Multi-Agent LLM Deployment on Consumer GPUs](energy-efficient-swarm.md)
 - [The Thick Band of 21st-Century Possibilities](thick-band-of-21st-century-possibilities.md)
 - [You Weren't Supposed to Invent Infinite Jest](you-werent-supposed-to-invent-infinite-jest.md)
-

--- a/docs/gaze-research/gaze_research_compiled.md
+++ b/docs/gaze-research/gaze_research_compiled.md
@@ -18,9 +18,9 @@ This document consolidates all deliverables for the research project “From Mir
 
 ## Using the Deliverables
 
-**Reading the report:** Open `gaze_research_compiled.md` in any markdown viewer to read the full analysis. Citations use tether identifiers (e.g., :contentReference[oaicite:0]{index=0}), which point to specific lines in the sources consulted during research.
+**Reading the report:** Open `gaze_research_compiled.md` in any markdown viewer to read the full analysis. Citations use BibTeX keys (e.g., [@lacan_sep]), which point to specific lines in the sources consulted during research.
 
-**Exploring sources:** The annotated bibliography below gives an overview of each major source. For full details and to trace the original passages, consult the tether IDs in the annotations or see the BibTeX section for publication information.
+**Exploring sources:** The annotated bibliography below gives an overview of each major source. For full details and to trace the original passages, consult the citation keys in the annotations or see the BibTeX section for publication information.
 
 **Visualising the genealogy:** The influence map embedded in this document shows how theoretical concepts influenced one another over time.
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,6 @@
+@misc{lacan_sep,
+  author       = {Stanford Encyclopedia of Philosophy},
+  title        = {Jacques Lacan},
+  year         = {2023},
+  url          = {https://plato.stanford.edu/entries/lacan/}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,12 +16,14 @@ theme:
 # Documentation directory
 docs_dir: docs
 # Custom 404 page lives at docs/404.md and is automatically used by MkDocs
-  plugins:
-    - search:
-        lang: en
-    - monorepo
-    - sitemap
-    - mermaid2
+plugins:
+  - search:
+      lang: en
+  - monorepo
+  - sitemap
+  - mermaid2
+  - bibtex:
+      bib_file: docs/references.bib
 markdown_extensions:
   - toc:
       permalink: true
@@ -29,6 +31,7 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.highlight
   - pymdownx.superfences
+  - footnotes
 
 nav:
   - Home: index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ mkdocs
 mkdocs-material
 mkdocs-monorepo-plugin
 mkdocs-mermaid2-plugin
+mkdocs-bibtex
 pymdown-extensions
 lunr[languages]
 pytest


### PR DESCRIPTION
## Summary
- configure `mkdocs-bibtex` plugin and enable footnotes in `mkdocs.yml`
- add `mkdocs-bibtex` dependency and new bibliography file
- replace tether ID example with a BibTeX citation key

## Testing
- `pre-commit run --config .pre-commit-config.yml --files mkdocs.yml requirements.txt $(git ls-files 'docs/**')`


------
https://chatgpt.com/codex/tasks/task_e_689cdc330f5c832684be0bdaab779f06