### PR TITLE
Add TOC to painterly Clip Studio Paint guide

### DIFF
--- a/docs/non-ai-research/painterly-style-clip-studio-paint.md
+++ b/docs/non-ai-research/painterly-style-clip-studio-paint.md
@@ -7,6 +7,8 @@ updated: 2025-09-08
 
 --8<-- "\_snippets/disclaimer.md"
 
+{{ toc }}
+
 # A Comprehensive Guide to the Painterly Style in Clip Studio Paint
 
 ## Introduction: The Philosophy of Painterly Digital Art


### PR DESCRIPTION
## Summary
- insert the sitewide table-of-contents directive into the painterly Clip Studio Paint guide so readers can navigate sections easily

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c976082278832693b6555856fb5324