### PR TITLE
Reflow index abstract and fix helper scripts wording

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,10 @@ updated: 2025-07-29
 
 # Tino Docs Hub
 
-**Abstract:** The Tino Docs Hub centralizes project documentation with MkDocs and Git submodules. Pre-commit hooks, helper scripts, and consistent directory conventions streamline contributions, keeping research artifacts easy to browse and maintain.
+**Abstract:** The Tino Docs Hub centralizes project documentation with MkDocs
+and Git submodules. Pre-commit hooks, helper scripts, and consistent directory
+conventions streamline contributions, keeping research artifacts easy to browse
+and maintain.
 
 This repository aggregates documentation and research across multiple projects.
 


### PR DESCRIPTION
## Summary
- reflow Abstract in docs index so lines stay within 80 characters
- ensure the phrase 'helper scripts' is joined on one line
- confirm Table of Contents headings and punctuation are consistent

## Testing
- no tests run; documentation-only change


------
https://chatgpt.com/codex/tasks/task_e_68b6e923e4d48326a220e84db06b80e5