### PR TITLE
lint: enforce research doc metadata and disclaimer

### DIFF
--- a/tests/test_lint_research_docs.py
+++ b/tests/test_lint_research_docs.py
@@ -16,17 +16,37 @@ def run_linter(path: Path) -> subprocess.CompletedProcess:
 def test_linter_detects_split(tmp_path):
     target = tmp_path / "docs" / "ai-research"
     target.mkdir(parents=True)
-    (target / "sample.md").write_text("mod\nel\n")
+    content = (
+        "---\n"
+        "title: T\n"
+        "tags: [a]\n"
+        "project: T\n"
+        "updated: 2024-01-01\n"
+        "---\n"
+        '--8<-- "_snippets/disclaimer.md"\n'
+        "mod\nel\n"
+    )
+    (target / "sample.md").write_text(content)
 
     result = run_linter(target)
     assert result.returncode == 1
-    assert "sample.md:1" in result.stdout
+    assert "possible mid-word split" in result.stdout
 
 
 def test_linter_passes_clean_file(tmp_path):
     target = tmp_path / "docs" / "ai-research"
     target.mkdir(parents=True)
-    (target / "sample.md").write_text("model\n\nworks\n")
+    content = (
+        "---\n"
+        "title: Sample\n"
+        "tags: [a]\n"
+        "project: Test\n"
+        "updated: 2024-01-01\n"
+        "---\n"
+        '--8<-- "_snippets/disclaimer.md"\n'
+        "model\n\nworks\n"
+    )
+    (target / "sample.md").write_text(content)
 
     result = run_linter(target)
     assert result.returncode == 0
@@ -36,9 +56,48 @@ def test_linter_passes_clean_file(tmp_path):
 def test_linter_detects_trailing_whitespace(tmp_path):
     target = tmp_path / "docs" / "ai-research"
     target.mkdir(parents=True)
-    (target / "sample.md").write_text("line with space \nnext\n")
+    content = (
+        "---\n"
+        "title: T\n"
+        "tags: [a]\n"
+        "project: T\n"
+        "updated: 2024-01-01\n"
+        "---\n"
+        '--8<-- "_snippets/disclaimer.md"\n'
+        "line with space \nnext\n"
+    )
+    (target / "sample.md").write_text(content)
 
     result = run_linter(target)
     assert result.returncode == 1
-    assert "sample.md:1" in result.stdout
+    assert "sample.md:" in result.stdout
     assert "trailing whitespace" in result.stdout
+
+
+def test_linter_requires_disclaimer(tmp_path):
+    target = tmp_path / "docs" / "ai-research"
+    target.mkdir(parents=True)
+    content = (
+        "---\n"
+        "title: Sample\n"
+        "tags: [a]\n"
+        "project: Test\n"
+        "updated: 2024-01-01\n"
+        "---\n"
+    )
+    (target / "sample.md").write_text(content)
+
+    result = run_linter(target)
+    assert result.returncode == 1
+    assert "missing disclaimer snippet" in result.stdout
+
+
+def test_linter_requires_metadata(tmp_path):
+    target = tmp_path / "docs" / "ai-research"
+    target.mkdir(parents=True)
+    content = '--8<-- "_snippets/disclaimer.md"\n'
+    (target / "sample.md").write_text(content)
+
+    result = run_linter(target)
+    assert result.returncode == 1
+    assert "missing front matter" in result.stdout


### PR DESCRIPTION
## Summary
- verify research docs contain required front matter metadata
- ensure disclaimer snippet follows front matter
- test linter for metadata and disclaimer requirements

## Testing
- `flake8 scripts/lint_research_docs.py tests/test_lint_research_docs.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2dafcbec832693742b74f2c84c23