### PR TITLE
docs: clarify influence map legend

### DIFF
--- a/docs/gaze-research/influence_map.md
+++ b/docs/gaze-research/influence_map.md
@@ -13,4 +13,13 @@ Below is a vector diagram mapping key theorists and gaze variants.
 
 ![Influence map illustrating theoretical lineage of gaze theories](influence-map.svg)
 
-*Figure: The map links Lacan’s psychoanalytic gaze through Foucault, Mulvey, and hooks to the algorithmic gaze.*
+*Figure: The map links [Lacan](gaze_bibliography.md#lacan-and-psychoanalysis)’s psychoanalytic gaze through [Foucault](gaze_bibliography.md#medical-and-surveillance-studies), [Mulvey](gaze_bibliography.md#film-and-gender-studies), and [hooks](gaze_bibliography.md#film-and-gender-studies) to the [algorithmic gaze](gaze_bibliography.md#medical-and-surveillance-studies).*
+
+## Legend
+
+- Pink nodes (e.g., [Lacan](gaze_bibliography.md#lacan-and-psychoanalysis)) denote psychoanalytic foundations.
+- Blue nodes (e.g., [Foucault](gaze_bibliography.md#medical-and-surveillance-studies)) mark post-structural power analyses.
+- Orange nodes (e.g., [Mulvey](gaze_bibliography.md#film-and-gender-studies)) represent feminist film theory.
+- Green nodes (e.g., [hooks](gaze_bibliography.md#film-and-gender-studies)) highlight intersectional feminism.
+- Gray node ([algorithmic gaze](gaze_bibliography.md#medical-and-surveillance-studies)) indicates contemporary digital extensions.
+- Arrows show the direction of theoretical influence from earlier to later thinkers.


### PR DESCRIPTION
## Summary
- link key theorists in influence map to bibliography entries
- document node colors and arrow direction in new legend section

## Testing
- `mkdocs build` *(fails: MkDocs encountered an error parsing the configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68adad2a7d988326afc7bafec3b63465