### PR TITLE
docs: tidy threat-model table formatting

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -38,7 +38,6 @@ flowchart LR
 
 ## Potential Threats
 
-
 | Threat | Impact | Likelihood | Severity | Mitigation |
 | --- | --- | --- | --- | --- |
 | Unauthorized modification or defacement of docs | Medium | Medium | Medium | Use version control; require code review to gate changes |


### PR DESCRIPTION
## Summary
- ensure threat model table rows stay on a single line
- remove extra blank line before threat table

## Testing
- `npx markdownlint docs/security/threat-model.md`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd3b1e3c8326b1f95002f46556d6