### PR TITLE
docs: caption reasoning flow for Grok 4 Heavy

### DIFF
--- a/docs/ai-research/reverse-engineering-grok4-heavy.md
+++ b/docs/ai-research/reverse-engineering-grok4-heavy.md
@@ -26,6 +26,8 @@ The system's primary operational modality involves decomposing complex user prom
 
 The reasoning loop and tool interactions can be visualized as:
 
+<figure aria-label="Flowchart depicting user queries passing through reasoning, optional tool use, and final response">
+
 ```mermaid
 flowchart TD
     U[User Query] --> R[Agent Reasoning]
@@ -36,6 +38,9 @@ flowchart TD
     R --> A
     A --> O[User Output]
 ```
+
+<figcaption>User query ➜ reasoning ➜ tools ➜ response</figcaption>
+</figure>
 
 ### 1.2 Inferred Architecture at a Glance
 


### PR DESCRIPTION
## Summary
- wrap Grok 4 Heavy reasoning mermaid diagram in `<figure>` tags
- add alt text and caption "User query ➜ reasoning ➜ tools ➜ response"

## Testing
- no tests run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68bef46abbe0832699ce9c7a81cbea9b