### PR TITLE
Specify text code fence for canonical oligonucleotide schema

### DIFF
--- a/docs/non-ai-research/dna-archival-storage-tepm.md
+++ b/docs/non-ai-research/dna-archival-storage-tepm.md
@@ -46,7 +46,7 @@ The model decomposes the end-to-end process into the following distinct stages, 
 
 The efficiency and overhead of the system are fundamentally defined by the structure of each synthesized oligo. This model uses a canonical layout that captures the essential components of a data-bearing DNA molecule:
 
-```
+```text
 [5'-Primer | Index | Payload | ECC | 3'-Primer]
 ```
 


### PR DESCRIPTION
## Summary
- specify `text` language for the canonical oligonucleotide schema code block to enable syntax highlighting

## Testing
- `python -m markdown -x fenced_code docs/non-ai-research/dna-archival-storage-tepm.md | sed -n '34,42p'`


------
https://chatgpt.com/codex/tasks/task_e_689f44d1b7fc8326857e428859533e05