### PR TITLE
Add TOC to neuropsychology of fandom doc

### DIFF
--- a/docs/non-ai-research/neuropsychology-of-fandom-affinity.md
+++ b/docs/non-ai-research/neuropsychology-of-fandom-affinity.md
@@ -7,6 +7,8 @@ updated: 2025-09-02
 
 --8<-- "_snippets/disclaimer.md"
 
+{{ toc }}
+
 # The Neuropsychology of Fandom Affinity: An Integrative Analysis of Furry Art, Identity, and Belonging
 
 ## Executive Summary


### PR DESCRIPTION
## Summary
- add a table of contents directive after the disclaimer include in the neuropsychology of fandom article so the page renders a navigation TOC

## Testing
- mkdocs build *(fails: missing `pymdownx.copybutton` module from the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c97bc8d9448326b5d382fe2fd9405c