### PR TITLE
Refine Palantir timeline graphic

### DIFF
--- a/docs/digital-panopticon.md
+++ b/docs/digital-panopticon.md
@@ -24,7 +24,9 @@ Palantir Technologies, born from the nexus of Silicon Valley innovation and CIA 
 This investigation examines Palantir not merely as a contractor but as a central architect of the contemporary surveillance state. Gotham and Foundry merge the siloed records of a citizen's life into a single plane of actionable data, revealing how the post‑9/11 security climate evolved into the reality of August 2025.
 
 ### Historical Context
-![Palantir timeline](img/palantir-timeline.svg)
+![Timeline of key Palantir and surveillance milestones from ECHELON in 1971 to the 2025 DOGE initiative.](img/palantir-timeline.svg)
+
+*Figure: Key events in the evolution of Palantir and the modern surveillance state.*
 
 #### 1960s–1970s: Signals Intelligence Takes Shape
 - ECHELON, formalized in 1971, created a Five Eyes signals intelligence network.
@@ -70,7 +72,6 @@ The impact was immediate and profound. The American public was sharply divided, 
 
 However, the Snowden rupture had a more complex and subtle effect on the surveillance industry. While the leaks created a public relations crisis for the intelligence community by exposing its indiscriminate, "brute force" methods of data collection, they also inadvertently created a market for a different kind of surveillance—one that could be framed as "smarter," more "targeted," and more respectful of civil liberties. Palantir was perfectly positioned to capitalize on this narrative shift. The company's marketing had always emphasized an "intelligence augmentation" approach, using its software to help human analysts find the "needle in a haystack" rather than simply collecting the entire haystack. Thiel himself had described Palantir as a "mission-oriented company" that aimed to "reduce terrorism while preserving civil liberties". In the post-Snowden debate over how to balance security and privacy, this narrative gained significant traction. The public backlash against the NSA's methods created a strategic opening for companies like Palantir to sell a more sophisticated, and arguably more insidious, form of surveillance—one based on the deep integration and algorithmic analysis of disparate datasets, rather than just bulk collection. The core surveillance infrastructure remained intact, but the public-facing justification for its use began to evolve, paving the way for Palantir's ascent.
 
-![Palantir timeline](img/palantir-timeline.svg)
 
 ## Part II: The Palantir Engine: Technology of Omniscience
 Palantir Technologies' influence stems not from its ability to collect new data, but from its unparalleled power to synthesize and make sense of existing, disparate information. The company's core innovation is a form of "integration intelligence," a technological capacity to transform oceans of fractured, messy, and often incompatible datasets into a single, coherent, and actionable model of reality. Its software platforms, Gotham and Foundry, function as an operating system for data, sitting atop a client's existing infrastructure and creating a unified analytical environment. This engine of omniscience, powered by a unique semantic layer and increasingly sophisticated AI, is the technical foundation of the modern surveillance state.

--- a/docs/img/palantir-timeline.svg
+++ b/docs/img/palantir-timeline.svg
@@ -3,19 +3,28 @@
     .label { font: 12px sans-serif; }
   </style>
   <line x1="50" y1="100" x2="750" y2="100" stroke="#555" stroke-width="2"/>
-  <!-- ECHELON -->
-  <circle cx="100" cy="100" r="8" fill="#1f77b4"/>
-  <text x="100" y="80" text-anchor="middle" class="label">1971 ECHELON formalized</text>
-  <!-- PATRIOT Act -->
-  <circle cx="250" cy="100" r="8" fill="#1f77b4"/>
-  <text x="250" y="80" text-anchor="middle" class="label">2001 PATRIOT Act</text>
-  <!-- Palantir founded -->
+  <!-- 1971 ECHELON -->
+  <circle cx="80" cy="100" r="8" fill="#1f77b4"/>
+  <text x="80" y="80" text-anchor="middle" class="label">1971 ECHELON formalized</text>
+  <!-- 1999 In-Q-Tel -->
+  <circle cx="200" cy="100" r="8" fill="#1f77b4"/>
+  <text x="200" y="80" text-anchor="middle" class="label">1999 In-Q-Tel founded</text>
+  <!-- 2001 PATRIOT Act -->
+  <circle cx="260" cy="100" r="8" fill="#1f77b4"/>
+  <text x="260" y="120" text-anchor="middle" class="label">2001 USA PATRIOT Act</text>
+  <!-- 2003 Palantir founded -->
   <circle cx="320" cy="100" r="8" fill="#1f77b4"/>
   <text x="320" y="80" text-anchor="middle" class="label">2003 Palantir founded</text>
-  <!-- Snowden -->
-  <circle cx="450" cy="100" r="8" fill="#1f77b4"/>
-  <text x="450" y="80" text-anchor="middle" class="label">2013 Snowden leaks</text>
-  <!-- DOGE/2025 -->
+  <!-- 2005 In-Q-Tel investment -->
+  <circle cx="380" cy="100" r="8" fill="#1f77b4"/>
+  <text x="380" y="120" text-anchor="middle" class="label">2005 In-Q-Tel invests</text>
+  <!-- 2013 Snowden -->
+  <circle cx="460" cy="100" r="8" fill="#1f77b4"/>
+  <text x="460" y="80" text-anchor="middle" class="label">2013 Snowden leaks</text>
+  <!-- 2020 HHS Tiberius -->
+  <circle cx="560" cy="100" r="8" fill="#1f77b4"/>
+  <text x="560" y="120" text-anchor="middle" class="label">2020 HHS Tiberius</text>
+  <!-- 2025 DOGE -->
   <circle cx="650" cy="100" r="8" fill="#1f77b4"/>
   <text x="650" y="80" text-anchor="middle" class="label">2025 DOGE initiative</text>
 </svg>


### PR DESCRIPTION
## Summary
- extend Palantir timeline graphic with additional milestones from ECHELON's 1971 formalization to the 2025 DOGE initiative
- embed updated timeline in digital-panopticon doc with descriptive alt text and caption

## Testing
- no tests run; documentation-only changes


------
https://chatgpt.com/codex/tasks/task_e_68b85224e8248326b42aec0e7f0f5891