### PR TITLE
docs: add threat model diagram

### DIFF
--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -14,6 +14,8 @@ Resources related to security practices and research.
 ## Guidance
 - [Threat Model](threat-model.md) — identifies potential security threats and proposes mitigation strategies.
 
+![Diagram illustrating the system's threat model and mitigation strategies](threat-model.svg)
+
 ## Research
 - [Quantum Reckoning](quantum-reckoning.md) — examines how quantum computing could undermine current cryptographic methods.
 


### PR DESCRIPTION
## Summary
- add inline threat model diagram to security guidance page with descriptive alt text

## Testing
- no tests run (docs change)


------
https://chatgpt.com/codex/tasks/task_e_68c04d5946108326880d976245ea521f