### PR TITLE
Add quantum computing timeline graphic

### DIFF
--- a/docs/img/quantum-milestones-timeline.svg
+++ b/docs/img/quantum-milestones-timeline.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 180" width="800" height="180">
+  <style>
+    .title { font: bold 16px sans-serif; }
+    .label { font: 12px sans-serif; }
+    .year { font: bold 12px sans-serif; }
+  </style>
+  <text x="400" y="20" text-anchor="middle" class="title">Key Quantum Milestones</text>
+  <line x1="50" y1="80" x2="750" y2="80" stroke="#555" stroke-width="2"/>
+  <circle cx="100" cy="80" r="5" fill="#555"/>
+  <text x="100" y="100" text-anchor="middle" class="year">1900</text>
+  <text x="100" y="115" text-anchor="middle" class="label">Planck</text>
+  <circle cx="200" cy="80" r="5" fill="#555"/>
+  <text x="200" y="100" text-anchor="middle" class="year">1935</text>
+  <text x="200" y="115" text-anchor="middle" class="label">EPR</text>
+  <circle cx="350" cy="80" r="5" fill="#555"/>
+  <text x="350" y="100" text-anchor="middle" class="year">1982</text>
+  <text x="350" y="115" text-anchor="middle" class="label">Feynman</text>
+  <circle cx="450" cy="80" r="5" fill="#555"/>
+  <text x="450" y="100" text-anchor="middle" class="year">1994</text>
+  <text x="450" y="115" text-anchor="middle" class="label">Shor</text>
+  <circle cx="600" cy="80" r="5" fill="#555"/>
+  <text x="600" y="100" text-anchor="middle" class="year">2019</text>
+  <text x="600" y="115" text-anchor="middle" class="label">Supremacy</text>
+  <circle cx="700" cy="80" r="5" fill="#555"/>
+  <text x="700" y="100" text-anchor="middle" class="year">2023</text>
+  <text x="700" y="115" text-anchor="middle" class="label">1,121 Qubits</text>
+</svg>

--- a/docs/security/quantum-reckoning.md
+++ b/docs/security/quantum-reckoning.md
@@ -21,6 +21,10 @@ updated: 2025-08-13
 ## Section I: The Genesis of the Quantum Threat: A Historical Timeline
 The journey from the theoretical underpinnings of quantum computation to the tangible hardware of the present day reveals a clear and accelerating trajectory. What began as an abstract inquiry into the computational power of quantum mechanics has evolved into a global technological race with profound implications for cryptography. The historical record shows that the knowledge of the cryptographic threat has long preceded the physical means to execute it, a dynamic that defines the strategic urgency of the current moment.
 
+![Timeline of key quantum computing milestones](../img/quantum-milestones-timeline.svg)
+
+*Figure: Key milestones in quantum theory and computing from Planck's 1900 quantum hypothesis to IBM's 2023 1,121-qubit processor.*
+
 ### 1.1 The Foundational Decade (1980s): From Theory to a New Model of Computation
 The 1980s laid the intellectual groundwork for quantum computing, transforming it from a speculative idea into a formal model of computation.
 


### PR DESCRIPTION
## Summary
- create `quantum-milestones-timeline.svg` showing major milestones from Planck's 1900 quantum hypothesis to IBM's 2023 1,121-qubit processor
- embed the timeline with caption in the Historical Timeline section of `quantum-reckoning.md`

## Testing
- no tests run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68adad367c74832694e229ab52a2ab43