### PR TITLE
docs: specify text fences for power calculations

### DIFF
--- a/docs/ai-research/context-windows-appendix.md
+++ b/docs/ai-research/context-windows-appendix.md
@@ -18,7 +18,7 @@ This appendix provides supporting material for the **Context Windows Field Gu
 
 For a transformer with **L** layers, **H** heads and head dimension **d**, and using a data type requiring **dtypeBytes** bytes (e.g. 2 bytes for FP16), the memory used by the key–value cache is
 
-```
+```text
 KV_memory_bytes ≈ 2 × L × H × d × seq_length × dtypeBytes.
 ```
 
@@ -32,7 +32,7 @@ Inference speed depends on the **prefill phase** (computing attention over the e
 
 When serving multiple requests concurrently, total KV memory is:
 
-```
+```text
 Total_KV_memory ≈ KV_memory_per_token × seq_length × num_concurrent_requests.
 ```
 

--- a/docs/ai-research/open-neuromorphic-roadmap.md
+++ b/docs/ai-research/open-neuromorphic-roadmap.md
@@ -133,7 +133,7 @@ An NVIDIA H100 PCIe (80GB) accelerator has a peak FP16 performance of approximat
 - **Power Consumption**: An NVIDIA H100 GPU has a Thermal Design Power (TDP) of up to 700 W. A high-density server containing eight H100s, along with CPUs and other components, can consume 10-12 kW. A 500-GPU cluster would require approximately 63 such servers, leading to a total power draw of roughly 63 \* 12 kW = 756 kW.
 - **Electricity Cost**: Using a U.S. average data center electricity rate of $0.1063 per kWh and a typical PUE of 1.6 (representing the overhead for cooling and power delivery), the annual power cost is calculated as:
 
-```
+```text
 756 kW × 8760 hours/year × $0.1063/kWh × 1.6 PUE ≈ $1,126,000 per year
 ```
 
@@ -161,7 +161,7 @@ Modeling the TCO for a neuromorphic cluster is more speculative due to the lack 
 - **Power Consumption**: The 1,152-chip Hala Point system consumes a maximum of 2.6 kW. A 50,000-chip cluster would therefore consume approximately (50,000 / 1,152) \* 2.6 kW ≈ 113 kW.
 - **Electricity Cost**: Using the same model as the GPU cluster:
 
-```
+```text
 113 kW × 8760 hours/year × $0.1063/kWh × 1.6 PUE ≈ $168,000 per year
 ```
 


### PR DESCRIPTION
## Summary
- ensure context windows appendix code snippets render with explicit `text` fences
- label neuromorphic roadmap power calculation blocks as `text` for clearer markdown

## Testing
- `python -m markdown -x fenced_code docs/ai-research/context-windows-appendix.md`
- `python -m markdown -x fenced_code docs/ai-research/open-neuromorphic-roadmap.md`


------
https://chatgpt.com/codex/tasks/task_e_689f44cb84b08326b887e4eff4a50757