### PR TITLE
Add TOC and glightbox image to terminal workflow doc

### DIFF
--- a/docs/terminal-workflow/index.md
+++ b/docs/terminal-workflow/index.md
@@ -13,6 +13,7 @@ This area collects notes on command-line tools and shell tips for daily
 development. More workflow examples will be added over time. For a broader
 overview of the docs repo, see [the main index](../index.md).
 
+[[toc]]
 
 ## tmux
 
@@ -76,4 +77,5 @@ git push origin main
 
 ## Example Session
 
-![Example terminal session](../img/example-session.svg)
+![Screenshot of an example terminal session](../img/example-session.svg){data-glightbox}
+


### PR DESCRIPTION
## Summary
- Insert table of contents macro below the Terminal Workflow intro paragraph
- Enable lightbox and descriptive alt text for the example session screenshot

## Testing
- `mkdocs build` *(fails: Config value 'plugins': The "sitemap" plugin is not installed)*
- `ls docs/index.md`


------
https://chatgpt.com/codex/tasks/task_e_68b85d2e75b48326b216bf30ca0bc685