### PR TITLE
Improve site map SVG readability

### DIFF
--- a/docs/img/site-map.svg
+++ b/docs/img/site-map.svg
@@ -1,5 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" font-family="monospace" font-size="12">
-  <rect width="100%" height="100%" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="300" height="200">
+  <style>
+    text {
+      font-family: monospace;
+      font-size: 14px;
+      font-weight: 600;
+      fill: currentColor;
+    }
+    rect {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1;
+    }
+  </style>
+  <rect width="100%" height="100%"/>
   <text x="10" y="20">docs/</text>
   <text x="10" y="40">├── ai-research/</text>
   <text x="10" y="60">├── arduino/</text>


### PR DESCRIPTION
## Summary
- enhance site map SVG with bold monospace font and scalable viewBox
- adopt `currentColor` and transparent background for light and dark themes

## Testing
- no tests run; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_68ada96f16988326a68e821948bb1691