### PR TITLE
Replace HTML severity labels with markdown

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -42,9 +42,11 @@ flowchart LR
 
 | Threat | Impact | Likelihood | Severity | Mitigation |
 | --- | --- | --- | --- | --- |
-| Unauthorized modification or defacement of docs | Medium | Medium | <span style="background-color:#f0ad4e; color:#fff; padding:2px 6px; border-radius:4px;">Medium</span> | Use version control; require code review to gate changes |
-| Malicious code injection in scripts | High | Low | <span style="background-color:#d9534f; color:#fff; padding:2px 6px; border-radius:4px;">High</span> | Restrict script permissions; validate dependencies |
-| Leakage of credentials or sensitive data | High | Low | <span style="background-color:#d9534f; color:#fff; padding:2px 6px; border-radius:4px;">High</span> | Scan commits for secrets; rotate credentials regularly |
+| Unauthorized modification or defacement of docs | Medium | Medium | 🟧 Medium | Use version control; require code review to gate changes |
+| Malicious code injection in scripts | High | Low | 🟥 High | Restrict script permissions; validate dependencies |
+| Leakage of credentials or sensitive data | High | Low | 🟥 High | Scan commits for secrets; rotate credentials regularly |
+
+**Severity legend:** 🟩 Low | 🟧 Medium | 🟥 High
 
 ### Verification Steps
 


### PR DESCRIPTION
## Summary
- switch threat model severity labels from HTML spans to markdown with colored emoji
- add severity color legend for clarity
- keep alt-text for mermaid diagram in security docs

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a709f624848326aad891838273c8c5