### PR TITLE
Replace TOC placeholder with directive

### DIFF
--- a/docs/ai-research/evolving-perspectives-on-agi.md
+++ b/docs/ai-research/evolving-perspectives-on-agi.md
@@ -9,7 +9,7 @@ updated: 2025-01-15
 
 # Evolving Perspectives on AGI: A Dialogue Between Francois Chollet and Dwarkesh Patel
 
-[TOC]
+[[toc]]
 
 In a riveting discussion hosted on the Dwarkesh Podcast, Francois Chollet, a prominent AI researcher known for his work on the Keras deep learning library and the ARC-AGI benchmark, engages with host Dwarkesh Patel on the trajectory of artificial general intelligence (AGI). Recorded approximately 12 months after their initial debate, this conversation reveals significant shifts in both participants' viewpoints, underscoring the rapid evolution in frontier AI research. Drawing from the transcript of the YouTube video (accessible at https://www.youtube.com/watch?v=1if6XbzD5Yg), this report synthesizes and expounds upon the key ideas, incorporating direct quotations to illuminate the nuanced arguments presented.
 

--- a/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
+++ b/docs/ai-research/reverse-engineering-chatgpt-agent-system.md
@@ -9,7 +9,7 @@ updated: 2025-07-29
 
 # Reverse-Engineering Design Report: OpenAI ChatGPT Agent System
 
-[TOC]
+[[toc]]
 
 ## Key Findings
 - The ChatGPT Agent system uses an asynchronous ReAct-style reasoning loop to break down user goals into tool-driven actions.

--- a/docs/cyberpunk-cookbook.md
+++ b/docs/cyberpunk-cookbook.md
@@ -9,7 +9,7 @@ updated: 2025-07-30
 
 # Cyberpunk Cookbook
 
-[TOC]
+[[toc]]
 
 ## Wave 1: Foundations ![Wave 1 foundations icon](wave-icons/wave1-foundations.svg){ width=20 }
 


### PR DESCRIPTION
## Summary
- swap `[TOC]` with `[[toc]]` after section titles in multiple research docs to enable in-page table of contents generation

## Testing
- `mkdocs build` *(fails: Config value 'plugins': The "sitemap" plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d3242008326b94ce8e739139774