### PR TITLE
Add non-AI research index updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ git submodule update --init --recursive
 
 Fetch documentation submodules to ensure project docs are available.
 
+### Update Research Indexes
+
+Rebuild research index pages after adding or renaming documents:
+
+```bash
+python scripts/update_ai_research_index.py
+python scripts/update_non_ai_research_index.py
+```
+
 ## Contributing
 
 1. Create a branch from `main` for your work.

--- a/docs/non-ai-research/index.md
+++ b/docs/non-ai-research/index.md
@@ -1,23 +1,21 @@
 ---
 title: "Non-AI Research"
 tags: [research, docs]
-project: non-ai-research
-updated: 2025-08-14
+project: "non-ai-research"
+updated: 2025-08-15
 ---
 
 # Non-AI Research
 
-Documents spanning productivity, philosophy, and organizational theory:
-
-- [Add Hours to Your Day? Debunking Productivity Frameworks](add-hours-to-your-day.md)
-- [Buying the Dip: A Historical, Signal-Driven Playbook for Identifying Corporate Turnarounds](buying-the-dip-playbook.md)
-- [The Metaorganism: A New Framework for Organizational Evolution](metaorganism.md)
-- [From Qualia to Simulacra: An Inquiry into the Communicability of Experience](from-qualia-to-simulacra.md)
-- [The Concrete Cognition Anthology](concrete-cognition-anthology.md)
-- [The High-Level Intelligence Qualia Atlas](high-level-intelligence-qualia-atlas.md)
-- [Notable Figures](inspiring-figures.md)
-- [An Interdisciplinary Examination of Modern Rationalism: Principles, Applications, and Critiques in the Scientific-Technological Age](modern-rationalism.md)
-- [The Corporate Egregore: An Interdisciplinary Analysis of the Corporation as an Autonomous Collective Entity](corporate-egregore.md)
-- [Evolution as a Computational Process: An Interdisciplinary Investigation into Biological Compute](evolution-as-a-computational-process.md)
+## Documents
 - [A Techno-Economic and Performance Model for DNA-Based Archival Storage](dna-archival-storage-tepm.md)
-
+- [Add Hours to Your Day? Debunking Productivity Frameworks](add-hours-to-your-day.md)
+- [An Interdisciplinary Examination of Modern Rationalism: Principles, Applications, and Critiques in the Scientific-Technological Age](modern-rationalism.md)
+- [Buying the Dip: A Historical, Signal-Driven Playbook for Identifying Corporate Turnarounds](buying-the-dip-playbook.md)
+- [Evolution as a Computational Process: An Interdisciplinary Investigation into Biological Compute](evolution-as-a-computational-process.md)
+- [From Qualia to Simulacra: An Inquiry into the Communicability of Experience](from-qualia-to-simulacra.md)
+- [Notable Figures](inspiring-figures.md)
+- [The Concrete Cognition Anthology](concrete-cognition-anthology.md)
+- [The Corporate Egregore: An Interdisciplinary Analysis of the Corporation as an Autonomous Collective Entity](corporate-egregore.md)
+- [The High-Level Intelligence Qualia Atlas](high-level-intelligence-qualia-atlas.md)
+- [The Metaorganism: A New Framework for Organizational Evolution](metaorganism.md)

--- a/scripts/update_non_ai_research_index.py
+++ b/scripts/update_non_ai_research_index.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Update docs/non-ai-research/index.md with a sorted list of documents."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = ROOT / "docs" / "non-ai-research"
+INDEX_FILE = DOCS_DIR / "index.md"
+
+
+def _extract_title(path: Path) -> str:
+    """Return the title from the markdown file at ``path``."""
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"^title:[ \t]*\"?([^\n\"]+)\"?", text, re.MULTILINE)
+    if match:
+        return match.group(1).strip()
+    match = re.search(
+        r"^title:\s*\n\s+\"([^\n\"]*(?:\n\s+[^\n\"]*)*)\"",
+        text,
+        re.MULTILINE,
+    )
+    if match:
+        return " ".join(line.strip() for line in match.group(1).splitlines())
+    return path.stem.replace("-", " ").title()
+
+
+def build_index() -> str:
+    """Construct the index markdown content."""
+    items = []
+    for md in sorted(DOCS_DIR.glob("*.md")):
+        if md.name == "index.md":
+            continue
+        title = _extract_title(md)
+        items.append((title, md.name))
+    items.sort(key=lambda x: x[0].lower())
+
+    lines = [
+        "---",
+        'title: "Non-AI Research"',
+        "tags: [research, docs]",
+        'project: "non-ai-research"',
+        f"updated: {_dt.date.today()}",
+        "---",
+        "",
+        "# Non-AI Research",
+        "",
+        "## Documents",
+    ]
+    for title, filename in items:
+        lines.append(f"- [{title}]({filename})")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    content = build_index()
+    INDEX_FILE.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to build Non-AI Research index with multiline title handling
- generate updated Non-AI Research index and document usage in README

## Testing
- `flake8 scripts/update_non_ai_research_index.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f322d3a10832681b01b26a0c61d53