### PR TITLE
docs: add disclaimer snippet to ai research docs

### DIFF
--- a/docs/ai-research/agentic-swe-discontinuity-forecast.md
+++ b/docs/ai-research/agentic-swe-discontinuity-forecast.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-09-15
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Projecting the Next Discontinuity in Agentic Software Engineering: An Analysis of RL Scaling, Pre-training Limits, and Benchmark Forensics
 
 ## Section 1: Executive Summary & The Greenblatt Conjecture

--- a/docs/ai-research/cognitive-architecture-of-artificial-societies.md
+++ b/docs/ai-research/cognitive-architecture-of-artificial-societies.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-09-15
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # The Cognitive Architecture of Artificial Societies: From Individual Minds to Emergent Complexity
 
 ## Part I: Foundations of Cognitive Architectures in Multi-Agent Systems

--- a/docs/ai-research/context-windows-appendix.md
+++ b/docs/ai-research/context-windows-appendix.md
@@ -6,6 +6,7 @@ project: ai-research
 updated: 2025-08-13
 ---
 
+--8<-- "_snippets/disclaimer.md"
 
 # Appendix: Context Windows Field Guide
 

--- a/docs/ai-research/context-windows-deep-dive.md
+++ b/docs/ai-research/context-windows-deep-dive.md
@@ -6,6 +6,8 @@ project: "ai-research"
 updated: 2025-08-09
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Context Windows in Large Language Models: A Deep Dive
 
 ## Executive summary

--- a/docs/ai-research/context-windows-field-guide.md
+++ b/docs/ai-research/context-windows-field-guide.md
@@ -6,6 +6,7 @@ project: ai-research
 updated: 2025-08-09
 ---
 
+--8<-- "_snippets/disclaimer.md"
 
 # Context Windows Field Guide
 

--- a/docs/ai-research/discord-friend-foe-prd.md
+++ b/docs/ai-research/discord-friend-foe-prd.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-27
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # PRD: Discord "Friend or Foe" AGI Chatbot
 
 ## Introduction

--- a/docs/ai-research/energy-efficient-swarm.md
+++ b/docs/ai-research/energy-efficient-swarm.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-28
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # The Energy-Efficient Swarm: A Playbook for High-Density, Multi-Agent LLM Deployment on Consumer GPUs
 
 ## Section 1: The Foundation - Model Quantization for VRAM-Constrained Environments

--- a/docs/ai-research/evolving-perspectives-on-agi.md
+++ b/docs/ai-research/evolving-perspectives-on-agi.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-01-15
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Evolving Perspectives on AGI: A Dialogue Between Francois Chollet and Dwarkesh Patel
 
 In a riveting discussion hosted on the Dwarkesh Podcast, Francois Chollet, a prominent AI researcher known for his work on the Keras deep learning library and the ARC-AGI benchmark, engages with host Dwarkesh Patel on the trajectory of artificial general intelligence (AGI). Recorded approximately 12 months after their initial debate, this conversation reveals significant shifts in both participants' viewpoints, underscoring the rapid evolution in frontier AI research. Drawing from the transcript of the YouTube video (accessible at https://www.youtube.com/watch?v=1if6XbzD5Yg), this report synthesizes and expounds upon the key ideas, incorporating direct quotations to illuminate the nuanced arguments presented.

--- a/docs/ai-research/grok-x-ecosystem-utilization.md
+++ b/docs/ai-research/grok-x-ecosystem-utilization.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-08-12
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Explanatory Report: Grok's Utilization of the X Ecosystem
 
 This report provides a fact-checked overview of how Grok, developed by xAI, leverages the X platform (formerly Twitter) ecosystem. Drawing on official announcements, product documentation, and reliable secondary sources as of August 12, 2025, the report examines real-time data access, platform integration, developmental advantages, and API extensions that collectively distinguish Grok through its use of X's dynamic social data.

--- a/docs/ai-research/index.md
+++ b/docs/ai-research/index.md
@@ -5,6 +5,8 @@ project: "ai-research"
 updated: 2025-08-14
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # AI Research
 
 ## Documents

--- a/docs/ai-research/logical-chunking.md
+++ b/docs/ai-research/logical-chunking.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-08-09
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Logical Chunking Strategies
 
 ## Introduction

--- a/docs/ai-research/neurosymbolic-reasoning-dossier.md
+++ b/docs/ai-research/neurosymbolic-reasoning-dossier.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-26
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Neurosymbolic Reasoning Dossier
 
 # The Neuro-Symbolic Landscape: A Unified Taxonomy

--- a/docs/ai-research/open-neuromorphic-roadmap.md
+++ b/docs/ai-research/open-neuromorphic-roadmap.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-08-01
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Democratizing Brain-Inspired AI: A Strategic Analysis and 5-Year Roadmap for an Open Neuromorphic Ecosystem
 
 ## 1 Executive Summary

--- a/docs/ai-research/peaks-and-freezes.md
+++ b/docs/ai-research/peaks-and-freezes.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-28
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Peaks and Freezes: A Strategic Analysis of AI's 70-Year Hype Cycle and Lessons for the Next Decade
 
 ## Executive Summary

--- a/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
+++ b/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-29
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Reverse-Engineering Design Report: OpenAI ChatGPT Agent System
 
 [TOC]

--- a/docs/ai-research/reverse-engineering-codex.md
+++ b/docs/ai-research/reverse-engineering-codex.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-26
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Reverse-Engineering Design Report: OpenAI Codex Software Engineering Agent
 
 Document ID: REDR-2025-07-26-001 Version: 1.0 Classification: Technical Analysis

--- a/docs/ai-research/reverse-engineering-gpt-o3.md
+++ b/docs/ai-research/reverse-engineering-gpt-o3.md
@@ -5,7 +5,9 @@ project: ai-research
 updated: 2025-10-26
 ---
 
-Reverse-Engineering Design Report: GPT-o3 Multi-Turn Reasoning System
+--8<-- "_snippets/disclaimer.md"
+
+# Reverse-Engineering Design Report: GPT-o3 Multi-Turn Reasoning System
 Document ID: REDR-2025-7B4A
 Version: 1.0
 Classification: CONFIDENTIAL // REBUILD BLUEPRINT

--- a/docs/ai-research/reverse-engineering-grok4-heavy.md
+++ b/docs/ai-research/reverse-engineering-grok4-heavy.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-10
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Reverse-Engineering Design Report: Grok 4 Heavy Multi-Agent Framework
 
 ## 1.0 Executive Summary

--- a/docs/ai-research/reverse-engineering-storm.md
+++ b/docs/ai-research/reverse-engineering-storm.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-30
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Reverse-Engineering Design Report: stanford-oval/storm
 
 # 1.0 Executive Summary

--- a/docs/ai-research/reverse-engineering-tribe.md
+++ b/docs/ai-research/reverse-engineering-tribe.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-08-14
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Reverse-Engineering Design Report: facebookresearch/algonauts-2025 (TRIBE)
 
 1.0 Executive Summary

--- a/docs/ai-research/seed-factory-feasibility-dossier.md
+++ b/docs/ai-research/seed-factory-feasibility-dossier.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-26
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Seed-Factory Feasibility Dossier
 
 _A Blueprint for Post-Scarcity Manufacturing_

--- a/docs/ai-research/strategic-roadmap-deepthought.md
+++ b/docs/ai-research/strategic-roadmap-deepthought.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-07-27
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # Strategic R&D Roadmap for the DeepThought-ReThought Initiative
 
 Strategic R&D Roadmap for the DeepThought-ReThought Initiative: A Bayesian

--- a/docs/ai-research/thick-band-of-21st-century-possibilities.md
+++ b/docs/ai-research/thick-band-of-21st-century-possibilities.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-08-01
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # The Thick Band of 21st-Century Possibilities
 
 ## Part I: The Lexicon of Possibility

--- a/docs/ai-research/you-werent-supposed-to-invent-infinite-jest.md
+++ b/docs/ai-research/you-werent-supposed-to-invent-infinite-jest.md
@@ -5,6 +5,8 @@ project: ai-research
 updated: 2025-08-05
 ---
 
+--8<-- "_snippets/disclaimer.md"
+
 # You Weren't Supposed to Invent Infinite Jest
 
 ## Executive Summary: The Uncaging of the Jest


### PR DESCRIPTION
## Summary
- insert standard disclaimer snippet after front matter in AI research markdown files
- convert opening line to heading in GPT-o3 reverse-engineering doc for consistent formatting

## Testing
- no tests run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_689f2e8adf908326b50e75a9fc6a3832