### PR TITLE
docs: highlight severity levels in threat model

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -42,15 +42,15 @@ flowchart LR
 
 | Threat                                          | Impact | Likelihood | Severity | Mitigation                                              |
 |-------------------------------------------------|--------|------------|----------|---------------------------------------------------------|
-| Unauthorized modification or defacement of docs | Medium | Medium     | Medium   | Use version control; require code review to gate changes |
-| Malicious code injection in scripts             | High   | Low        | High     | Restrict script permissions; validate dependencies      |
-| Leakage of credentials or sensitive data        | High   | Low        | High     | Scan commits for secrets; rotate credentials regularly   |
+| Unauthorized modification or defacement of docs | Medium | Medium     | 🟧 Medium | Use version control; require code review to gate changes |
+| Malicious code injection in scripts             | High   | Low        | 🟥 High   | Restrict script permissions; validate dependencies      |
+| Leakage of credentials or sensitive data        | High   | Low        | 🟥 High   | Scan commits for secrets; rotate credentials regularly   |
 
 **Severity legend:**
 
-- Low
-- Medium
-- High
+- 🟩 Low
+- 🟧 Medium
+- 🟥 High
 
 ### Verification Steps
 


### PR DESCRIPTION
## Summary
- add colored emoji to severity column in threat model table
- document legend for severity colors

## Testing
- `npx markdownlint docs/security/threat-model.md`
- `python -m markdown -x tables docs/security/threat-model.md > /tmp/rendered_py.html`
- `grep -n '<table' /tmp/rendered.html`


------
https://chatgpt.com/codex/tasks/task_e_68af11aabbe08326a0a33e22d933f268