### PR TITLE
feat: enable tabbed and copybutton extensions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.highlight
   - pymdownx.superfences
+  - pymdownx.tabbed
+  - pymdownx.copybutton
   - footnotes
 
 nav:


### PR DESCRIPTION
## Summary
- enable pymdownx.tabbed and pymdownx.copybutton extensions in mkdocs config

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_68c02f97e83c83269d31d1466906c941