### PR TITLE
Add glightbox attribute and regeneration instructions

### DIFF
--- a/docs/a-fire-upon-the-deep-consciousness.md
+++ b/docs/a-fire-upon-the-deep-consciousness.md
@@ -18,7 +18,7 @@ The narrative begins with human archaeologists from the Straumli Realm awakening
 One of the novel's most original contributions is the concept of the Zones of Thought, a stratified galactic structure where the feasibility of intelligence and technology diminishes toward the core. The Unthinking Depths at the center render complex thought impossible, while the Slow Zone limits advanced capabilities such as faster-than-light (FTL) travel and artificial intelligence. Further outward, the Beyond enables interstellar commerce and communication, and the Transcend fosters godlike superintelligences, or Powers.
 
 <figure>
-  <img src="img/zones-of-thought.svg" alt="Diagram of the Zones of Thought showing layers from Unthinking Depths to Transcend">
+  <img src="img/zones-of-thought.svg" alt="Diagram of the Zones of Thought showing layers from Unthinking Depths to Transcend" data-glightbox>
   <figcaption>The galaxy is divided into concentric layers: the Unthinking Depths suppress sentience, the Slow Zone limits advanced technology, the Beyond enables interstellar commerce, and the Transcend hosts godlike Powers.</figcaption>
 </figure>
 

--- a/docs/ai-research/context-windows-design-matrix.md
+++ b/docs/ai-research/context-windows-design-matrix.md
@@ -26,4 +26,9 @@ The matrix compares long-context techniques across complexity, maximum effective
 
 ### Regeneration
 
-Use [context-windows-design-matrix.py](context-windows-design-matrix.py) to regenerate the chart and interactive table. Requires `plotly` and `kaleido`. The script writes an updated [`context-windows-design-matrix.svg`](context-windows-design-matrix.svg) and a companion HTML table in the same directory.
+Use [context-windows-design-matrix.py](context-windows-design-matrix.py) to regenerate the chart and interactive table. Requires `plotly` and `kaleido`. When the underlying data changes, regenerate both the [`context-windows-design-matrix.svg`](context-windows-design-matrix.svg) and its companion HTML table to keep them synchronized.
+
+```bash
+python -m pip install plotly kaleido            # install dependencies
+python context-windows-design-matrix.py         # update SVG and HTML when data changes
+```


### PR DESCRIPTION
## Summary
- enable lightbox for Zones of Thought SVG
- document regenerating context windows design matrix assets and include python commands

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c02fa210bc83269053c84bdf89c431