### PR TITLE
Add security index script and update security docs

### DIFF
--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,10 +1,16 @@
 ---
 title: Security
 tags: [security]
-updated: 2025-08-13
+updated: 2025-08-15
 ---
+--8<-- "_snippets/disclaimer.md"
 
 # Security
 
 Resources related to security practices and research.
 
+## Threat Model
+- [Threat Model](threat-model.md)
+
+## Research
+- [Quantum Reckoning](quantum-reckoning.md)

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -2,8 +2,9 @@
 title: "Threat Model"
 tags: [security, docs]
 project: docs-hub
-updated: 2025-07-28
+updated: 2025-08-15
 ---
+--8<-- "_snippets/disclaimer.md"
 
 # Documentation and Scripts Threat Model
 

--- a/scripts/update_security_index.py
+++ b/scripts/update_security_index.py
@@ -1,0 +1,18 @@
+"""List markdown files in docs/security."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SECURITY_DIR = ROOT / "docs" / "security"
+
+
+def list_files() -> None:
+    """Print all markdown files in the security docs directory."""
+    for path in sorted(SECURITY_DIR.glob("*.md")):
+        print(path.name)
+
+
+if __name__ == "__main__":
+    list_files()


### PR DESCRIPTION
## Summary
- Add `update_security_index.py` to list markdown files in `docs/security`
- Insert standard disclaimer snippet in security docs missing it
- Regenerate `docs/security/index.md` with categorized links for Threat Model and Research

## Testing
- `flake8 scripts/update_security_index.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f36db1aa88326bdf2e9fff2156f12