### PR TITLE
docs: expand contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,24 @@ Thank you for your interest in improving the Tino Docs Hub.
 4. Commit your work and open a Pull Request for review.
 
 Please follow these steps to keep contributions consistent and easy to review.
+
+## Commit Message Conventions
+
+- Use the present tense and imperative mood (e.g., "add feature" not "added" or "adds").
+- Begin the subject with an optional scope such as `docs:`, `feat:`, or `fix:` when it helps clarify the change.
+- Keep the subject line to 72 characters or fewer.
+
+## Code Style Expectations
+
+- Match the surrounding code and documentation style.
+- Run linters and formatters before committing to avoid style issues.
+
+## Running pre-commit locally
+
+`scripts/setup_hooks.sh` installs the repository's pre-commit hooks. After installation, run:
+
+```bash
+pre-commit run --files <path/to/file>
+```
+
+Use `pre-commit run --all-files` to check the entire repository.


### PR DESCRIPTION
## Summary
- document commit message conventions
- note code style expectations
- explain how to run pre-commit locally

## Testing
- `pre-commit run --files CONTRIBUTING.md -c .pre-commit-config.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b6ecbebb708326a259f4bc6b800313