### PR TITLE
docs: embed kv cache chart iframe

### DIFF
--- a/docs/ai-research/kv-cache-chart.md
+++ b/docs/ai-research/kv-cache-chart.md
@@ -14,7 +14,9 @@ updated: 2025-08-15
 *Figure: KV cache memory grows nearly linearly with context length across model scales.*
 
 
-[Interactive HTML visualization](kv-cache-chart.html)
+<iframe src="kv-cache-chart.html" width="100%" height="420"></iframe>
+
+*Note:* Regenerate the HTML using [`scripts/kv_capacity.py`](../../scripts/kv_capacity.py) with the `--plotly` flag if the underlying data changes.
 
 A static rendering of the KV cache visualization originally distributed as an HTML artifact.
 


### PR DESCRIPTION
## Summary
- embed the kv-cache chart HTML directly via an iframe with explicit width/height
- document how to regenerate the HTML output via `scripts/kv_capacity.py`

## Testing
- no tests run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68bef46fa64483269694f9007332d394