### PR TITLE
docs: add friendly 404 page illustration

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -9,9 +9,12 @@ updated: 2025-08-12
 
 # Page Not Found
 
+![Friendly robot holding a 404 sign](img/404.svg)
+
 The requested page could not be located.
 
 - [Return to the home page](index.md)
+- [Quickstart guide](quickstart.md)
 - Explore the [AI Research overview](ai-research/index.md)
 - Visit the [Culture Project](culture-project/index.md)
 - Review the [Security Threat Model](security/threat-model.md)

--- a/docs/img/404.svg
+++ b/docs/img/404.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120" role="img" aria-labelledby="title">
+  <title id="title">Friendly robot 404</title>
+  <rect width="200" height="120" fill="#f0f4f8"/>
+  <circle cx="60" cy="60" r="30" fill="#ffffff" stroke="#4a5568" stroke-width="3"/>
+  <circle cx="50" cy="55" r="5" fill="#4a5568"/>
+  <circle cx="70" cy="55" r="5" fill="#4a5568"/>
+  <path d="M45 70 Q60 80 75 70" stroke="#4a5568" stroke-width="3" fill="none"/>
+  <text x="110" y="70" font-size="32" fill="#4a5568" font-family="Arial, sans-serif">404</text>
+</svg>


### PR DESCRIPTION
## Summary
- add friendly 404 page illustration
- embed 404 image and quick links on 404 page

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a0bd3a75b48326b10ec41d51ad407b