### PR TITLE
Replace context window matrix CSV with markdown table

### DIFF
--- a/docs/ai-research/context-windows-appendix.md
+++ b/docs/ai-research/context-windows-appendix.md
@@ -98,7 +98,7 @@ For each position *p* in {1 k, 4 k, 16 k, 64 k, …}, embed a retrieval
 
 ## D. Design matrix summary
 
-The CSV file `context-windows-design-matrix.csv` (see repository) lists the main families of methods (positional scaling, efficient attention, streaming/compressive, distributed full attention, external memory, system-level optimisations) along with their complexity, typical effective length, advantages and caveats.  Use this matrix to compare techniques and decide which to apply in your project.
+The table in [context-windows-design-matrix.md](context-windows-design-matrix.md) lists the main families of methods (positional scaling, efficient attention, streaming/compressive, distributed full attention, external memory, system-level optimisations) along with their complexity, typical effective length, advantages and caveats. Use this matrix to compare techniques and decide which to apply in your project.
 
 ![Context windows design matrix](context-windows-design-matrix.svg)
 

--- a/docs/ai-research/context-windows-design-matrix.csv
+++ b/docs/ai-research/context-windows-design-matrix.csv
@@ -1,7 +1,0 @@
-Method,Complexity,Typical max effective length,Advantages,Caveats
-Position Interpolation / YaRN / StRing,Quadratic,32k–128k,"Simple to implement; preserves in-window quality","Drift or instability beyond trained range; still quadratic"
-Longformer / BigBird / Performer,Linear or sparse,100k+,"Scales to long inputs; good for long documents","May lose global information; trained models required"
-Transformer-XL / Infini-attention / StreamingLLM,Streaming,100k–1M,"Handles arbitrarily long streams; bounded memory","Compression may lose information; limited joint reasoning"
-Ring Attention,Distributed quadratic,1M+,"Exact full attention for extreme lengths","Requires multiple GPUs and high-speed interconnect"
-kNN-LM / RETRO / RAG,Retriever-dependent,Unbounded,"Decouples knowledge from window; excels at factual recall","Requires external memory and retriever; alignment complexity"
-FlashAttention / PagedAttention / vLLM,Quadratic but IO-optimised,Hardware-dependent,"Makes long context feasible by reducing memory bandwidth; essential for serving","Kernel/serving stack changes required; does not change algorithmic scaling"

--- a/docs/ai-research/context-windows-design-matrix.md
+++ b/docs/ai-research/context-windows-design-matrix.md
@@ -13,8 +13,8 @@ updated: 2025-08-15
 
 The matrix compares long-context techniques across complexity, maximum effective length, advantages, and caveats. Each row represents a strategy for extending transformer context windows, enabling quick trade-off evaluations.
 
-| Method | Complexity | Typical max effective length | Advantages | Caveats |
-| --- | --- | --- | --- | --- |
+| **Method** | **Complexity** | **Typical max effective length** | **Advantages** | **Caveats** |
+| :--- | :--- | :--- | :--- | :--- |
 | Position Interpolation / YaRN / StRing | Quadratic | 32k–128k | Simple to implement; preserves in-window quality | Drift or instability beyond trained range; still quadratic |
 | Longformer / BigBird / Performer | Linear or sparse | 100k+ | Scales to long inputs; good for long documents | May lose global information; trained models required |
 | Transformer-XL / Infini-attention / StreamingLLM | Streaming | 100k–1M | Handles arbitrarily long streams; bounded memory | Compression may lose information; limited joint reasoning |

--- a/docs/ai-research/context-windows-design-matrix.py
+++ b/docs/ai-research/context-windows-design-matrix.py
@@ -1,20 +1,31 @@
 #!/usr/bin/env python3
 """Generate Plotly table for context-windows design matrix."""
 from pathlib import Path
-import csv
+
 import plotly.graph_objects as go
+
+
+def _read_markdown_table(path: Path) -> tuple[list[str], list[list[str]]]:
+    rows: list[list[str]] = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line.startswith("|"):
+                continue
+            if set(line.replace("|", "").strip()) <= set("-: "):
+                continue
+            rows.append([cell.strip() for cell in line.strip("|").split("|")])
+    header = rows[0]
+    data_rows = rows[1:]
+    return header, data_rows
 
 
 def main() -> None:
     base_path = Path(__file__).resolve().parent
-    csv_path = base_path / "context-windows-design-matrix.csv"
+    md_path = base_path / "context-windows-design-matrix.md"
     html_path = base_path / "context-windows-design-matrix.html"
 
-    with csv_path.open(newline="", encoding="utf-8") as f:
-        reader = csv.reader(f)
-        header = next(reader)
-        rows = list(reader)
-
+    header, rows = _read_markdown_table(md_path)
     columns = list(zip(*rows)) if rows else [[] for _ in header]
 
     table = go.Figure(

--- a/docs/ai-research/context-windows-field-guide.md
+++ b/docs/ai-research/context-windows-field-guide.md
@@ -36,7 +36,7 @@ KV_memory_bytes ≈ 2 × L × H × d × seq_length × dtypeBytes
 
 *Figure 1: KV cache size grows roughly linearly with model scale and token count.*
 
-The underlying data in [context-windows-design-matrix.csv](context-windows-design-matrix.csv) maps each bar to a model and sequence length, helping you read exact memory requirements from the chart.
+The underlying data in [context-windows-design-matrix.md](context-windows-design-matrix.md) maps each bar to a model and sequence length, helping you read exact memory requirements from the chart.
 {{ read_file('docs/ai-research/context-windows-design-matrix.html') }}
 
 ![Context windows design matrix](context-windows-design-matrix.svg)


### PR DESCRIPTION
## Summary
- Replace CSV-based context window matrix with inlined Markdown table
- Update scripts to parse Markdown table instead of CSV
- Refresh documentation links and remove obsolete CSV file

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af0d843e808326899dbf4a20ba5d2f