### PR TITLE
docs: replace site map img tag with markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Key features:
 - Pre-commit hooks and helper scripts that standardize contributions.
 - Clear directory conventions that streamline browsing and preserve version history.
 
-<img src="docs/img/site-map.svg" alt="Diagram of repository site map illustrating documentation flow across modules" />
+![Site map diagram](docs/img/site-map.svg)
+
+This diagram illustrates documentation flow across project modules.
 
 This repository aggregates documentation and research across multiple projects.
 


### PR DESCRIPTION
## Summary
- use Markdown image syntax for the site map diagram in README
- add a brief caption describing the diagram's role

## Testing
- no tests run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68b6e92351fc8326aff2ead8b1c0b6e7