### PR TITLE
Organize AI research index by topic

### DIFF
--- a/docs/ai-research/index.md
+++ b/docs/ai-research/index.md
@@ -8,25 +8,33 @@ updated: 2025-08-14
 # AI Research
 
 ## Documents
-- [Agentic SWE Discontinuity Forecast](agentic-swe-discontinuity-forecast.md)
-- [Context Windows Deep Dive](context-windows-deep-dive.md)
-- [Context Windows Field Guide](context-windows-field-guide.md)
-- [Context Windows Field Guide — Appendix](context-windows-appendix.md)
-- [Democratizing Brain-Inspired AI: A Strategic Analysis and 5-Year Roadmap for an Open Neuromorphic Ecosystem](open-neuromorphic-roadmap.md)
-- [Evolving Perspectives on AGI: A Dialogue Between Francois Chollet and Dwarkesh Patel](evolving-perspectives-on-agi.md)
-- [Grok's Utilization of the X Ecosystem](grok-x-ecosystem-utilization.md)
-- [Logical Chunking Strategies](logical-chunking.md)
-- [Neurosymbolic Reasoning Dossier](neurosymbolic-reasoning-dossier.md)
-- [Peaks and Freezes: A Strategic Analysis of AI's 70-Year Hype Cycle and Lessons for the Next Decade](peaks-and-freezes.md)
-- [PRD: Discord 'Friend or Foe' AGI Chatbot](discord-friend-foe-prd.md)
+
+### Reverse Engineering
 - [Reverse-Engineering Design Report: OpenAI ChatGPT Agent System](reverse-engineering-chatgpt-agent-system.md)
 - [Reverse-Engineering Design Report: stanford-oval/storm](reverse-engineering-storm.md)
 - [Reverse-Engineering GPT-o3 Multi-Turn Reasoning](reverse-engineering-gpt-o3.md)
 - [Reverse-Engineering Grok 4 Heavy](reverse-engineering-grok4-heavy.md)
 - [Reverse-Engineering OpenAI Codex](reverse-engineering-codex.md)
-- [Seed-Factory Feasibility Dossier](seed-factory-feasibility-dossier.md)
+
+### Context Windows
+- [Context Windows Deep Dive](context-windows-deep-dive.md)
+- [Context Windows Field Guide](context-windows-field-guide.md)
+- [Context Windows Field Guide — Appendix](context-windows-appendix.md)
+- [Logical Chunking Strategies](logical-chunking.md)
+
+### Strategic Roadmaps
+- [Agentic SWE Discontinuity Forecast](agentic-swe-discontinuity-forecast.md)
+- [Democratizing Brain-Inspired AI: A Strategic Analysis and 5-Year Roadmap for an Open Neuromorphic Ecosystem](open-neuromorphic-roadmap.md)
+- [Grok's Utilization of the X Ecosystem](grok-x-ecosystem-utilization.md)
+- [Peaks and Freezes: A Strategic Analysis of AI's 70-Year Hype Cycle and Lessons for the Next Decade](peaks-and-freezes.md)
 - [Strategic R&D Roadmap for the DeepThought-ReThought Initiative](strategic-roadmap-deepthought.md)
-- [The Cognitive Architecture of Artificial Societies](cognitive-architecture-of-artificial-societies.md)
 - [The Energy-Efficient Swarm: A Playbook for High-Density, Multi-Agent LLM Deployment on Consumer GPUs](energy-efficient-swarm.md)
 - [The Thick Band of 21st-Century Possibilities](thick-band-of-21st-century-possibilities.md)
+
+### Other Research
+- [Evolving Perspectives on AGI: A Dialogue Between Francois Chollet and Dwarkesh Patel](evolving-perspectives-on-agi.md)
+- [Neurosymbolic Reasoning Dossier](neurosymbolic-reasoning-dossier.md)
+- [PRD: Discord 'Friend or Foe' AGI Chatbot](discord-friend-foe-prd.md)
+- [Seed-Factory Feasibility Dossier](seed-factory-feasibility-dossier.md)
+- [The Cognitive Architecture of Artificial Societies](cognitive-architecture-of-artificial-societies.md)
 - [You Weren't Supposed to Invent Infinite Jest](you-werent-supposed-to-invent-infinite-jest.md)


### PR DESCRIPTION
## Summary
- group AI research docs into focused subsections for reverse engineering, context windows, strategic roadmaps, and other research

No tests or linters were run because only documentation was changed.

------
https://chatgpt.com/codex/tasks/task_e_689d40c334c883268af207defec610ca