### PR TITLE
docs: expand site map description

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,9 @@ README.
 ## Directory Structure
 Overview of key directories and their purposes.
 
-![Diagram of documentation flow](img/site-map.svg)
+![Site map diagram illustrating the flow from the landing page through section directories and project submodules](img/site-map.svg)
+
+*Figure: Documentation flow showing relationships between the landing page, section directories, and project submodules.*
 
 | Location | Description |
 | --- | --- |


### PR DESCRIPTION
## Summary
- replace site map alt text with fuller description of documentation flow
- add caption under image for clarity

## Testing
- `mkdocs build` *(fails: Config value 'plugins': The "sitemap" plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b862c5b8f88326a584a04d37bb1b0e