### PR TITLE
Link interactive context window matrix and clarify asset regeneration

### DIFF
--- a/docs/ai-research/context-windows-appendix.md
+++ b/docs/ai-research/context-windows-appendix.md
@@ -100,7 +100,7 @@ For each position *p* in {1 k, 4 k, 16 k, 64 k, …}, embed a retrieval
 
 The table in [context-windows-design-matrix.md](context-windows-design-matrix.md) lists the main families of methods (positional scaling, efficient attention, streaming/compressive, distributed full attention, external memory, system-level optimisations) along with their complexity, typical effective length, advantages and caveats. Use this matrix to compare techniques and decide which to apply in your project. The figure below is also featured in the [Context Windows Field Guide](context-windows-field-guide.md) and examined in depth in the [Context Windows Deep Dive](context-windows-deep-dive.md).
 
-![Context windows design matrix](context-windows-design-matrix.svg)
+![Context windows design matrix with methods on the x-axis and typical max effective length in tokens on the y-axis, based on data from context-windows-design-matrix.md](context-windows-design-matrix.svg)
 
 ## See also
 

--- a/docs/ai-research/context-windows-design-matrix.md
+++ b/docs/ai-research/context-windows-design-matrix.md
@@ -9,7 +9,7 @@ updated: 2025-08-15
 
 # Context Windows Design Matrix
 
-![Context windows design matrix with methods on the x-axis and typical max effective length in tokens on the y-axis](context-windows-design-matrix.svg)
+![Context windows design matrix with methods on the x-axis and typical max effective length in tokens on the y-axis, based on data from the table below](context-windows-design-matrix.svg)
 
 The matrix compares long-context techniques across complexity, maximum effective length, advantages, and caveats. Each row represents a strategy for extending transformer context windows, enabling quick trade-off evaluations.
 
@@ -26,4 +26,4 @@ The matrix compares long-context techniques across complexity, maximum effective
 
 ### Regeneration
 
-Use [context-windows-design-matrix.py](context-windows-design-matrix.py) to regenerate the chart and interactive table. Requires `plotly` and `kaleido`. The script writes an updated [`context-windows-design-matrix.svg`](context-windows-design-matrix.svg) and a companion HTML table in the same directory.
+Use `scripts/context-windows-design-matrix.py` to regenerate the chart and interactive table. Requires `plotly` and `kaleido`. The script writes an updated [`context-windows-design-matrix.svg`](context-windows-design-matrix.svg) and a companion HTML table in the same directory.

--- a/docs/ai-research/context-windows-field-guide.md
+++ b/docs/ai-research/context-windows-field-guide.md
@@ -39,9 +39,9 @@ KV_memory_bytes ≈ 2 × L × H × d × seq_length × dtypeBytes
 The underlying data in [context-windows-design-matrix.md](context-windows-design-matrix.md) maps each bar to a model and sequence length, helping you read exact memory requirements from the chart.
 {{ read_file('docs/ai-research/context-windows-design-matrix.html') }}
 
-![Context windows design matrix](context-windows-design-matrix.svg)
+![Context windows design matrix with methods on the x-axis and typical max effective length in tokens on the y-axis, based on data from context-windows-design-matrix.md](context-windows-design-matrix.svg)
 
-
+[Interactive table](context-windows-design-matrix.html). Regenerate the SVG and HTML with `scripts/context-windows-design-matrix.py`.
 A single 16 k-token request therefore uses over 40 GiB of memory[^3].  Activation memory (intermediate activations needed for backpropagation) also scales with sequence length.  Training long contexts often requires gradient accumulation, checkpointing, recomputation or reversible layers to manage memory[^4].  During inference, memory fragmentation and scheduler constraints further limit the usable window.  Hardware improvements (larger VRAM, faster memory bandwidth) and algorithmic innovations (FlashAttention, PagedAttention) are critical to make long context practical.
 
 ## 2 Landscape of context sizes in 2025


### PR DESCRIPTION
## Summary
- link to `context-windows-design-matrix.html` beneath the context window chart and document the regeneration script
- expand the SVG alt text in field guide, appendix, and design matrix to describe axes and source data
- mention `scripts/context-windows-design-matrix.py` as the tool for rebuilding the SVG and HTML assets

## Testing
- no tests run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c02fa12e748326ace1ebd2a90518aa