### PR TITLE
docs: add overviews to non-ai research index

### DIFF
--- a/docs/non-ai-research/index.md
+++ b/docs/non-ai-research/index.md
@@ -14,14 +14,17 @@ This collection brings together research into topics outside of AI, including pr
 ## Documents
 
 ### Productivity
+- Explores methods for boosting personal efficiency and time management, with foundational practices covered in the [Quickstart guide](../quickstart.md).
 - [Add Hours to Your Day? Debunking Productivity Frameworks](add-hours-to-your-day.md)
 
 ### Corporate Studies
+- Investigates organizational behavior and corporate power structures, complemented by analyses like [The Friendly Face of Power](../friendly-face-of-power.md).
 - [Buying the Dip: A Historical, Signal-Driven Playbook for Identifying Corporate Turnarounds](buying-the-dip-playbook.md)
 - [The Corporate Egregore: An Interdisciplinary Analysis of the Corporation as an Autonomous Collective Entity](corporate-egregore.md)
 - [The Metaorganism: A New Framework for Organizational Evolution](metaorganism.md)
 
 ### General Research
+- Covers interdisciplinary inquiries into science and philosophy beyond AI; for AI-focused work, see the [AI Research collection](../ai-research/index.md).
 - [A Techno-Economic and Performance Model for DNA-Based Archival Storage](dna-archival-storage-tepm.md)
 - [An Interdisciplinary Examination of Modern Rationalism: Principles, Applications, and Critiques in the Scientific-Technological Age](modern-rationalism.md)
 - [Evolution as a Computational Process: An Interdisciplinary Investigation into Biological Compute](evolution-as-a-computational-process.md)


### PR DESCRIPTION
## Summary
- add concise overviews for productivity, corporate, and general research sections
- link productivity to quickstart guide and corporate studies to friendly face of power
- reference AI research collection from general research section

## Testing
- no tests run; documentation change only

------
https://chatgpt.com/codex/tasks/task_e_68a4909389f88326aac59288a4d56cec