### PR TITLE
docs: move quick links checklist to appendix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,18 +18,13 @@ directory conventions keep artifacts easy to browse and maintain.
 Quick links to essential guides and resources.
 
 ### Getting Started
-- [Quickstart Guide](quickstart.md)
-- [Threat Model](security/threat-model.md)
+The quick links checklist now lives in [Appendix A: Resource Checklist](#appendix-a-resource-checklist).
 
 ### Research
-- [AI Research](ai-research/index.md)
-- [Non-AI Research](non-ai-research/index.md)
-- [Gaze Research](gaze-research/index.md)
+Appendix A consolidates the research links that were previously listed here.
 
 ### Playbooks
-- [Terminal Workflow](terminal-workflow/index.md)
-- [GitHub Actions Workflows](../playbooks/github-actions-workflows.md)
-- [Local Docker Build](../playbooks/local-docker-build.md)
+Appendix A also collects the workflow playbooks for easy reference.
 
 ## Getting Started
 Guides for setting up the docs hub and exploring resources.
@@ -159,6 +154,22 @@ history:
 ```bash
 git merge d0tTino-import --allow-unrelated-histories
 ```
+
+## Appendix A: Resource Checklist
+
+### Getting Started
+- [Quickstart Guide](quickstart.md)
+- [Threat Model](security/threat-model.md)
+
+### Research
+- [AI Research](ai-research/index.md)
+- [Non-AI Research](non-ai-research/index.md)
+- [Gaze Research](gaze-research/index.md)
+
+### Playbooks
+- [Terminal Workflow](terminal-workflow/index.md)
+- [GitHub Actions Workflows](../playbooks/github-actions-workflows.md)
+- [Local Docker Build](../playbooks/local-docker-build.md)
 
 ## Ingesting and Querying Markdown
 Use the ingestion utility to store and search markdown snippets.


### PR DESCRIPTION
## Summary
- move the quick links checklist from the main Table of Contents into a new Appendix A section
- update the Table of Contents headings to point readers to the relocated checklist

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c98c1cd2708326b25f6b3a3d9a77e0