### PR TITLE
feat: add snippet expansion precommit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,8 @@
 #!/bin/sh
-npx -y markdownlint-cli "**/*.md"
+md_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.md')
+if [ -n "$md_files" ]; then
+  npm run preexpand -- $md_files && git add $md_files && npx -y markdownlint-cli $md_files
+fi
 flake8 --exclude node_modules
 files=$(git diff --cached --name-only --diff-filter=ACM -- 'docs/ai-research/*.md')
 [ -z "$files" ] || python scripts/lint_research_docs.py $files

--- a/README.md
+++ b/README.md
@@ -18,14 +18,19 @@ model](docs/security/threat-model.md).
 
 ## Development
 
-Install [pre-commit](https://pre-commit.com/) hooks to automatically lint Markdown files:
+### Pre-commit
+
+Install [pre-commit](https://pre-commit.com/) hooks to automatically expand snippets and lint Markdown files:
 
 ```bash
 pip install pre-commit
 pre-commit install
 ```
 
-The hook runs `scripts/lint_research_docs.py` to catch mid-word line splits.
+Run `npm run preexpand <file>` to manually expand `--8<--` markers when needed.
+
+The hook runs `scripts/expand_snippets.py` to inline snippet references and
+`scripts/lint_research_docs.py` to catch mid-word line splits.
 
 ### Preview Docs Locally
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "markdownlint-cli": "^0.45.0"
+  },
+  "scripts": {
+    "preexpand": "python scripts/expand_snippets.py"
   }
 }

--- a/scripts/expand_snippets.py
+++ b/scripts/expand_snippets.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Inline snippet markers in Markdown files.
+
+This script searches for lines matching the pattern ``--8<-- "path"`` in the
+provided Markdown files and replaces them with the contents of the referenced
+file. Paths are resolved relative to the documentation root directory, which
+defaults to ``docs`` under the repository root but can be overridden with
+``--docs-dir``.
+
+Usage:
+    python scripts/expand_snippets.py [--docs-dir DIR] file [file ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Iterable
+
+SNIPPET_RE = re.compile(r"^--8<--\s+\"([^\"]+)\"\s*\n?", re.MULTILINE)
+
+
+def expand_file(md_file: Path, docs_dir: Path) -> None:
+    """Replace snippet markers in ``md_file``."""
+    text = md_file.read_text(encoding="utf-8")
+
+    def repl(match: re.Match[str]) -> str:
+        rel_path = match.group(1)
+        snippet_path = docs_dir / rel_path
+        if not snippet_path.is_file():
+            raise FileNotFoundError(f"snippet not found: {rel_path}")
+        return snippet_path.read_text(encoding="utf-8")
+
+    new_text = SNIPPET_RE.sub(repl, text)
+    md_file.write_text(new_text, encoding="utf-8")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="+", type=Path, help="Markdown files to expand")
+    parser.add_argument(
+        "--docs-dir",
+        default=Path(__file__).resolve().parent.parent / "docs",
+        type=Path,
+        help="Base directory for snippet paths",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    for md_file in args.files:
+        expand_file(md_file, args.docs_dir)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -75,3 +75,20 @@ def test_bulk_submodule_update_runs_git_command(tmp_path):
 
     commands = log_file.read_text().splitlines()
     assert commands == ["submodule update --remote --recursive"]
+
+
+def test_expand_snippets_replaces_marker(tmp_path):
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    snippet = docs_dir / "snippet.md"
+    snippet.write_text("SNIPPET\n")
+    doc = docs_dir / "doc.md"
+    doc.write_text('before\n--8<-- "snippet.md"\nafter\n')
+
+    script = ROOT / "scripts" / "expand_snippets.py"
+    subprocess.run(
+        ["python", str(script), "--docs-dir", str(docs_dir), str(doc)],
+        check=True,
+    )
+
+    assert doc.read_text() == "before\nSNIPPET\nafter\n"


### PR DESCRIPTION
## Summary
- expand `--8<--` snippet markers via `scripts/expand_snippets.py`
- run snippet expansion in git pre-commit through `npm run preexpand`
- lint only staged markdown files to avoid unrelated failures
- document snippet expansion workflow in README

## Testing
- `pytest`
- `flake8 --exclude node_modules`
- `npx -y markdownlint-cli README.md`


------
https://chatgpt.com/codex/tasks/task_e_689f2db0d6408326938f202edb855e62