### PR TITLE
docs: add TOC to context windows guide

### DIFF
--- a/docs/ai-research/context-windows-field-guide.md
+++ b/docs/ai-research/context-windows-field-guide.md
@@ -8,6 +8,8 @@ updated: 2025-08-09
 
 --8<-- "_snippets/disclaimer.md"
 
+[[toc]]
+
 # Context Windows Field Guide
 
 ## Executive summary


### PR DESCRIPTION
## Summary
- add `[[toc]]` so the context windows guide includes a table of contents

## Testing
- ⚠️ no tests run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68a71fd9534c8326a12a16985bda15cc