### PR TITLE
Format headings for neuropsychology fandom doc

### DIFF
--- a/docs/non-ai-research/neuropsychology-of-fandom-affinity.md
+++ b/docs/non-ai-research/neuropsychology-of-fandom-affinity.md
@@ -9,30 +9,30 @@ updated: 2025-09-02
 
 # The Neuropsychology of Fandom Affinity: An Integrative Analysis of Furry Art, Identity, and Belonging
 
-Introduction
+## Introduction
 This report investigates why the furry fandom and its art resonate so powerfully with neurodivergent individuals. By synthesizing peer-reviewed research from neurodiversity studies (autism and ADHD), social neuroscience, clinical psychology, and fandom studies, it maps how attentional style, social processing, interpersonal regulation, and motivational dynamics converge within the fandom to foster identity, belonging, and well-being.
 
-Part I: The Neurodivergent Lens: Attention, Perception, and Social Processing
+## Part I: The Neurodivergent Lens: Attention, Perception, and Social Processing
 This part analyzes how distinct neurocognitive frameworks shape perception, processing, and interaction for neurodivergent individuals, showing how furry art and the fandom environment mitigate challenges while amplifying inherent strengths.
 
-Section 1: The Focused Mind - Monotropism, Hyperfocus, and Flow
+### Section 1: The Focused Mind - Monotropism, Hyperfocus, and Flow
 This section compares monotropism, ADHD hyperfocus, and flow to explain why immersive furry art aligns so well with neurodivergent attentional styles.
 
-1.1. Monotropism: An Interest-Based Cognitive System
+#### 1.1. Monotropism: An Interest-Based Cognitive System
 Monotropism, a theory of autistic cognition developed by Murray, Lawson, and Lesser, posits a foundational cognitive style oriented around a limited number of intense interests. It is characterized as a "single-minded cognitive style" wherein an individual's attention is powerfully drawn into a narrow "attention tunnel". Within this model, the mind is conceptualized as an "interest system". In a monotropic mind, fewer interests are aroused at any given time, but those that are active attract a disproportionate share of processing resources, making it difficult to attend to stimuli or tasks outside the current focus.  
 
 This is not a deficit but an ability to focus in great detail, which can lead to deep engagement and intrinsically rewarding "flow states". Engagement with these deep interests, often referred to as "special interests," serves as a vital mechanism for self-regulation, promoting a sense of calm, happiness, and control. This perspective reframes autistic cognition in a neuro-affirmative light, suggesting that effective support involves "joining the autistic individual in their attention tunnel rather than trying to get them to come out". This approach fosters autonomy and leverages the monotropic ability to absorb and process vast quantities of information within a field of interest.  
 
 A key challenge of this cognitive style is the high energetic and cognitive cost associated with shifting attention between channels. Interruptions or demands to multitask can be jarring and distressing, a phenomenon sometimes referred to as "monotropic split". This explains why environments that require frequent task-switching are particularly exhausting for monotropic individuals and can contribute to sensory overload and burnout.  
 
-1.2. ADHD Hyperfocus: A State of Dopamine-Driven Concentration
+#### 1.2. ADHD Hyperfocus: A State of Dopamine-Driven Concentration
 ADHD hyperfocus is an intense state of fixation on an activity that is interesting or enjoyable, during which the external world, the passage of time, and even bodily needs can seem to fall away. This state is often considered a paradoxical symptom of ADHD, a condition more commonly associated with distractibility and an inability to sustain attention.  
 
 The neurobiological underpinnings of hyperfocus are linked to the dopamine system. Research led by Nora Volkow has provided compelling evidence that individuals with ADHD have lower baseline levels of dopamine synaptic markers, specifically D2/D3 receptors and dopamine transporters, in the brain's mesoaccumbens reward pathway. This pathway is critical for motivation and processing rewards. The resulting dopamine deficiency makes it difficult to engage with tasks that are not intrinsically rewarding. Hyperfocus can thus be understood as a state of intense dopamine-seeking, where an individual becomes completely absorbed in an activity that provides the continuous stream of stimulation, progress, and reward that their brain is otherwise lacking. This explains the powerful pull of activities with constant feedback loops, such as video games, creative projects, or deep dives into online content.  
 
 Like monotropic states, hyperfocus has a dual nature. When channeled into a productive or desired task, it can be a significant asset, leading to marked improvements in performance and productivity. However, when this intense concentration is captured by an unproductive or unintended activity, it becomes a liability, leading to time blindness, neglect of responsibilities, and social or physical problems.  
 
-1.3. A Comparative Framework: Monotropism, Hyperfocus, and Flow
+#### 1.3. A Comparative Framework: Monotropism, Hyperfocus, and Flow
 While these three states share the characteristic of deep task absorption, they are distinct phenomena with different underlying mechanisms, experiential qualities, and implications. The confusion between them often leads to a mischaracterization of neurodivergent experiences.  
 
 The concept of "flow," as defined by Mihaly Csikszentmihalyi, describes an "optimal experience" of ecstatic, effortless absorption that is achievable by most people when their skills are well-matched to a clear and challenging task. It is a highly positive state where one feels in control and fully present, but typically without a complete loss of environmental awareness. ADHD hyperfocus is a more extreme and less controllable state of absorption, often characterized by a profound obliviousness to one's surroundings and needs. While flow is almost universally positive, hyperfocus can be maladaptive depending on the context.  
@@ -54,20 +54,20 @@ The aesthetic and narrative qualities inherent in furry art are uniquely suited 
 
 Beyond the art itself, the furry fandom as a social structure functions as an "attentional sanctuary." It is a community built around a shared, deep interest, where social interaction frequently revolves around creating, discussing, and celebrating that interest. This structure inherently validates the interest-driven nature of monotropism and hyperfocus, transforming what might be a solitary "special interest" into a medium for social connection. It significantly reduces the need for the costly attention-switching that makes polytropic environments so dysregulating for a monotropic mind. An individual can remain within the same broad "attention tunnel" of the fandom while engaging in diverse activities like art creation, online discussion, or convention attendance. This community framework provides an external scaffold that lowers the executive function demands of socializing, validating the individual's natural attentional style rather than penalizing it.  
 
-Section 2: The Social World - Gaze, Empathy, and the Burden of Performance
+### Section 2: The Social World - Gaze, Empathy, and the Burden of Performance
 This section examines how neurotypical social expectations impose heavy physiological and cognitive costs on neurodivergent people and how furry art and fursonas provide a safer interface that mitigates those burdens.
 
-2.1. The Neurobiology of Gaze and Eye Contact Aversion
+#### 2.1. The Neurobiology of Gaze and Eye Contact Aversion
 Direct eye contact is a powerful and highly salient social signal that modulates cognitive processes by increasing arousal and capturing attention. For many neurodivergent individuals, however, this experience is not neutral or positive but is instead overwhelming, threatening, and physiologically distressing.  
 
 The "eye avoidance hypothesis" of autism posits that this aversion is a regulatory strategy. According to this model, direct gaze leads to hyperactivation of the subcortical fear circuitry, most notably the amygdala, which results in aversive hyperarousal. Studies using fMRI have shown that experimentally forcing eye contact in autistic individuals potentiates this elevated amygdala response. Therefore, looking away from the eyes is an active, motivated behavior designed to reduce a painful physiological and emotional state. A similar mechanism is observed in Social Anxiety Disorder (SAD), where direct gaze also triggers heightened activity in the amygdala, insula, and other brain regions associated with fear processing. For individuals with these conditions, fear and avoidance of eye contact are core features used to manage social anxiety. This aversion is not primarily about reducing cognitive load, as it might be for a neurotypical person engaged in a difficult task, but is fundamentally about regulating a powerful and negative emotional response.  
 
-2.2. The Double Empathy Problem: A Relational Model of Social Difficulty
+#### 2.2. The Double Empathy Problem: A Relational Model of Social Difficulty
 The social challenges faced by autistic individuals have historically been framed as a deficit within the person, often attributed to an impaired "theory of mind." Damian Milton's theory of the "double empathy problem" (DEP) provides a crucial and neuro-affirming reframing of this issue. The DEP posits that empathy is an interactional, two-way process. Breakdowns in communication and understanding between autistic and allistic (non-autistic) people are not the result of an autistic deficit, but are a mutual and reciprocal problem arising from a mismatch in lived experiences, processing styles, and communication norms.  
 
 This "disjuncture in reciprocity" creates a translation gap for both parties. Allistic individuals may struggle to interpret autistic body language or a literal communication style, while autistic individuals may struggle with the ambiguity of neurotypical indirect speech and nonverbal cues. However, because neurotypical norms are dominant, the burden of bridging this gap disproportionately falls upon the autistic person, who must constantly work to translate and adapt to a social world not built for them.  
 
-2.3. The High Cost of Camouflaging
+#### 2.3. The High Cost of Camouflaging
 In response to the constant pressure to navigate a world structured around the DEP and to avoid the stigma and negative social consequences of appearing different, many autistic individuals engage in camouflaging, or masking. This is the conscious or subconscious suppression of natural autistic traits and the performance of neurotypical social behaviors. The Camouflaging Autistic Traits Questionnaire (CAT-Q) provides a validated framework for measuring this phenomenon, breaking it down into three core strategies:  
 
 Compensation: Using learned rules and scripts to navigate social situations, such as deliberately copying another person's body language or rehearsing conversations.  
@@ -82,18 +82,18 @@ The depiction of non-human faces in furry art fundamentally alters the neurobiol
 
 This principle extends from art to identity. The fursona—an anthropomorphic avatar created by an individual—is a revolutionary tool for bypassing the Double Empathy Problem and mitigating the need for camouflaging. It functions as a form of "social prosthetic" or a customized communication interface. The DEP arises from a mismatch in embodied experience and communication styles, and masking is the costly, exhausting attempt to bridge that gap by performing neurotypicality. A fursona, however, is an identity curated by the individual to be an authentic, if idealized, representation of the self. When individuals interact as their fursonas, whether through art, writing, or performance, they are not communicating through the ambiguous and stressful filter of human nonverbal cues. They are interacting through interfaces of their own design, within a shared fandom context where the rules of communication are mutually understood. This dramatically reduces the cognitive load of social interaction and replaces the costly performance of being "normal" with the joyful and affirming act of authentic self-expression.
 
-Part II: The Dynamics of Connection: Regulation, Relationships, and Identity
+## Part II: The Dynamics of Connection: Regulation, Relationships, and Identity
 This part explores how the furry fandom's structure supports emotional regulation, interpersonal connection, and identity development, turning engagement into a constructive form of growth.
 
-Section 3: The Physics of Interaction - Co-Regulation in Dyads and Communities
+### Section 3: The Physics of Interaction - Co-Regulation in Dyads and Communities
 This section applies co-regulation theory to the fandom, framing it as a large-scale system that provides "cues of safety" and predictable, responsive interactions for those prone to dysregulation.
 
-3.1. The Physiology of Co-Regulation
+#### 3.1. The Physiology of Co-Regulation
 Co-regulation is the fundamental biological process through which one individual's autonomic nervous system is calmed, balanced, and stabilized through social interaction with another. This concept is central to Stephen Porges' Polyvagal Theory, which identifies the ventral vagal complex of the vagus nerve as the core of the human "social engagement system". When an individual perceives "cues of safety"—such as a calm tone of voice, gentle facial expressions, and attentive posture—this system is activated, leading to an increase in vagal tone. This physiological state promotes feelings of calm, safety, and connection, and down-regulates defensive fight-or-flight responses.  
 
 In close relationships, this process manifests as a bidirectional linkage of emotional and physiological channels. Successful co-regulation involves partners engaging in mutually dampening negative feedback loops; as one person's emotional state deviates from their baseline, the other's responsive presence helps guide them back toward homeostasis. In contrast, co-dysregulation occurs when interactions create mutually amplifying positive feedback loops, where distress escalates in both partners, moving them further away from emotional stability.  
 
-3.2. From Dyads to Community: Co-Regulation Across the Lifespan
+#### 3.2. From Dyads to Community: Co-Regulation Across the Lifespan
 The principles of co-regulation are not confined to romantic dyads or parent-infant bonds. The process begins in infancy, where caregivers provide the external support—warmth, responsiveness, and a structured, predictable environment—that scaffolds the development of a child's internal self-regulation capacities. This supportive dynamic can occur within any caring relationship across the entire lifespan.  
 
 The essential components for a co-regulating environment, whether it is a family, a classroom, or a community, remain consistent: the presence of warm and responsive relationships, the establishment of a safe and structured environment, and the consistent modeling and support of healthy regulatory skills. A community, therefore, can function as a powerful co-regulatory force if its social norms and patterns of interaction consistently provide these foundational elements.  
@@ -102,27 +102,27 @@ The social architecture of the furry fandom, both in its online spaces and at in
 
 Real-world conventions illustrate this co-regulating design: events like Anthrocon include quiet rooms and structured support areas, and Furscience reports that 10–15% of attendees identify as autistic, highlighting the need for such accommodations.[^1]
 
-Section 4: The Motivation to Engage - Escapism as Self-Expansion
+### Section 4: The Motivation to Engage - Escapism as Self-Expansion
 This section reframes fandom-related escapism as an adaptive, growth-oriented process of identity exploration and self-expansion rather than a flight from reality.
 
-4.1. A Dualistic Model of Escapism
+#### 4.1. A Dualistic Model of Escapism
 Researcher Frode Stenseng has developed a two-dimensional model of escapism that provides a critical distinction between its maladaptive and adaptive forms. This model reframes escapism based on its underlying motivation:  
 
 Self-Suppression (Maladaptive Escapism): This form is motivated by the desire to prevent a negative mood or to escape from unpleasant self-awareness, ruminative thoughts, and real-life problems. It is functionally an avoidance coping strategy and is associated with lower subjective well-being, emotional suppression, and a higher risk for behavioral addictions.  
 
 Self-Expansion (Adaptive Escapism): This form is motivated by the desire to promote a positive mood and to gain new, enriching experiences. It is functionally an approach-oriented coping strategy and is associated with harmonious passion, the experience of flow states, and higher levels of subjective well-being and psychological adjustment.  
 
-4.2. Fandom as a Vehicle for Self-Expansion
+#### 4.2. Fandom as a Vehicle for Self-Expansion
 Online fandoms provide fertile ground for self-expansion. They offer myriad opportunities for creative expression (fan art, writing), social connection with like-minded peers, and the development of new skills and knowledge. Research has indicated that active participation in fandom communities is associated with significantly higher levels of well-being.  
 
 The creation and development of a fursona is a quintessential example of self-expansion in practice. Research from Furscience demonstrates that furries frequently create fursonas that represent idealized versions of themselves, embodying traits they admire or wish to cultivate. Engaging with the community as this idealized self within a safe and supportive context allows individuals to "try out" new ways of being—for example, a shy person can experiment with being more extraverted and socially confident. This identity play is not merely fantasy; it can lead to tangible changes in one's real-world self-concept and is correlated with higher self-esteem and overall well-being. This process directly aligns with self-expansion theory, which posits that individuals are motivated to grow and enhance the self by incorporating new perspectives, identities, and resources.  
 
 The act of creating and embodying a fursona is a direct and powerful application of self-expansion escapism. The motivation is not to escape from the self, but rather to escape into a potential, more actualized version of the self. This is the fundamental difference between self-suppression, which seeks to numb or avoid the self, and self-expansion, which seeks to enrich and grow the self. The engagement is an active, creative process—drawing, writing, roleplaying, performing—that builds skills and facilitates positive social experiences. It provides a low-stakes laboratory for identity exploration, where one can practice being a desired version of oneself and receive affirming social feedback. The strong, positive correlation found between having an idealized fursona and measures of psychological well-being provides robust evidence for this dynamic. The engagement is not about forgetting one's problems, but about building the psychological resources, confidence, and self-concept needed to better face them.  
 
-Part III: Synthesis - The Furry Fandom as a Nexus for Neurodivergent Well-Being
+## Part III: Synthesis - The Furry Fandom as a Nexus for Neurodivergent Well-Being
 This part synthesizes the neurological, psychological, and social mechanisms discussed earlier to show how the furry fandom forms a synergistic ecosystem that transforms neurodivergent challenges into assets.
 
-Section 5: The Fursona as a Vehicle for Self and Socialization
+### Section 5: The Fursona as a Vehicle for Self and Socialization
 This section explains how the fursona operates as the central mechanism that channels the fandom's benefits across multiple domains of the neurodivergent experience.
 
 As an idealized self-representation, the fursona provides a clear and motivating target for the process of self-expansion. It is not a static mask but a dynamic project of personal growth and becoming.  
@@ -135,7 +135,7 @@ The shared symbolic language and context of fursonas helps to bridge the Double 
 
 The very act of creating art that depicts one's fursona is an exercise in monotropic or hyperfocused engagement. It is a deeply regulating and intrinsically rewarding activity that simultaneously serves the crucial functions of identity expression and social communication, allowing one to "show" who they are in a rich, detailed, and non-verbal format.  
 
-Section 6: Optimal Distinctiveness and the Architecture of Belonging
+### Section 6: Optimal Distinctiveness and the Architecture of Belonging
 This section uses Optimal Distinctiveness Theory to explain how the furry fandom satisfies the dual needs for belonging and uniqueness that generate strong group identification.
 
 Furscience researchers have explicitly applied this theory to the furry fandom, with compelling results. Their studies show a significant interaction effect: furries who report both a high degree of belonging within the fandom and who perceive the fandom as being highly distinct from other groups (such as anime fans or the mainstream) express the strongest level of identification with the community.  
@@ -150,20 +150,26 @@ This synthesis reveals that the furry fandom's structure creates a psychosocial 
 
 The reason furry art "lights up the brain" is because it is the vibrant, aesthetic focal point of an entire system that is exquisitely calibrated to meet a cascade of neurological, psychological, and social needs that frequently go unmet in the default world. It is a powerful signal of safety, belonging, creativity, and the profound potential for authentic self-expression.
 
-Conclusion and Recommendations
+## Conclusion and Recommendations
 This analysis concludes that affinity for furry art reflects a deep neuropsychological resonance in which attentional style, social perception, regulation, and identity motivation converge. The fandom minimizes cognitive costs, maximizes inherent strengths, and leverages the fursona as a customizable interface that enables authentic expression and co-regulation while satisfying the human need for optimal distinctiveness.
 
 Based on this synthesis, the following recommendations are proposed:
 
-For Individuals: Fandom engagement can be consciously utilized as a tool for personal development. Individuals can leverage the creation and exploration of their fursona as a low-stakes environment to practice desired social skills, explore aspects of their identity, and build self-esteem. Recognizing the regulating function of engaging with one's interests can empower individuals to proactively use their fandom activities to manage stress and prevent burnout.
+### For Individuals
 
-For Clinicians and Mental Health Professionals: It is imperative to adopt a neuro-affirming and culturally competent perspective when working with clients who are members of the furry fandom. "Special interests" should be viewed not as pathological symptoms of restriction but as profound sources of joy, expertise, self-regulation, and social connection. The fursona should be understood as a complex and meaningful tool for identity work, not as a sign of delusion or escapist fantasy. Therapeutic interventions can be made more effective by integrating a client's fandom identity into the process, using it as a source of strength and resilience.
+Fandom engagement can be consciously utilized as a tool for personal development. Individuals can leverage the creation and exploration of their fursona as a low-stakes environment to practice desired social skills, explore aspects of their identity, and build self-esteem. Recognizing the regulating function of engaging with one's interests can empower individuals to proactively use their fandom activities to manage stress and prevent burnout.
 
-For Researchers: This analysis highlights several promising avenues for future research. Longitudinal studies are needed to track the long-term impact of fandom participation on the mental health, social skills, and well-being of neurodivergent individuals. Neuroimaging studies, particularly those using fMRI, could directly test the "gaze aversion" hypothesis by comparing amygdala and social brain network activation in response to human faces versus anthropomorphic faces in autistic and socially anxious populations. Further qualitative research can continue to explore the lived experience of self-expansion and identity formation through the fursona, providing richer data to inform both theory and clinical practice.
+### For Clinicians and Mental Health Professionals
+
+It is imperative to adopt a neuro-affirming and culturally competent perspective when working with clients who are members of the furry fandom. "Special interests" should be viewed not as pathological symptoms of restriction but as profound sources of joy, expertise, self-regulation, and social connection. The fursona should be understood as a complex and meaningful tool for identity work, not as a sign of delusion or escapist fantasy. Therapeutic interventions can be made more effective by integrating a client's fandom identity into the process, using it as a source of strength and resilience.
+
+### For Researchers
+
+This analysis highlights several promising avenues for future research. Longitudinal studies are needed to track the long-term impact of fandom participation on the mental health, social skills, and well-being of neurodivergent individuals. Neuroimaging studies, particularly those using fMRI, could directly test the "gaze aversion" hypothesis by comparing amygdala and social brain network activation in response to human faces versus anthropomorphic faces in autistic and socially anxious populations. Further qualitative research can continue to explore the lived experience of self-expansion and identity formation through the fursona, providing richer data to inform both theory and clinical practice.
 
 [^1]: Furscience, "Autism in the Fandom: Opportunities, Barriers & Recommendations," https://furscience.com/research-findings/autism-in-the-fandom/ (accessed 2024).
 
-Sources used in the report
+## Sources Used in the Report
 
 ndconnection.co.uk
 Monotropism and The Monotropism Questionnaire - Neurodiverse Connection


### PR DESCRIPTION
## Summary
- convert legacy section labels into hierarchical Markdown headings throughout the neuropsychology fandom article
- promote recommendation audiences and the sources list to headings so they appear in the generated table of contents

## Testing
- mkdocs build *(fails: ModuleNotFoundError: No module named 'pymdownx.copybutton')*


------
https://chatgpt.com/codex/tasks/task_e_68c96d7e331c8326863564ccc2fb1899