### PR TITLE
docs: expand gaze alt text and summary

### DIFF
--- a/docs/gaze-research/img/influence-map.svg
+++ b/docs/gaze-research/img/influence-map.svg
@@ -1,4 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="200" viewBox="0 0 800 200">
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="200" viewBox="0 0 800 200" role="img">
+  <title>Influence map linking Jacques Lacan, Michel Foucault, Laura Mulvey, and bell hooks to the algorithmic gaze</title>
+  <desc>Diagram showing theoretical influence from Lacan to Foucault to Mulvey to hooks culminating in the algorithmic gaze.</desc>
   <defs>
     <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#000" />

--- a/docs/gaze-research/index.md
+++ b/docs/gaze-research/index.md
@@ -20,5 +20,7 @@ This section collects deliverables for the project "From Mirror to Feed: A Compr
 - [Influence Map](influence_map.md): Visualizes conceptual relationships among thinkers and ideas surrounding the gaze.
 - [BibTeX References](gaze_references.bib): Supplies machine-readable citations for further research.
 
-![Diagram showing theoretical influence among Lacan, Foucault, Mulvey, hooks, and the algorithmic gaze](img/influence-map.svg)
+Together, these materials trace the evolution of gaze theory from psychoanalytic and feminist foundations to contemporary algorithmic perspectives.
+
+![Influence map linking Jacques Lacan, Michel Foucault, Laura Mulvey, and bell hooks to the algorithmic gaze](img/influence-map.svg)
 


### PR DESCRIPTION
## Summary
- expand alt text for gaze influence map and add accessible title/description in SVG
- add concise summary sentence after deliverables list

## Testing
- `pre-commit run --config .pre-commit-config.yml --files docs/gaze-research/index.md docs/gaze-research/img/influence-map.svg`

------
https://chatgpt.com/codex/tasks/task_e_68c02f9313a4832689f32936bdd4f593