### PR TITLE
Standardize citation style in context windows docs

### DIFF
--- a/docs/ai-research/context-windows-appendix.md
+++ b/docs/ai-research/context-windows-appendix.md
@@ -22,7 +22,7 @@ For a transformer with **L** layers, **H** heads and head dimension **d**, and u
 KV_memory_bytes ≈ 2 × L × H × d × seq_length × dtypeBytes.
 ```
 
-The factor of 2 accounts for keys and values.  For example, a 70 B-parameter model with **L ≈ 80**, **H ≈ 64**, **d ≈ 128** and **dtypeBytes = 2** uses approximately 2.6 MiB per thousand tokens【563653443713035†L150-L171】.  A 7 B model with half as many layers and heads uses ~0.7 MiB per thousand tokens.  Multiply the per-token cost by the sequence length to estimate VRAM requirements.  Remember to leave room for model parameters, activations and overhead.
+The factor of 2 accounts for keys and values.  For example, a 70 B-parameter model with **L ≈ 80**, **H ≈ 64**, **d ≈ 128** and **dtypeBytes = 2** uses approximately 2.6 MiB per thousand tokens[^1].  A 7 B model with half as many layers and heads uses ~0.7 MiB per thousand tokens.  Multiply the per-token cost by the sequence length to estimate VRAM requirements.  Remember to leave room for model parameters, activations and overhead.
 
 ### A.2 Throughput and latency
 
@@ -78,23 +78,23 @@ For each position *p* in {1 k, 4 k, 16 k, 64 k, …}, embed a retrieval
 
 **Nominal context:** The advertised maximum context length (e.g., 128 k tokens).  It is the upper bound on input length supported by the model and serving stack.
 
-**Effective context:** The portion of the context window that the model actually uses.  Effective context may be much smaller than nominal due to positional biases and training distribution【812281553901334†L65-L76】.
+**Effective context:** The portion of the context window that the model actually uses.  Effective context may be much smaller than nominal due to positional biases and training distribution[^2].
 
-**Key–value (KV) cache:** The memory used to store key and value vectors for each token in each layer during inference.  It scales linearly with sequence length and model depth【563653443713035†L150-L171】.
+**Key–value (KV) cache:** The memory used to store key and value vectors for each token in each layer during inference.  It scales linearly with sequence length and model depth[^1].
 
 **Prefill vs decode:** The prefill phase processes the entire context at once; decode generates tokens one by one.  Prefill complexity is O(N²) for full attention and O(N) for linear/sparse attention; decode is O(N) per token.
 
-**FlashAttention:** A kernel that reorganises the attention computation to reduce memory bandwidth, enabling longer contexts at high throughput【563653443713035†L150-L171】.
+**FlashAttention:** A kernel that reorganises the attention computation to reduce memory bandwidth, enabling longer contexts at high throughput[^1].
 
 **PagedAttention/vLLM:** A serving mechanism that stores KV tensors in a paged format and evicts unused pages to support large windows and concurrent requests.
 
-**Position Interpolation (PI):** A method to extend rotary position embeddings (RoPE) by downscaling positions, enabling models trained on short sequences to extrapolate to longer ones【989342212075024†L50-L60】.
+**Position Interpolation (PI):** A method to extend rotary position embeddings (RoPE) by downscaling positions, enabling models trained on short sequences to extrapolate to longer ones[^3].
 
-**YaRN:** A refinement of PI that reduces the amount of data needed during fine-tuning and reaches 128 k tokens with fewer steps【556094126408083†L50-L60】.
+**YaRN:** A refinement of PI that reduces the amount of data needed during fine-tuning and reaches 128 k tokens with fewer steps[^4].
 
-**StRing:** A technique that shifts position indices during fine-tuning to improve long-context performance【199134859253240†L78-L94】.
+**StRing:** A technique that shifts position indices during fine-tuning to improve long-context performance[^5].
 
-**Infini-attention:** A transformer variant that combines masked local attention with long-term linear attention and a compressive memory to handle sequences of hundreds of thousands of tokens【100878192473897†L50-L60】.
+**Infini-attention:** A transformer variant that combines masked local attention with long-term linear attention and a compressive memory to handle sequences of hundreds of thousands of tokens[^6].
 
 ## D. Design matrix summary
 
@@ -106,3 +106,10 @@ The CSV file `context-windows-design-matrix.csv` (see repository) lists the main
 
 - [Context Windows Field Guide](context-windows-field-guide.md)
 - [Context Windows Deep Dive](context-windows-deep-dive.md)
+
+[^1]: Source 563653443713035 lines 150-171.
+[^2]: Source 812281553901334 lines 65-76.
+[^3]: Source 989342212075024 lines 50-60.
+[^4]: Source 556094126408083 lines 50-60.
+[^5]: Source 199134859253240 lines 78-94.
+[^6]: Source 100878192473897 lines 50-60.

--- a/docs/ai-research/context-windows-deep-dive.md
+++ b/docs/ai-research/context-windows-deep-dive.md
@@ -12,7 +12,7 @@ updated: 2025-08-09
 
 ## Executive summary
 
-Language models have undergone a rapid expansion in **context window** sizes over the past few years. While early models like GPT‑3 processed only 2 k–4 k tokens, state‑of‑the‑art models in mid‑2025 claim to handle hundreds of thousands or even millions of tokens【477669928722032†L226-L297】【480357281697940†L79-L83】. Larger contexts unlock new capabilities: summarising entire codebases, analysing multiple documents, preserving conversational state over long dialogues and performing multi‑step reasoning across disparate passages. However, the path from nominal context length to *effective* context is fraught with practical constraints.
+Language models have undergone a rapid expansion in **context window** sizes over the past few years. While early models like GPT‑3 processed only 2 k–4 k tokens, state‑of‑the‑art models in mid‑2025 claim to handle hundreds of thousands or even millions of tokens[^1][^2]. Larger contexts unlock new capabilities: summarising entire codebases, analysing multiple documents, preserving conversational state over long dialogues and performing multi‑step reasoning across disparate passages. However, the path from nominal context length to *effective* context is fraught with practical constraints.
 
 This deep dive explains **why models have different context sizes**, explores the **limitations** imposed by memory, compute and positional encodings, and surveys the **techniques** that push LLMs toward effectively infinite context. We provide formulas and capacity planners, summarise model context sizes, outline evaluation benchmarks and propose a multi‑tier architecture for exploiting long contexts responsibly. This document complements the existing *Context Windows Field Guide*, offering additional depth, background and actionable guidance.
 ## Key Takeaways
@@ -26,15 +26,15 @@ This deep dive explains **why models have different context sizes**, explores th
 
 ## 1. Introduction: context windows and their significance
 
-The **context window** is the maximum number of tokens a model consumes per inference request. A token is roughly ~¾ of a word in English; a 32 k token input corresponds to ~49 pages of text【477669928722032†L226-L297】. Context length matters because it determines how much information can be considered at once. With a larger window, an LLM can ingest more supporting documents, maintain dialogue across long conversations and perform reasoning that spans multiple pages or code files.
+The **context window** is the maximum number of tokens a model consumes per inference request. A token is roughly ~¾ of a word in English; a 32 k token input corresponds to ~49 pages of text[^1]. Context length matters because it determines how much information can be considered at once. With a larger window, an LLM can ingest more supporting documents, maintain dialogue across long conversations and perform reasoning that spans multiple pages or code files.
 
-The expansion from 2 k tokens to 32 k, 128 k and beyond means that models can summarise books, entire code repositories and cross‑reference long legal documents【477669928722032†L226-L297】【480357281697940†L79-L83】. Researchers have even demonstrated context windows up to 10 million tokens for code analysis【480357281697940†L79-L83】. Despite these advances, *context is expensive*: memory and compute scale at least linearly (and for standard attention, quadratically) with sequence length, and the model’s advertised context does not always reflect what it uses effectively.
+The expansion from 2 k tokens to 32 k, 128 k and beyond means that models can summarise books, entire code repositories and cross‑reference long legal documents[^1][^2]. Researchers have even demonstrated context windows up to 10 million tokens for code analysis[^2]. Despite these advances, *context is expensive*: memory and compute scale at least linearly (and for standard attention, quadratically) with sequence length, and the model’s advertised context does not always reflect what it uses effectively.
 
 ### 1.1 Nominal vs. effective context
 
-The **nominal context length** is the advertised maximum sequence length (e.g., 128 k tokens). The **effective context** is the portion of the input that the model actually attends to and utilises during inference. Empirical studies show that models often prioritise the beginning and end of long sequences, ignoring middle sections—a phenomenon known as the *lost‑in‑the‑middle* effect【812281553901334†L65-L76】. Even models trained with 32 k–128 k context lengths attend less to information placed in the middle, highlighting that effective context is usually shorter than the nominal maximum.
+The **nominal context length** is the advertised maximum sequence length (e.g., 128 k tokens). The **effective context** is the portion of the input that the model actually attends to and utilises during inference. Empirical studies show that models often prioritise the beginning and end of long sequences, ignoring middle sections—a phenomenon known as the *lost‑in‑the‑middle* effect[^3]. Even models trained with 32 k–128 k context lengths attend less to information placed in the middle, highlighting that effective context is usually shorter than the nominal maximum.
 
-Factors influencing effective context include the distribution of positions seen during training, the choice of positional encoding, memory bandwidth and architecture‑specific biases. Meaningful evaluation requires tasks like retrieval, aggregation and reasoning across different positions, such as the **RULER** benchmark and **LongBench**【812281553901334†L65-L76】.
+Factors influencing effective context include the distribution of positions seen during training, the choice of positional encoding, memory bandwidth and architecture‑specific biases. Meaningful evaluation requires tasks like retrieval, aggregation and reasoning across different positions, such as the **RULER** benchmark and **LongBench**[^3].
 
 ### 1.2 Memory and compute scaling
 
@@ -44,7 +44,7 @@ For a transformer with **L** layers, **H** heads and head dimension **d**, stori
 \text{KV\_memory\_bytes} = 2 \times L \times H \times d \times \text{seq\_length} \times \text{dtypeBytes},
 \]
 
-where the factor 2 accounts for keys and values. For example, a 70 B parameter model with around L≈80, H≈64 and d≈128 uses about 2.6 MiB per thousand tokens in FP16【563653443713035†L150-L171】. A **16 k** request thus consumes over **40 GiB** of GPU memory for the KV cache alone【563653443713035†L150-L171】. Activation memory (for back‑prop during training) and OS overhead push memory requirements even higher. Techniques like gradient accumulation, gradient checkpointing, reversible layers and memory‑efficient optimisers are used to train long contexts【477669928722032†L344-L360】, but at inference time the KV cache usually dominates memory usage.
+where the factor 2 accounts for keys and values. For example, a 70 B parameter model with around L≈80, H≈64 and d≈128 uses about 2.6 MiB per thousand tokens in FP16[^4]. A **16 k** request thus consumes over **40 GiB** of GPU memory for the KV cache alone[^4]. Activation memory (for back‑prop during training) and OS overhead push memory requirements even higher. Techniques like gradient accumulation, gradient checkpointing, reversible layers and memory‑efficient optimisers are used to train long contexts[^5], but at inference time the KV cache usually dominates memory usage.
 
 Compute also grows quadratically with sequence length in standard self‑attention, because every token attends to every other token. FlashAttention and other IO‑aware kernels reduce overhead by fusing operations and optimising memory accesses, but do not change the asymptotic cost. Linear and sparse attention schemes aim to reduce complexity (see section 5).
 
@@ -54,17 +54,17 @@ The last two years have seen a proliferation of LLMs boasting large contexts. Ta
 
 | Model / system | Nominal context window | Notes |
 |---|---|---|
-| **GPT‑3** | 2 k | Early large model; limited context restricts reasoning to short prompts【477669928722032†L226-L297】. |
+| **GPT‑3** | 2 k | Early large model; limited context restricts reasoning to short prompts[^1]. |
 | **Mistral 7B** | 8 k | Mid‑sized open‑source model; typical for 2023–24. |
-| **GPT‑4o** | 60 k–128 k | Multi‑modal model; high‑quality context for code and chat【477669928722032†L226-L297】. |
+| **GPT‑4o** | 60 k–128 k | Multi‑modal model; high‑quality context for code and chat[^1]. |
 | **Claude 3.5** | 100 k | Good summarisation; widely used for legal and technical docs. |
 | **Llama 3.1 (Meta)** | 128 k | Extended using position scaling; used in retrieval‑augmented tasks. |
-| **Gemini 1.5 Pro** | up to 1 M | Google claims 1M tokens; experiments with 10 M tokens on code bases【480357281697940†L79-L83】. |
-| **Magic.dev LTM‑2‑Mini** | 100 M | For code repository analysis; uses retrieval and compression【480357281697940†L79-L83】. |
-| **Llama 4 Scout** | 10 M | Experimental; used for continuous memory in embodied agents【480357281697940†L79-L83】. |
-| **GPT‑4.1, Gemini 2.5 Flash / Pro, Llama 4 Maverick** | 1 M | Commercial models with million‑token context【480357281697940†L79-L83】. |
-| **Claude 4 (Opus/Sonnet)** | 200 k | Balanced context size for chat and summarisation【480357281697940†L82-L89】. |
-| **DeepSeek R1 /V3** | 128 k | Chinese open‑source models for code and text【480357281697940†L90-L93】. |
+| **Gemini 1.5 Pro** | up to 1 M | Google claims 1M tokens; experiments with 10 M tokens on code bases[^2]. |
+| **Magic.dev LTM‑2‑Mini** | 100 M | For code repository analysis; uses retrieval and compression[^2]. |
+| **Llama 4 Scout** | 10 M | Experimental; used for continuous memory in embodied agents[^2]. |
+| **GPT‑4.1, Gemini 2.5 Flash / Pro, Llama 4 Maverick** | 1 M | Commercial models with million‑token context[^2]. |
+| **Claude 4 (Opus/Sonnet)** | 200 k | Balanced context size for chat and summarisation[^6]. |
+| **DeepSeek R1 /V3** | 128 k | Chinese open‑source models for code and text[^7]. |
 
 These nominal lengths reflect training setups and marketing claims. Effective context can be much smaller, and many tasks do not benefit beyond 32 k–64 k. Instead of chasing ever‑larger windows, practitioners should evaluate whether longer contexts deliver meaningful gains relative to cost and complexity.
 
@@ -76,9 +76,9 @@ Most transformer‑based LLMs are trained on fixed‑length segments, typically 
 
 Several techniques have emerged to extend RoPE:
 
-1. **Position Interpolation (PI)** rescales input positions to fit within the original window, preventing large rotation angles. PI extends 4 k models to 32 k or more with minimal fine‑tuning and preserves in‑window quality【989342212075024†L50-L60】.
-2. **YaRN (Yet another RoPE extension)** fine‑tunes using a truncated normal schedule that covers a wide range of positions while requiring fewer tokens than PI. YaRN enables Llama models to extrapolate to 128 k with 10× less data and 2.5× fewer steps than previous methods【556094126408083†L50-L60】.
-3. **StRing** (Shifted Rotary Position Embedding) shifts positions so that queries and keys attend using positive phase differences. StRing improves long‑context performance and enables up to 128 k effective context on Llama 3.1 70B, outperforming GPT‑4‑128k and Claude 2 on retrieval tasks【199134859253240†L78-L94】.
+1. **Position Interpolation (PI)** rescales input positions to fit within the original window, preventing large rotation angles. PI extends 4 k models to 32 k or more with minimal fine‑tuning and preserves in‑window quality[^8].
+2. **YaRN (Yet another RoPE extension)** fine‑tunes using a truncated normal schedule that covers a wide range of positions while requiring fewer tokens than PI. YaRN enables Llama models to extrapolate to 128 k with 10× less data and 2.5× fewer steps than previous methods[^9].
+3. **StRing** (Shifted Rotary Position Embedding) shifts positions so that queries and keys attend using positive phase differences. StRing improves long‑context performance and enables up to 128 k effective context on Llama 3.1 70B, outperforming GPT‑4‑128k and Claude 2 on retrieval tasks[^10].
 4. **ALiBi** (Attention with Linear Bias) adds a position‑dependent bias term; it naturally extrapolates to longer contexts but may degrade quality at shorter lengths. It is used in models like BLOOM and EleutherAI GPT‑NeoX.
 5. **NTK scaling** (a relative attention scaling method) adjusts frequencies to match Neural Tangent Kernel properties; combined with RoPE it improves extrapolation.
 
@@ -86,7 +86,7 @@ Relative positional encodings and learned positions (e.g., T5) can also generali
 
 ### 3.2 Memory and compute ceilings
 
-As illustrated earlier, the KV cache scales linearly with sequence length and model size【563653443713035†L150-L171】. Memory fragmentation, limited GPU memory and scheduler constraints can reduce usable context. Systems like **FlashAttention** fuse operations to reduce IO and memory overhead, enabling efficient exact attention. **PagedAttention** (vLLM) implements a multi‑paged KV cache that evicts least‑used blocks and reduces fragmentation, allowing 128 k contexts on consumer GPUs.
+As illustrated earlier, the KV cache scales linearly with sequence length and model size[^4]. Memory fragmentation, limited GPU memory and scheduler constraints can reduce usable context. Systems like **FlashAttention** fuse operations to reduce IO and memory overhead, enabling efficient exact attention. **PagedAttention** (vLLM) implements a multi‑paged KV cache that evicts least‑used blocks and reduces fragmentation, allowing 128 k contexts on consumer GPUs.
 
 #### KV‑cache capacity planning
 
@@ -108,20 +108,20 @@ Inference frameworks significantly influence effective context. **vLLM** uses a 
 
 Beyond the transformer, alternative architectures exhibit different context properties:
 
-- **Efficient attention** uses local or sparse patterns; examples include **Longformer** (sliding window + global attention)【222591077498926†L48-L60】, **BigBird** (random + global + block attention) and **Performer** (linear attention via kernel approximations). These reduce cost but may lose global dependencies.
+- **Efficient attention** uses local or sparse patterns; examples include **Longformer** (sliding window + global attention)[^11], **BigBird** (random + global + block attention) and **Performer** (linear attention via kernel approximations). These reduce cost but may lose global dependencies.
 - **State‑space models** like **Mamba** and the **Legendre Memory Unit (LMU)** treat sequences as continuous dynamical systems, offering linear memory but potentially limited long‑range modelling.
-- **Compressive transformers** append a second memory to store compressed summaries of past tokens and enable arbitrarily long sequences.【100878192473897†L50-L60】. **Transformer‑XL** uses segment‑level recurrence and relative position encodings to extend context and speed up evaluation【626234754762794†L260-L315】.
-- **Ring Attention** distributes long sequences across multiple devices, performing blockwise attention with overlapping communications. It achieves sequences millions of tokens long without approximations【138967914803289†L71-L85】.
+- **Compressive transformers** append a second memory to store compressed summaries of past tokens and enable arbitrarily long sequences.[^12]. **Transformer‑XL** uses segment‑level recurrence and relative position encodings to extend context and speed up evaluation[^13].
+- **Ring Attention** distributes long sequences across multiple devices, performing blockwise attention with overlapping communications. It achieves sequences millions of tokens long without approximations[^14].
 
 ### 3.5 Data distribution and training curriculum
 
-Long context models require training on long sequences. However, natural language corpora rarely contain contiguous passages of 32 k+ tokens. Data must be concatenated or artificially generated, and curriculum schedules (increasing context gradually) help models generalise. Strategies like **gradient accumulation** and **curriculum learning** are used【477669928722032†L344-L360】. Without proper training, models with long windows may overfit to local patterns and fail to utilise the full context.
+Long context models require training on long sequences. However, natural language corpora rarely contain contiguous passages of 32 k+ tokens. Data must be concatenated or artificially generated, and curriculum schedules (increasing context gradually) help models generalise. Strategies like **gradient accumulation** and **curriculum learning** are used[^5]. Without proper training, models with long windows may overfit to local patterns and fail to utilise the full context.
 
 ## 4. Effective context and failure modes
 
 ### 4.1 Lost-in-the-middle and position sensitivity
 
-The *lost‑in‑the‑middle* effect arises when relevant information placed in the middle of a long context is ignored. Studies reveal that retrieval accuracy peaks when the key passage is near the beginning or end of the context, degrading when placed mid‑sequence【812281553901334†L65-L76】. This occurs even in long‑context models, indicating that attention weights are not uniformly distributed. Effective context is thus limited by inductive biases and training distribution. Benchmarks such as **RULER** (Retrieval, Multi‑step Reasoning and Evidence), **Lost‑in‑the‑Middle** and **InfiniteBench** evaluate position sensitivity by inserting “passkeys” at different positions and measuring retrieval success.
+The *lost‑in‑the‑middle* effect arises when relevant information placed in the middle of a long context is ignored. Studies reveal that retrieval accuracy peaks when the key passage is near the beginning or end of the context, degrading when placed mid‑sequence[^3]. This occurs even in long‑context models, indicating that attention weights are not uniformly distributed. Effective context is thus limited by inductive biases and training distribution. Benchmarks such as **RULER** (Retrieval, Multi‑step Reasoning and Evidence), **Lost‑in‑the‑Middle** and **InfiniteBench** evaluate position sensitivity by inserting “passkeys” at different positions and measuring retrieval success.
 
 ### 4.2 Long-range dependency and forgetting
 
@@ -129,31 +129,31 @@ Long contexts can lead to **vanishing gradients** during training, causing the m
 
 ### 4.3 Cost and latency trade‑offs
 
-Doubling sequence length roughly doubles prefill time (loading tokens into the model) and memory usage. Multi‑turn interactive sessions may pay this cost repeatedly. Serving a 128 k input on a 70 B model can take tens of seconds and consume >40 GiB of VRAM【563653443713035†L150-L171】. Developers must weigh context length against throughput, latency and cost. Batching and KV sharing across requests improve efficiency but complicate scheduling.
+Doubling sequence length roughly doubles prefill time (loading tokens into the model) and memory usage. Multi‑turn interactive sessions may pay this cost repeatedly. Serving a 128 k input on a 70 B model can take tens of seconds and consume >40 GiB of VRAM[^4]. Developers must weigh context length against throughput, latency and cost. Batching and KV sharing across requests improve efficiency but complicate scheduling.
 
 ## 5. Techniques for extending context windows
 
 ### 5.1 Positional scaling and interpolation
 
-As described in section 3.1, **Position Interpolation** and **YaRN** enable RoPE models to extrapolate to 32 k–128 k tokens with limited fine‑tuning【989342212075024†L50-L60】【556094126408083†L50-L60】. PI rescales positions while YaRN samples from a truncated normal distribution; both maintain in‑window accuracy. **StRing** further shifts positions to mitigate phase drift and improves effective context【199134859253240†L78-L94】. More recent methods (e.g., **NTK‑scaled RoPE**, **CARoPE**) adjust frequencies to match kernel eigenvalues.
+As described in section 3.1, **Position Interpolation** and **YaRN** enable RoPE models to extrapolate to 32 k–128 k tokens with limited fine‑tuning[^8][^9]. PI rescales positions while YaRN samples from a truncated normal distribution; both maintain in‑window accuracy. **StRing** further shifts positions to mitigate phase drift and improves effective context[^10]. More recent methods (e.g., **NTK‑scaled RoPE**, **CARoPE**) adjust frequencies to match kernel eigenvalues.
 
 **ALiBi** uses linear biases relative to position differences; it naturally extends to long contexts but may trade off accuracy at shorter lengths.
 
 ### 5.2 Efficient, sparse and linear attention
 
-**Longformer** introduces a sliding window attention pattern with optional global tokens, achieving linear complexity and performing well on long document tasks【222591077498926†L48-L60】. **BigBird** and **LED** (Longformer Encoder–Decoder) extend these ideas to the encoder–decoder setting. **Performer** uses kernel tricks (FAVOR+) to approximate softmax attention in linear time, enabling very long contexts but sometimes at the cost of lower accuracy. **Reformer**, **Linear Transformer** and **Retentive Networks** provide alternative linear attention mechanisms. These methods drastically reduce compute and memory, but the restricted receptive field can harm tasks requiring global cross‑attention.
+**Longformer** introduces a sliding window attention pattern with optional global tokens, achieving linear complexity and performing well on long document tasks[^11]. **BigBird** and **LED** (Longformer Encoder–Decoder) extend these ideas to the encoder–decoder setting. **Performer** uses kernel tricks (FAVOR+) to approximate softmax attention in linear time, enabling very long contexts but sometimes at the cost of lower accuracy. **Reformer**, **Linear Transformer** and **Retentive Networks** provide alternative linear attention mechanisms. These methods drastically reduce compute and memory, but the restricted receptive field can harm tasks requiring global cross‑attention.
 
 ### 5.3 Streaming and compressive attention
 
-**Transformer‑XL** caches hidden states from previous segments and uses relative positional encodings, effectively extending context across segments and reducing computation【626234754762794†L260-L315】. **Compressive Transformers** compress past memories into smaller representations with learned convolution kernels. **StreamingLLM** uses *attention sinks*—special tokens that summarise past context and maintain state. **Infini‑attention** adds a compressive memory inside each transformer block, combining masked local attention with long‑term linear attention to handle extremely long sequences【100878192473897†L50-L60】. These models support streaming input and require bounded memory per time step, making them suitable for real‑time, long‑running conversations.
+**Transformer‑XL** caches hidden states from previous segments and uses relative positional encodings, effectively extending context across segments and reducing computation[^13]. **Compressive Transformers** compress past memories into smaller representations with learned convolution kernels. **StreamingLLM** uses *attention sinks*—special tokens that summarise past context and maintain state. **Infini‑attention** adds a compressive memory inside each transformer block, combining masked local attention with long‑term linear attention to handle extremely long sequences[^12]. These models support streaming input and require bounded memory per time step, making them suitable for real‑time, long‑running conversations.
 
 ### 5.4 Distributed full attention
 
-When high accuracy across the entire context is required, approximate methods may be insufficient. **Ring Attention** distributes the sequence across multiple GPUs or TPUs and performs blockwise full attention, overlapping communication with computation【138967914803289†L71-L85】. This approach enables sequences millions of tokens long without approximations, but requires high‑bandwidth interconnects and careful scheduling. It is used in training extremely long context models and for certain “hero run” analyses.
+When high accuracy across the entire context is required, approximate methods may be insufficient. **Ring Attention** distributes the sequence across multiple GPUs or TPUs and performs blockwise full attention, overlapping communication with computation[^14]. This approach enables sequences millions of tokens long without approximations, but requires high‑bandwidth interconnects and careful scheduling. It is used in training extremely long context models and for certain “hero run” analyses.
 
 ### 5.5 External memory and retrieval augmentation
 
-Long contexts are not always the best way to capture long‑term knowledge. **Retrieval‑augmented models** like **kNN‑LM** and **RETRO** attach an external memory of billions of tokens. At inference time, the model retrieves relevant chunks based on the current query and cross‑attends to them【605812693674672†L49-L63】【897139308669472†L78-L95】. This decouples knowledge storage from the context window: a small model with a short context can outperform a much larger model by looking up relevant information. kNN‑LM uses a nearest neighbour search over the model’s own embeddings, while RETRO employs a BERT‑based retriever and chunked cross‑attention. Retrieval augmentation requires building and maintaining a large vector store but avoids the quadratic cost of long context attention.
+Long contexts are not always the best way to capture long‑term knowledge. **Retrieval‑augmented models** like **kNN‑LM** and **RETRO** attach an external memory of billions of tokens. At inference time, the model retrieves relevant chunks based on the current query and cross‑attends to them[^15][^16]. This decouples knowledge storage from the context window: a small model with a short context can outperform a much larger model by looking up relevant information. kNN‑LM uses a nearest neighbour search over the model’s own embeddings, while RETRO employs a BERT‑based retriever and chunked cross‑attention. Retrieval augmentation requires building and maintaining a large vector store but avoids the quadratic cost of long context attention.
 
 ### 5.6 System‑level optimisations
 
@@ -204,3 +204,20 @@ Approaching *effectively infinite context* is less about training a single model
 
 - [Context Windows Field Guide](context-windows-field-guide.md)
 - [Context Windows Field Guide — Appendix](context-windows-appendix.md)
+
+[^1]: Source 477669928722032 lines 226-297.
+[^2]: Source 480357281697940 lines 79-83.
+[^3]: Source 812281553901334 lines 65-76.
+[^4]: Source 563653443713035 lines 150-171.
+[^5]: Source 477669928722032 lines 344-360.
+[^6]: Source 480357281697940 lines 82-89.
+[^7]: Source 480357281697940 lines 90-93.
+[^8]: Source 989342212075024 lines 50-60.
+[^9]: Source 556094126408083 lines 50-60.
+[^10]: Source 199134859253240 lines 78-94.
+[^11]: Source 222591077498926 lines 48-60.
+[^12]: Source 100878192473897 lines 50-60.
+[^13]: Source 626234754762794 lines 260-315.
+[^14]: Source 138967914803289 lines 71-85.
+[^15]: Source 605812693674672 lines 49-63.
+[^16]: Source 897139308669472 lines 78-95.

--- a/docs/ai-research/context-windows-field-guide.md
+++ b/docs/ai-research/context-windows-field-guide.md
@@ -12,19 +12,19 @@ updated: 2025-08-09
 
 ## Executive summary
 
-Modern large language models (LLMs) are defined not only by the number of parameters they contain but by how much input they can consider at once.  The **context window**—the span of tokens processed per call—has grown from 2–4 k tokens in early GPT-3 to hundreds of thousands or even millions of tokens in 2025【477669928722032†L226-L297】.  Larger windows unlock new capabilities: summarising long books, reasoning over codebases, preserving conversational state and enabling multi-document question answering.  But context is expensive: doubling the window roughly quadruples compute and memory, and a model’s advertised limit often exceeds what it uses effectively.  Simply increasing the window can lead to the *lost-in-the-middle* effect, where information in the middle of long sequences is ignored【812281553901334†L65-L76】, and extreme lengths stress the serving stack and positional encodings.  This guide maps the landscape of context windows in 2025, explains why different models have different limits, details the math behind scaling, surveys the families of techniques to extend or circumvent context limits and outlines a practical multi-tier architecture for approaching an **effectively infinite context**.  For a deeper technical exploration, see the companion [Context Windows Deep Dive](context-windows-deep-dive.md), and consult the [appendix](context-windows-appendix.md) for formulas and evaluation templates.
+Modern large language models (LLMs) are defined not only by the number of parameters they contain but by how much input they can consider at once.  The **context window**—the span of tokens processed per call—has grown from 2–4 k tokens in early GPT-3 to hundreds of thousands or even millions of tokens in 2025[^1].  Larger windows unlock new capabilities: summarising long books, reasoning over codebases, preserving conversational state and enabling multi-document question answering.  But context is expensive: doubling the window roughly quadruples compute and memory, and a model’s advertised limit often exceeds what it uses effectively.  Simply increasing the window can lead to the *lost-in-the-middle* effect, where information in the middle of long sequences is ignored[^2], and extreme lengths stress the serving stack and positional encodings.  This guide maps the landscape of context windows in 2025, explains why different models have different limits, details the math behind scaling, surveys the families of techniques to extend or circumvent context limits and outlines a practical multi-tier architecture for approaching an **effectively infinite context**.  For a deeper technical exploration, see the companion [Context Windows Deep Dive](context-windows-deep-dive.md), and consult the [appendix](context-windows-appendix.md) for formulas and evaluation templates.
 
 ## 1 Introduction and definitions
 
-LLMs operate on sequences of discrete tokens.  At inference time, a model receives a prompt consisting of **N** tokens and predicts the next token.  The **context window** (also called the attention span or maximum sequence length) is the maximum **N** supported.  When the window is short, tasks requiring long memory—such as analysing lengthy documents or maintaining conversational history—must be broken into pieces, with information condensed or lost.  A 32 k-token window corresponds to roughly 49 pages of text【477669928722032†L226-L297】; a 128 k-token window encompasses an entire novella; a million-token window can contain thousands of pages of code or multiple books.  However, a longer window increases compute cost quadratically (for standard attention) and pushes memory requirements beyond what most GPUs can handle【563653443713035†L150-L171】.
+LLMs operate on sequences of discrete tokens.  At inference time, a model receives a prompt consisting of **N** tokens and predicts the next token.  The **context window** (also called the attention span or maximum sequence length) is the maximum **N** supported.  When the window is short, tasks requiring long memory—such as analysing lengthy documents or maintaining conversational history—must be broken into pieces, with information condensed or lost.  A 32 k-token window corresponds to roughly 49 pages of text[^1]; a 128 k-token window encompasses an entire novella; a million-token window can contain thousands of pages of code or multiple books.  However, a longer window increases compute cost quadratically (for standard attention) and pushes memory requirements beyond what most GPUs can handle[^3].
 
 ### 1.1 Nominal vs effective context
 
-The **nominal context length** is the maximum supported by the model.  The **effective context** is the portion of the input the model actually attends to and utilises during generation.  Studies like *Lost-in-the-Middle* show that even models with 32 k–128 k contexts pay more attention to the first and last few thousand tokens and often ignore content placed in the middle【812281553901334†L65-L76】.  Effective context is influenced by positional encodings, training distribution and architectural biases.  Practical evaluation requires tasks that measure retrieval and reasoning across different positions and lengths, such as RULER and LongBench benchmarks.
+The **nominal context length** is the maximum supported by the model.  The **effective context** is the portion of the input the model actually attends to and utilises during generation.  Studies like *Lost-in-the-Middle* show that even models with 32 k–128 k contexts pay more attention to the first and last few thousand tokens and often ignore content placed in the middle[^2].  Effective context is influenced by positional encodings, training distribution and architectural biases.  Practical evaluation requires tasks that measure retrieval and reasoning across different positions and lengths, such as RULER and LongBench benchmarks.
 
 ### 1.2 Memory and compute scaling
 
-For a transformer with **L** layers, **H** heads and head dimension **d**, storing the key–value (KV) cache for each token requires roughly **2 × L × H × d × dtypeBytes** bytes.  For a 70 B-parameter model (L≈80, H≈64, d≈128) in FP16, the KV cache consumes about 2.6 MiB per thousand tokens【563653443713035†L150-L171】.  Thus:
+For a transformer with **L** layers, **H** heads and head dimension **d**, storing the key–value (KV) cache for each token requires roughly **2 × L × H × d × dtypeBytes** bytes.  For a 70 B-parameter model (L≈80, H≈64, d≈128) in FP16, the KV cache consumes about 2.6 MiB per thousand tokens[^3].  Thus:
 
 ```
 KV_memory_bytes ≈ 2 × L × H × d × seq_length × dtypeBytes
@@ -40,7 +40,7 @@ The underlying data in [context-windows-design-matrix.csv](context-windows-desig
 ![Context windows design matrix](context-windows-design-matrix.svg)
 
 
-A single 16 k-token request therefore uses over 40 GiB of memory【563653443713035†L150-L171】.  Activation memory (intermediate activations needed for backpropagation) also scales with sequence length.  Training long contexts often requires gradient accumulation, checkpointing, recomputation or reversible layers to manage memory【477669928722032†L344-L360】.  During inference, memory fragmentation and scheduler constraints further limit the usable window.  Hardware improvements (larger VRAM, faster memory bandwidth) and algorithmic innovations (FlashAttention, PagedAttention) are critical to make long context practical.
+A single 16 k-token request therefore uses over 40 GiB of memory[^3].  Activation memory (intermediate activations needed for backpropagation) also scales with sequence length.  Training long contexts often requires gradient accumulation, checkpointing, recomputation or reversible layers to manage memory[^4].  During inference, memory fragmentation and scheduler constraints further limit the usable window.  Hardware improvements (larger VRAM, faster memory bandwidth) and algorithmic innovations (FlashAttention, PagedAttention) are critical to make long context practical.
 
 ## 2 Landscape of context sizes in 2025
 
@@ -48,12 +48,12 @@ The race to extend context windows has accelerated dramatically.  Models launche
 
 | Model (2025) | Approx. context window | Notes and typical uses |
 |---|---|---|
-| **Magic.dev LTM-2-Mini** | 100 million tokens | Processes entire code repositories or large document corpora; built for ultra-long code comprehension【480357281697940†L73-L83】. |
-| **Meta Llama 4 Scout** | 10 million tokens | MoE model delivering a 10 M-token window on a single GPU, suitable for on-device multimodal workflows and book-length summarisation【480357281697940†L79-L83】. |
-| **GPT-4.1 / Gemini 2.5 Pro/Flash / Llama 4 Maverick** | 1 million tokens | Frontier models offering million-token windows for complex multimodal tasks, deep research and enterprise document analysis【480357281697940†L82-L89】.  Gemini 1.5 Pro has demonstrated up to 10 million tokens in research experiments【162697279310482†L304-L324】. |
-| **Claude 4 & 3.7 Sonnet, OpenAI o3/o4** | 200 k tokens | High-precision multi-step reasoning and safe multi-turn dialogues【480357281697940†L86-L89】. |
-| **GPT-4o, Mistral Large 2, DeepSeek R1/V3, Mistral Medium 3** | 128 k tokens | Balanced efficiency and performance across vision-language tasks, code generation and summarisation【480357281697940†L90-L93】. |
-| **Llama 3.1 8B/70B, Claude 3.5 Sonnet, Gemini 1.0** | 100 k – 128 k tokens | Extended via position scaling techniques or trained from scratch with long contexts【477669928722032†L226-L297】. |
+| **Magic.dev LTM-2-Mini** | 100 million tokens | Processes entire code repositories or large document corpora; built for ultra-long code comprehension[^5]. |
+| **Meta Llama 4 Scout** | 10 million tokens | MoE model delivering a 10 M-token window on a single GPU, suitable for on-device multimodal workflows and book-length summarisation[^6]. |
+| **GPT-4.1 / Gemini 2.5 Pro/Flash / Llama 4 Maverick** | 1 million tokens | Frontier models offering million-token windows for complex multimodal tasks, deep research and enterprise document analysis[^7].  Gemini 1.5 Pro has demonstrated up to 10 million tokens in research experiments[^8]. |
+| **Claude 4 & 3.7 Sonnet, OpenAI o3/o4** | 200 k tokens | High-precision multi-step reasoning and safe multi-turn dialogues[^9]. |
+| **GPT-4o, Mistral Large 2, DeepSeek R1/V3, Mistral Medium 3** | 128 k tokens | Balanced efficiency and performance across vision-language tasks, code generation and summarisation[^10]. |
+| **Llama 3.1 8B/70B, Claude 3.5 Sonnet, Gemini 1.0** | 100 k – 128 k tokens | Extended via position scaling techniques or trained from scratch with long contexts[^1]. |
 | **GPT-3.5, Mistral 7B** | 8 k – 32 k tokens | Early models with limited windows; still widely used for cost-effective tasks. |
 
 The progression from 8 k to 100 million tokens has been achieved through a combination of longer pre-training sequences, improved positional encodings, sparse attention, compressive memory and system-level innovations.  However, many of these extremely large contexts are experimental or restricted to certain tiers of customers.  Using them effectively requires careful engineering.
@@ -64,25 +64,25 @@ The progression from 8 k to 100 million tokens has been achieved through a com
 
 Transformers need a way to represent token positions.  Most mainstream models use **rotary position embeddings** (RoPE), which encode relative positions as complex exponentials and naturally generalise across sequence lengths.  RoPE parameters are implicitly trained only up to the maximum sequence length seen during pre-training.  Extrapolating to longer positions without adaptation can produce very large attention scores, causing instabilities.  Several techniques have emerged to extend RoPE:
 
-* **Position Interpolation (PI):** downscales the input positions so that a model trained on 2 k tokens can be fine-tuned to handle 32 k or 64 k tokens without modifying the architecture【989342212075024†L50-L60】.  PI ensures that the effective positional frequencies remain within the range the model has seen, avoiding large magnitude attention values.
-* **YaRN:** modifies the interpolation schedule to reduce the number of tokens needed during fine-tuning, enabling RoPE models to reach 128 k tokens with 10× fewer tokens and 2.5× fewer steps【556094126408083†L50-L60】.
-* **StRing:** shifts the position indices during fine-tuning, rebalancing the distribution of positional frequencies and improving performance on long-context benchmarks【199134859253240†L78-L94】.  Models fine-tuned with StRing on 70 B parameters surpass GPT-4-128 k and Claude 2 on RULER and InfiniteBench tasks【199134859253240†L78-L94】.
+* **Position Interpolation (PI):** downscales the input positions so that a model trained on 2 k tokens can be fine-tuned to handle 32 k or 64 k tokens without modifying the architecture[^11].  PI ensures that the effective positional frequencies remain within the range the model has seen, avoiding large magnitude attention values.
+* **YaRN:** modifies the interpolation schedule to reduce the number of tokens needed during fine-tuning, enabling RoPE models to reach 128 k tokens with 10× fewer tokens and 2.5× fewer steps[^12].
+* **StRing:** shifts the position indices during fine-tuning, rebalancing the distribution of positional frequencies and improving performance on long-context benchmarks[^13].  Models fine-tuned with StRing on 70 B parameters surpass GPT-4-128 k and Claude 2 on RULER and InfiniteBench tasks[^13].
 * **ALiBi:** uses a linear bias in attention that can extrapolate gracefully beyond the training range.  It is used by some models (e.g., early GPT-NeoX and Pythia) and allows training with shorter sequences.
-* **Relative position encodings (Transformer-XL):** encode distances rather than absolute positions, enabling recurrence across segments【626234754762794†L260-L315】.
+* **Relative position encodings (Transformer-XL):** encode distances rather than absolute positions, enabling recurrence across segments[^14].
 
 By contrast, models like Llama 4 Scout and GPT-4.1 were trained from scratch with long sequences.  Their positional embeddings and attention layers have directly experienced millions of tokens, avoiding the need for extrapolation.  Training with long sequences is expensive and requires gradient accumulation, but yields more stable long-context behaviour.
 
 ### 3.2 Memory and compute ceilings
 
-Even if a model can theoretically attend to a million tokens, hardware limits may make such contexts impractical.  VRAM memory is dominated by the KV cache.  For example, a 7 B model with 32 layers and 32 heads might require ~0.7 MiB per thousand tokens; a 70 B model uses ~2.6 MiB【563653443713035†L150-L171】.  Serving a million-token prompt for a 70 B model would require over 2.6 TiB of memory—beyond any single GPU.  Multi-GPU systems can shard the KV cache (as in Ring Attention), but high-speed interconnects are needed.  Activation memory during training also scales with sequence length, requiring gradient checkpointing or reversible layers.  All of these factors influence the maximum *practical* context length.
+Even if a model can theoretically attend to a million tokens, hardware limits may make such contexts impractical.  VRAM memory is dominated by the KV cache.  For example, a 7 B model with 32 layers and 32 heads might require ~0.7 MiB per thousand tokens; a 70 B model uses ~2.6 MiB[^3].  Serving a million-token prompt for a 70 B model would require over 2.6 TiB of memory—beyond any single GPU.  Multi-GPU systems can shard the KV cache (as in Ring Attention), but high-speed interconnects are needed.  Activation memory during training also scales with sequence length, requiring gradient checkpointing or reversible layers.  All of these factors influence the maximum *practical* context length.
 
 ### 3.3 Serving stack and scheduling
 
-Long contexts often cause performance degradation due to kernel inefficiencies, memory fragmentation and scheduling overhead.  **FlashAttention** reorders the attention computation to reduce memory traffic and achieve near-ideal bandwidth, enabling longer sequences and higher throughput【563653443713035†L150-L171】.  **PagedAttention** in vLLM stores KV tensors in a paged format and evicts unused pages, allowing dynamic batching and greatly reducing fragmentation.  Without such kernel and memory improvements, the overhead of moving KV tensors around can dominate runtime.  Thus the same model may have different effective context windows depending on the serving environment.
+Long contexts often cause performance degradation due to kernel inefficiencies, memory fragmentation and scheduling overhead.  **FlashAttention** reorders the attention computation to reduce memory traffic and achieve near-ideal bandwidth, enabling longer sequences and higher throughput[^3].  **PagedAttention** in vLLM stores KV tensors in a paged format and evicts unused pages, allowing dynamic batching and greatly reducing fragmentation.  Without such kernel and memory improvements, the overhead of moving KV tensors around can dominate runtime.  Thus the same model may have different effective context windows depending on the serving environment.
 
 ## 4 Effective vs nominal: how models use long context
 
-Models seldom use their entire window uniformly.  **Lost-in-the-Middle** experiments place a “needle” (a piece of relevant information) at various positions within a long prompt.  Even models with extended contexts perform best when the needle is at the beginning or end; accuracy drops when it is placed in the middle【812281553901334†L65-L76】.  This suggests that positional encodings and attention patterns bias the model toward recency and early positions.  Effective context is further reduced by the training distribution; if most training sequences are <4 k tokens, the model may not learn to distribute attention evenly across 128 k positions.
+Models seldom use their entire window uniformly.  **Lost-in-the-Middle** experiments place a “needle” (a piece of relevant information) at various positions within a long prompt.  Even models with extended contexts perform best when the needle is at the beginning or end; accuracy drops when it is placed in the middle[^2].  This suggests that positional encodings and attention patterns bias the model toward recency and early positions.  Effective context is further reduced by the training distribution; if most training sequences are <4 k tokens, the model may not learn to distribute attention evenly across 128 k positions.
 
 The **RULER** benchmark extends “needle in a haystack” to multi-step reasoning and aggregation over sequences up to 1 M tokens.  **LongBench** and **LongBench v2** evaluate summarisation, code understanding, question answering and mathematical reasoning at 32 k–512 k tokens.  These benchmarks measure not only retrieval but also whether the model can combine distant pieces of information and perform arithmetic or logic.  Evaluations must report performance as a function of sequence length and token position, along with throughput and VRAM usage, to capture effective context.
 
@@ -94,23 +94,23 @@ Position scaling methods (PI, YaRN, StRing, NTK scaling) retrofit RoPE models to
 
 ### 5.2 Efficient and sparse attention
 
-Reducing the number of pairwise interactions lowers the asymptotic cost.  **Longformer** uses a sliding local window with a handful of global tokens, achieving linear complexity and outperforming RoBERTa on long document tasks【222591077498926†L48-L60】.  **BigBird** combines local, random and global attention; it offers theoretical guarantees for capturing dependencies and scales to hundreds of thousands of tokens.  **Performer** approximates softmax attention using random feature maps, making attention linear in sequence length.  Other variants (Reformer, Nyströmformer, Linformer) employ low-rank or kernel approximations.  These techniques enable long contexts but may sacrifice some global reasoning capability and require training from scratch or substantial fine-tuning.
+Reducing the number of pairwise interactions lowers the asymptotic cost.  **Longformer** uses a sliding local window with a handful of global tokens, achieving linear complexity and outperforming RoBERTa on long document tasks[^15].  **BigBird** combines local, random and global attention; it offers theoretical guarantees for capturing dependencies and scales to hundreds of thousands of tokens.  **Performer** approximates softmax attention using random feature maps, making attention linear in sequence length.  Other variants (Reformer, Nyströmformer, Linformer) employ low-rank or kernel approximations.  These techniques enable long contexts but may sacrifice some global reasoning capability and require training from scratch or substantial fine-tuning.
 
 ### 5.3 Streaming, recurrent and compressive models
 
-Models like **Transformer-XL** employ segment-level recurrence and relative positional encodings to reuse past hidden states【626234754762794†L260-L315】.  **StreamingLLM** introduces “attention sinks” and sliding windows that allow continuous processing without storing all keys and values.  **Compressive Transformer** and **Infini-attention** add a compressive memory that summarizes distant past activations; Infini-attention combines masked local attention with long-term linear attention and compressive memory to handle sequences hundreds of thousands of tokens long【100878192473897†L50-L60】.  These methods achieve essentially unbounded context with bounded memory but require custom architectures and may lose fine-grained information across long distances.  They are ideal for streaming inputs, logs and chat applications where approximate memory suffices.
+Models like **Transformer-XL** employ segment-level recurrence and relative positional encodings to reuse past hidden states[^14].  **StreamingLLM** introduces “attention sinks” and sliding windows that allow continuous processing without storing all keys and values.  **Compressive Transformer** and **Infini-attention** add a compressive memory that summarizes distant past activations; Infini-attention combines masked local attention with long-term linear attention and compressive memory to handle sequences hundreds of thousands of tokens long[^16].  These methods achieve essentially unbounded context with bounded memory but require custom architectures and may lose fine-grained information across long distances.  They are ideal for streaming inputs, logs and chat applications where approximate memory suffices.
 
 ### 5.4 Distributed full attention
 
-When one needs exact full attention over extreme lengths, sequences can be distributed across multiple devices.  **Ring Attention** partitions the sequence into blocks across devices and rotates the key and value blocks around the ring while computing attention, overlapping communication with computation【138967914803289†L71-L85】.  This allows processing sequences millions of tokens long without approximations but requires as many devices as the block size and high-speed interconnects.  It is used primarily in research and high-end deployments.
+When one needs exact full attention over extreme lengths, sequences can be distributed across multiple devices.  **Ring Attention** partitions the sequence into blocks across devices and rotates the key and value blocks around the ring while computing attention, overlapping communication with computation[^17].  This allows processing sequences millions of tokens long without approximations but requires as many devices as the block size and high-speed interconnects.  It is used primarily in research and high-end deployments.
 
 ### 5.5 External memory and retrieval augmentation
 
-Instead of storing all context within the model, one can retrieve relevant information from an external datastore.  **kNN-LM** augments a base language model by interpolating its next-token distribution with a k-nearest-neighbour search over an embedding datastore【605812693674672†L49-L63】.  **RETRO** uses a frozen BERT retriever to fetch chunks from a large corpus and cross-attends to them【897139308669472†L78-L95】.  Retrieval-augmented generation (RAG) decouples knowledge from the context window, allowing a modest window (e.g., 8 k tokens) to answer questions about arbitrarily long documents.  However, these approaches require building and maintaining a retrieval index and rely on the retriever’s recall; they also introduce latency due to the search step.
+Instead of storing all context within the model, one can retrieve relevant information from an external datastore.  **kNN-LM** augments a base language model by interpolating its next-token distribution with a k-nearest-neighbour search over an embedding datastore[^18].  **RETRO** uses a frozen BERT retriever to fetch chunks from a large corpus and cross-attends to them[^19].  Retrieval-augmented generation (RAG) decouples knowledge from the context window, allowing a modest window (e.g., 8 k tokens) to answer questions about arbitrarily long documents.  However, these approaches require building and maintaining a retrieval index and rely on the retriever’s recall; they also introduce latency due to the search step.
 
 ### 5.6 System-level and architectural optimisations
 
-**FlashAttention** reorders the loops in attention computation to maximize memory locality and minimise redundant reads and writes, achieving exact attention with much lower memory bandwidth【563653443713035†L150-L171】.  **PagedAttention** in vLLM uses a paged KV cache and dynamic batching to avoid fragmentation and support concurrent requests at long context lengths.  **Quantisation** and **Mixture-of-Experts (MoE)** architectures can reduce memory footprint per token; MoE models like Llama 4 Scout use gating to activate only a subset of experts, enabling larger contexts on the same hardware【480357281697940†L79-L83】.  Training strategies such as gradient accumulation, reversible layers and memory-efficient optimisers allow fine-tuning at longer sequence lengths without prohibitive memory usage【477669928722032†L344-L360】.
+**FlashAttention** reorders the loops in attention computation to maximize memory locality and minimise redundant reads and writes, achieving exact attention with much lower memory bandwidth[^3].  **PagedAttention** in vLLM uses a paged KV cache and dynamic batching to avoid fragmentation and support concurrent requests at long context lengths.  **Quantisation** and **Mixture-of-Experts (MoE)** architectures can reduce memory footprint per token; MoE models like Llama 4 Scout use gating to activate only a subset of experts, enabling larger contexts on the same hardware[^6].  Training strategies such as gradient accumulation, reversible layers and memory-efficient optimisers allow fine-tuning at longer sequence lengths without prohibitive memory usage[^4].
 
 ## 6 Evaluation and benchmarking
 
@@ -123,17 +123,17 @@ When evaluating long-context models, one should measure more than single-needle 
 * **Position sensitivity**: measure accuracy when relevant information is placed at the beginning, middle or end of the sequence.
 * **Resource metrics**: record VRAM usage, KV bytes per token and tokens per second (prefill and decode).  These metrics highlight system-level bottlenecks.
 
-Public benchmarks such as Lost-in-the-Middle【812281553901334†L65-L76】, RULER, LongBench, LongBench v2 and InfiniteBench provide standardised tasks.  However, custom tests tailored to an application’s domain (e.g., legal document analysis, code comprehension) are essential for real-world deployment.
+Public benchmarks such as Lost-in-the-Middle[^2], RULER, LongBench, LongBench v2 and InfiniteBench provide standardised tasks.  However, custom tests tailored to an application’s domain (e.g., legal document analysis, code comprehension) are essential for real-world deployment.
 
 ## 7 Toward effectively infinite context
 
 No single method provides an infinite context; practical systems layer multiple techniques to approximate it.  A **three-tier architecture** can achieve near-infinite context:
 
 1. **Working set (Tier 1):** Keep a small window (8 k–32 k tokens) in full attention using FlashAttention or similar kernels.  Use a paged KV cache and smart eviction policies to prioritise recent and important tokens.  This tier supports precise reasoning and short-term memory.
-2. **Compressed stream (Tier 2):** Use a streaming or compressive model (e.g., Transformer-XL or Infini-attention) to summarise the distant past into a fixed-size state【626234754762794†L260-L315】【100878192473897†L50-L60】.  This allows the system to remember salient information across hundreds of thousands of tokens without storing all keys.  The compressed state is updated as new tokens arrive.
-3. **External memory and retrieval (Tier 3):** Store the entire conversation history and relevant documents in a retrieval index.  At each step, retrieve the most relevant chunks based on the current query and insert them into the working set.  This decouples knowledge from the window and enables unlimited memory.  Use RAG or kNN-LM style interpolation to integrate retrieved information【605812693674672†L49-L63】.
+2. **Compressed stream (Tier 2):** Use a streaming or compressive model (e.g., Transformer-XL or Infini-attention) to summarise the distant past into a fixed-size state[^14][^16].  This allows the system to remember salient information across hundreds of thousands of tokens without storing all keys.  The compressed state is updated as new tokens arrive.
+3. **External memory and retrieval (Tier 3):** Store the entire conversation history and relevant documents in a retrieval index.  At each step, retrieve the most relevant chunks based on the current query and insert them into the working set.  This decouples knowledge from the window and enables unlimited memory.  Use RAG or kNN-LM style interpolation to integrate retrieved information[^18].
 
-Optional **Tier 4** for extreme cases uses distributed full attention (e.g., Ring Attention) across multiple GPUs to process million-token sequences exactly【138967914803289†L71-L85】.  This is used for research experiments or one-off deep analyses.
+Optional **Tier 4** for extreme cases uses distributed full attention (e.g., Ring Attention) across multiple GPUs to process million-token sequences exactly[^17].  This is used for research experiments or one-off deep analyses.
 
 To implement such a system in practice:
 
@@ -158,3 +158,23 @@ As hardware improves and architectures evolve, LLMs will continue to push the li
 
 - [Context Windows Deep Dive](context-windows-deep-dive.md)
 - [Context Windows Field Guide — Appendix](context-windows-appendix.md)
+
+[^1]: Source 477669928722032 lines 226-297.
+[^2]: Source 812281553901334 lines 65-76.
+[^3]: Source 563653443713035 lines 150-171.
+[^4]: Source 477669928722032 lines 344-360.
+[^5]: Source 480357281697940 lines 73-83.
+[^6]: Source 480357281697940 lines 79-83.
+[^7]: Source 480357281697940 lines 82-89.
+[^8]: Source 162697279310482 lines 304-324.
+[^9]: Source 480357281697940 lines 86-89.
+[^10]: Source 480357281697940 lines 90-93.
+[^11]: Source 989342212075024 lines 50-60.
+[^12]: Source 556094126408083 lines 50-60.
+[^13]: Source 199134859253240 lines 78-94.
+[^14]: Source 626234754762794 lines 260-315.
+[^15]: Source 222591077498926 lines 48-60.
+[^16]: Source 100878192473897 lines 50-60.
+[^17]: Source 138967914803289 lines 71-85.
+[^18]: Source 605812693674672 lines 49-63.
+[^19]: Source 897139308669472 lines 78-95.


### PR DESCRIPTION
## Summary
- replace `【id†Lx-Ly】` markers with footnotes in context windows field guide
- convert citation markers to footnotes in context windows appendix
- clean up citation style in context windows deep dive

## Testing
- no tests run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_689f414dece883268f4e3801e8e02a11