### PR TITLE
docs: make threat model more accessible

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -34,15 +34,17 @@ flowchart LR
     D --> R --> C --> S --> H --> U
 ```
 
+**Diagram description:** Developers commit documentation to a repository within the Contributors trust boundary. The CI system builds the docs and generates a static site in the CI boundary. The static site is then hosted and served to users in the Public boundary.
+
 *Figure: Flow of documentation from developers to users via CI and hosting.*
 
 ## Potential Threats
 
 | Threat | Impact | Likelihood | Severity | Mitigation |
 | --- | --- | --- | --- | --- |
-| Unauthorized modification or defacement of docs | Medium | Medium | Medium | Use version control; require code review to gate changes |
-| Malicious code injection in scripts | High | Low | High | Restrict script permissions; validate dependencies |
-| Leakage of credentials or sensitive data | High | Low | High | Scan commits for secrets; rotate credentials regularly |
+| Unauthorized modification or defacement of docs | Medium | Medium | <span style="background-color:#f0ad4e; color:#fff; padding:2px 6px; border-radius:4px;">Medium</span> | Use version control; require code review to gate changes |
+| Malicious code injection in scripts | High | Low | <span style="background-color:#d9534f; color:#fff; padding:2px 6px; border-radius:4px;">High</span> | Restrict script permissions; validate dependencies |
+| Leakage of credentials or sensitive data | High | Low | <span style="background-color:#d9534f; color:#fff; padding:2px 6px; border-radius:4px;">High</span> | Scan commits for secrets; rotate credentials regularly |
 
 ### Verification Steps
 


### PR DESCRIPTION
## Summary
- add screen-reader description for threat model diagram
- use colored badges for severity values in threat table

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a49093d6288326b5273fe5dd2516e7