### PR TITLE
Document ignoring painterly sample PNGs

### DIFF
--- a/docs/non-ai-research/img/README.md
+++ b/docs/non-ai-research/img/README.md
@@ -3,7 +3,13 @@
 The **painterly-style-clip-studio-paint.md** guide references PNG assets that live beside this
 README. To keep the repository lightweight and binary-free, those images are _not_ stored in git.
 When you're ready to supply your own examples, export them as PNG files and place them in this
-folder using the exact filenames below so the existing Markdown links resolve automatically.
+folder using the exact filenames below so the existing Markdown links resolve automatically. Add
+those filenames to your `.gitignore` so local renders stay out of the repository. For example:
+
+```
+# Painterly brush demo captures
+docs/non-ai-research/img/*.png
+```
 
 - Recommended canvas: 1600×900 px (or similar 16:9 ratio) with transparent or neutral-gray
   background.


### PR DESCRIPTION
## Summary
- remind contributors to place painterly sample exports under `.gitignore`
- provide a `.gitignore` snippet to avoid committing binary example assets

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c98c4f65448326a958b36d7d52a432