### PR TITLE
docs: add RL vs pretraining diagram

### DIFF
--- a/docs/ai-research/agentic-swe-discontinuity-forecast.md
+++ b/docs/ai-research/agentic-swe-discontinuity-forecast.md
@@ -27,6 +27,10 @@ The second perspective views the problem not as one of fine-tuning but of fundam
 
 These two hypotheses are not mutually exclusive. A cleaner, more capable base model from a successful pre-training run would provide a much better foundation for subsequent RL scaling. However, they compete for the same finite and increasingly strained resource: vast, stable, large-scale compute. This report will systematically analyze the evidence for both hypotheses, concluding that progress is likely to be a function of both, but that the technical challenges of "Fixing the Machine" are becoming a dominant constraint on the pace of frontier development.
 
+Figure 1 contrasts these two paths to capability: scaling RL compute versus executing a clean pre-training run.
+
+![Figure 1: RL scaling versus clean pre-training](../img/rl-vs-pretraining.svg)
+
 ### 1.3 The Accelerating Baseline
 
 To quantitatively assess the potential for a future discontinuity, it is essential to first establish a robust baseline of current progress. This report adopts the "50% task-completion time horizon" metric, developed by the AI safety and evaluation organization METR, as its primary measure of agentic capability. This metric defines a model's capability in terms of the length of time a human expert would take to complete a task that the AI agent can successfully complete with 50% probability. This provides a universal, intuitive scale for comparing performance across diverse tasks and models, from simple coding problems that take minutes to complex software engineering challenges that take hours.

--- a/docs/img/rl-vs-pretraining.svg
+++ b/docs/img/rl-vs-pretraining.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <style>
+    .axis { stroke:#000; stroke-width:2; fill:none; }
+    .rl { stroke:#1f77b4; stroke-width:2; fill:none; }
+    .pre { stroke:#ff7f0e; stroke-width:2; fill:none; stroke-dasharray:5,5; }
+    text { font-family: sans-serif; font-size:12px; }
+  </style>
+  <line class="axis" x1="40" y1="200" x2="360" y2="200"/>
+  <line class="axis" x1="40" y1="200" x2="40" y2="20"/>
+  <path class="rl" d="M40 180 Q150 100 360 40"/>
+  <path class="pre" d="M40 180 Q180 160 360 80"/>
+  <text x="360" y="215" text-anchor="end">Compute</text>
+  <text x="15" y="20" text-anchor="middle" transform="rotate(-90 15,20)">Capability</text>
+  <text x="230" y="70" fill="#1f77b4">RL scaling</text>
+  <text x="230" y="110" fill="#ff7f0e">Clean pre-training</text>
+</svg>


### PR DESCRIPTION
## Summary
- add diagram comparing RL scaling and clean pre-training
- reference the figure with a short caption in the introduction

## Testing
- no tests were run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68af0d8619f88326a051fa1cd7efb5ab