### PR TITLE
docs: add Wise idempotency example and diagram

### DIFF
--- a/docs/img/wise-payouts-idempotency-cycle.svg
+++ b/docs/img/wise-payouts-idempotency-cycle.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200" viewBox="0 0 600 200">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="40" y="30" width="110" height="40" rx="5" ry="5" fill="#e0f7fa" stroke="#006064"/>
+  <text x="95" y="55" font-family="Arial" font-size="12" text-anchor="middle">Client</text>
+
+  <rect x="240" y="30" width="110" height="40" rx="5" ry="5" fill="#e8f5e9" stroke="#1b5e20"/>
+  <text x="295" y="55" font-family="Arial" font-size="12" text-anchor="middle">Wise API</text>
+
+  <rect x="440" y="30" width="120" height="40" rx="5" ry="5" fill="#fff3e0" stroke="#ef6c00"/>
+  <text x="500" y="55" font-family="Arial" font-size="12" text-anchor="middle">Idempotency Store</text>
+
+  <line x1="150" y1="50" x2="240" y2="50" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="195" y="40" font-size="10" text-anchor="middle" font-family="Arial">1. POST with ID</text>
+
+  <line x1="350" y1="50" x2="440" y2="50" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="395" y="40" font-size="10" text-anchor="middle" font-family="Arial">2. Check ID</text>
+
+  <line x1="440" y1="70" x2="350" y2="110" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="395" y="105" font-size="10" text-anchor="middle" font-family="Arial">3. Store result</text>
+
+  <line x1="240" y1="110" x2="150" y2="70" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="195" y="105" font-size="10" text-anchor="middle" font-family="Arial">4. Response</text>
+
+  <line x1="95" y1="120" x2="95" y2="150" stroke="#333" stroke-width="2"/>
+  <line x1="95" y1="150" x2="295" y2="150" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="195" y="140" font-size="10" text-anchor="middle" font-family="Arial">5. Retry with same ID</text>
+
+  <line x1="350" y1="150" x2="440" y2="150" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="395" y="140" font-size="10" text-anchor="middle" font-family="Arial">6. ID found</text>
+
+  <line x1="440" y1="170" x2="240" y2="170" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="340" y="160" font-size="10" text-anchor="middle" font-family="Arial">7. Return cached result</text>
+
+  <line x1="240" y1="170" x2="40" y2="170" stroke="#333" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="140" y="160" font-size="10" text-anchor="middle" font-family="Arial">8. Same response</text>
+</svg>


### PR DESCRIPTION
## Summary
- add Wise transfer example demonstrating idempotent customerTransactionId handling
- include flow diagram for the idempotent request cycle

## Testing
- `pre-commit run --files docs/wise-payouts-idempotency.md` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68c81fa911c483268dc7b622f9b8351d