### PR TITLE
docs(contributing): add documentation style guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,22 @@ Please follow these steps to keep contributions consistent and easy to review.
 - Begin the subject with an optional scope such as `docs:`, `feat:`, or `fix:` when it helps clarify the change.
 - Keep the subject line to 72 characters or fewer.
 
+Example:
+
+```
+docs(quickstart): add Git LFS instructions
+```
+
 ## Code Style Expectations
 
 - Match the surrounding code and documentation style.
 - Run linters and formatters before committing to avoid style issues.
+
+## Documentation Style
+
+- Each Markdown file must begin with front matter containing `title`, `tags`, `project`, and `updated` fields.
+- Reuse common content with snippets using `--8<-- "path/to/snippet.md"` syntax.
+- All images require descriptive alt text to aid accessibility.
 
 ## Running pre-commit locally
 


### PR DESCRIPTION
## Summary
- document required front matter fields and snippet and image conventions
- add commit message example with scope tag

## Testing
- no tests needed

------
https://chatgpt.com/codex/tasks/task_e_68b84bd465088326ba1a8ea85063fa15