### PR TITLE
Add docs lint workflow

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,21 @@
+name: Docs Lint
+on:
+  push:
+    paths:
+      - 'docs/**'
+  pull_request:
+    paths:
+      - 'docs/**'
+
+jobs:
+  docs-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: npm install markdownlint-cli
+      - run: npx markdownlint docs
+      - run: pip install -r requirements.txt
+      - run: python scripts/lint_research_docs.py

--- a/tests/test_document_view_performance.py
+++ b/tests/test_document_view_performance.py
@@ -28,6 +28,9 @@ def test_document_view_latest_only_is_fast(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(difflib, "unified_diff", slow_diff)
     client = TestClient(api.app)
 
+    # warm up the app to avoid startup costs skewing timings
+    client.get("/docs/doc/revisions")
+
     start = time.time()
     res = client.get("/docs/doc/view")
     latest_duration = time.time() - start


### PR DESCRIPTION
## Summary
- add CI workflow to lint docs and research docs
- stabilize document view performance test by warming up the app before measuring timings

## Testing
- `pre-commit run --config .pre-commit-config.yml --files tests/test_document_view_performance.py`
- `PYTHONPATH=. pytest tests/test_document_view_performance.py::test_document_view_latest_only_is_fast -q`


------
https://chatgpt.com/codex/tasks/task_e_689f2daefd208326aebb1feb01cdd6f8