### PR TITLE
docs: update README with badges and site map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # Tino Docs Hub
 
+[![Build Status](https://github.com/d0tTino/docs-/actions/workflows/tests.yml/badge.svg)](https://github.com/d0tTino/docs-/actions/workflows/tests.yml) [![License](https://img.shields.io/github/license/d0tTino/docs-)](LICENSE)
+
 Central hub for project documentation and research across Tino initiatives.
 
-**Abstract:** The Tino Docs Hub employs a modular architecture built on MkDocs with
-Git submodules to centralize project documentation. Pre-commit hooks, helper
-scripts, and clear directory conventions standardize contributions and
+**Abstract:** The Tino Docs Hub employs a modular architecture built on MkDocs
+with Git submodules to centralize project documentation. Pre-commit hooks,
+helper scripts, and clear directory conventions standardize contributions and
 workflows. This methodology streamlines ingestion and browsing while preserving
 versioned histories. The hub ultimately enhances collaboration and ensures
 research artifacts remain accessible and maintainable.
 
+![Site Map](docs/img/site-map.svg)
+
 This repository aggregates documentation and research across multiple projects.
 
-For setup instructions, directory overview, and detailed research listings, see
-[docs/index.md](docs/index.md). For a quick start, read the [Quickstart
+For setup instructions, directory overview, and detailed research listings,
+see [docs/index.md](docs/index.md). For a quick start, read the [Quickstart
 guide](docs/quickstart.md) and review the [documentation threat
 model](docs/security/threat-model.md).
 
@@ -20,14 +24,16 @@ model](docs/security/threat-model.md).
 
 ### Pre-commit
 
-Install [pre-commit](https://pre-commit.com/) hooks to automatically expand snippets and lint Markdown files:
+Install [pre-commit](https://pre-commit.com/) hooks to automatically expand
+snippets and lint Markdown files:
 
 ```bash
 pip install pre-commit
 pre-commit install
 ```
 
-Run `npm run preexpand <file>` to manually expand `--8<--` markers when needed.
+Run `npm run preexpand <file>` to manually expand `--8<--` markers when
+needed.
 
 The hook runs `scripts/expand_snippets.py` to inline snippet references and
 `scripts/lint_research_docs.py` to catch mid-word line splits.
@@ -39,7 +45,8 @@ pip install -r requirements.txt
 mkdocs serve
 ```
 
-Install Python dependencies and serve the docs at <http://127.0.0.1:8000>.
+Install Python dependencies and serve the docs at
+<http://127.0.0.1:8000>.
 
 ### Update Submodules
 


### PR DESCRIPTION
## Summary
- add build status and license badges near README top
- embed site map diagram after abstract
- wrap README text to ~80 columns for readability

## Testing
- no tests run; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_68a0aefa7a088326bd2b760ac01185f9