### PR TITLE
docs: list required tool versions

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,6 +12,13 @@ updated: 2025-08-13
 !!! note
     Need command-line tips? See the [Terminal Workflow guide](terminal-workflow/index.md) for more CLI tips.
 
+| Tool | Required Version |
+| --- | --- |
+| Python | >=3.11 |
+| Node.js | >=20 |
+| Git | >=2.40 |
+| MkDocs | >=1.5 |
+
 ## Set Up Git LFS and pre-commit
 1. Install Git LFS:
 


### PR DESCRIPTION
## Summary
- add a quick reference table of required Python, Node, Git, and MkDocs versions to the quickstart guide

## Testing
- `pip install -r requirements.txt`
- `mkdocs build` *(fails: Config value 'plugins': The "sitemap" plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b862c66d6c8326bf05031daf1906dd