### PR TITLE
Add Jungian psyche layers diagram

### DIFF
--- a/docs/non-ai-research/fig/jungian-psyche-layers.svg
+++ b/docs/non-ai-research/fig/jungian-psyche-layers.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 500 500" role="img" aria-labelledby="title desc">
+  <title id="title">Jungian Psyche Layers</title>
+  <desc id="desc">Diagram of Persona, Ego, Shadow, Self, and Unconscious layers</desc>
+  <defs>
+    <style>
+      text { font-family: Arial, sans-serif; font-size: 16px; text-anchor: middle; }
+    </style>
+  </defs>
+  <!-- Persona outer ring -->
+  <circle cx="250" cy="250" r="220" fill="none" stroke="#ffcc00" stroke-width="20" />
+  <text x="250" y="30">Persona</text>
+  <!-- Self -->
+  <circle cx="250" cy="250" r="200" fill="#e6f7ff" stroke="#000" stroke-width="2" />
+  <text x="250" y="60">Self</text>
+  <!-- Unconscious region -->
+  <circle cx="250" cy="250" r="150" fill="#f2e6ff" stroke="none" />
+  <text x="250" y="110">Unconscious</text>
+  <!-- Shadow area -->
+  <path d="M250,250 m0,-150 a150,150 0 0,1 130,75 l-130,75 z" fill="#999" opacity="0.7" />
+  <text x="350" y="260">Shadow</text>
+  <!-- Ego -->
+  <circle cx="250" cy="250" r="80" fill="#fff" stroke="#000" stroke-width="2" />
+  <text x="250" y="255">Ego</text>
+</svg>

--- a/docs/non-ai-research/jungian-psyche-analysis.md
+++ b/docs/non-ai-research/jungian-psyche-analysis.md
@@ -34,6 +34,8 @@ The entire psychic system—Consciousness, the Personal Unconscious, and the Col
 
 Dynamic processes connect these structures. Repression is the mechanism by which the Ego pushes unwanted content into the Shadow. Projection is the process by which the contents of the Shadow are unconsciously externalized and perceived in other people. The process of Individuation is the lifelong journey of integrating these disparate parts, bringing the contents of the Shadow into relationship with the Ego, and shifting the center of the personality from the Ego to the Self. This diagrammatic representation clarifies that the psyche, in Jung's view, is not a static entity but a living system of interacting, often conflicting, components striving for balance and wholeness.
 
+![Diagram of Jungian psyche layers including Persona, Ego, Shadow, Self, and the Unconscious](fig/jungian-psyche-layers.svg)
+
 Part II: An Annotated Glossary of the Jungian Psyche
 This section provides a more exhaustive, referenced exploration of the core concepts, grounding them firmly in Jung's Collected Works and reputable Jungian scholarship. Each entry details the term's definition, its relationship to other psychic structures, and the risks associated with its misunderstanding or mismanagement.
 


### PR DESCRIPTION
## Summary
- add SVG diagram depicting Persona, Ego, Shadow, Self, and Unconscious layers
- reference the new diagram in Jungian psyche analysis doc

## Testing
- `mkdocs serve -f mkdocs-nositemap.yml -a 0.0.0.0:8000` (served site for manual verification)
- `curl -s http://localhost:8000/non-ai-research/jungian-psyche-analysis/ | grep -n "jungian-psyche-layers"`

------
https://chatgpt.com/codex/tasks/task_e_68b862cf75348326a3e7047873e9e61c