### PR TITLE
docs: reorganize security index

### DIFF
--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -5,14 +5,18 @@ updated: 2025-08-15
 ---
 --8<-- "_snippets/disclaimer.md"
 
+{{ toc }}
+
 # Security
 
 Resources related to security practices and research.
 
 ## Guidance
-- [Threat Model](threat-model.md):
-  Identifies potential security threats and proposes mitigation strategies.
+- [Threat Model](threat-model.md) — identifies potential security threats and proposes mitigation strategies.
 
 ## Research
-- [Quantum Reckoning](quantum-reckoning.md):
-  Examines how quantum computing could undermine current cryptographic methods.
+- [Quantum Reckoning](quantum-reckoning.md) — examines how quantum computing could undermine current cryptographic methods.
+
+## Further Reading
+
+- [Privacy & OpSec Icon](../wave-icons/wave3-privacy-opsec.svg)


### PR DESCRIPTION
## Summary
- insert table of contents after disclaimer in security docs
- restructure security resources into Guidance and Research lists
- add Further Reading link to wave3 Privacy & OpSec icon

## Testing
- No tests were run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68bef4517c2c83269edb6a43641cc50a