### PR TITLE
Add qubit error amplification diagram

### DIFF
--- a/docs/img/qubit-error-amplification.svg
+++ b/docs/img/qubit-error-amplification.svg
@@ -1,0 +1,20 @@
+<svg width="400" height="100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#000" />
+    </marker>
+    <marker id="arrow-red" markerWidth="10" markerHeight="10" refX="5" refY="3" orient="auto">
+      <path d="M0,0 L10,3 L0,6 Z" fill="red" />
+    </marker>
+  </defs>
+  <rect x="20" y="30" width="100" height="40" rx="5" ry="5" fill="#e6f2ff" stroke="#003366"/>
+  <text x="70" y="55" font-size="12" text-anchor="middle" fill="#000">Initial Qubit</text>
+  <rect x="150" y="30" width="100" height="40" rx="5" ry="5" fill="#ffe6e6" stroke="#660000"/>
+  <text x="200" y="55" font-size="12" text-anchor="middle" fill="#000">Error Introduced</text>
+  <rect x="280" y="30" width="100" height="40" rx="5" ry="5" fill="#ffcccc" stroke="#660000"/>
+  <text x="330" y="55" font-size="12" text-anchor="middle" fill="#000">Amplified Error</text>
+  <line x1="120" y1="50" x2="150" y2="50" stroke="#000" marker-end="url(#arrow)"/>
+  <line x1="250" y1="50" x2="280" y2="50" stroke="#000" marker-end="url(#arrow)"/>
+  <text x="150" y="20" font-size="10" fill="red">noise</text>
+  <line x1="145" y1="25" x2="150" y2="40" stroke="red" marker-end="url(#arrow-red)"/>
+</svg>

--- a/docs/security/quantum-reckoning.md
+++ b/docs/security/quantum-reckoning.md
@@ -18,6 +18,10 @@ updated: 2025-08-13
 - Cryptocurrencies relying on ECDSA are particularly exposed, making the shift to quantum-safe standards a complex yet urgent challenge.
 - The report urges immediate "quantum readiness": inventory existing cryptography, prioritize high-value assets, invest in crypto-agility, and develop time-bound roadmaps for PQC adoption to avoid escalating risk and cost.
 
+![Illustration of qubit error amplification](../img/qubit-error-amplification.svg)
+
+*Figure: A single qubit error can cascade through entangling operations, amplifying faults across a quantum system.*
+
 ## Section I: The Genesis of the Quantum Threat: A Historical Timeline
 The journey from the theoretical underpinnings of quantum computation to the tangible hardware of the present day reveals a clear and accelerating trajectory. What began as an abstract inquiry into the computational power of quantum mechanics has evolved into a global technological race with profound implications for cryptography. The historical record shows that the knowledge of the cryptographic threat has long preceded the physical means to execute it, a dynamic that defines the strategic urgency of the current moment.
 


### PR DESCRIPTION
## Summary
- add SVG diagram illustrating qubit error amplification
- embed the diagram near the introduction of the quantum reckoning guide with caption and alt text

## Testing
- no tests run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68af11ac485c8326bbe9cb95c337e9d6