### PR TITLE
Expand dynamic symmetry digital workflows

### DIFF
--- a/docs/non-ai-research/composition-101-chaptered-intro.md
+++ b/docs/non-ai-research/composition-101-chaptered-intro.md
@@ -2,7 +2,7 @@
 title: "Composition 101 — Chaptered Intro"
 tags: [composition, visual-design, art, research]
 project: docs-hub
-updated: 2025-09-16
+updated: 2025-09-17
 ---
 
 --8<-- "_snippets/disclaimer.md"
@@ -64,15 +64,141 @@ taper weight as the eye travels.[^nng-visual-hierarchy][^nng-visual-video]
 - Does placement on the thirds grid support the weight pattern you designed?
 
 
-## Chapter 4 — Space, headroom, and lead room (especially for figures & film)
+## Chapter 4 — Cinematic framing: lead room, headroom, and motion
 
-- **Headroom:** The space above a subject’s head to the top of frame. Too much makes
-  people look like they’re sinking; too little feels cramped. Eyes near the upper
-  third usually nail it.
-- **Lead/Nose/Look room:** Leave more space in front of where the subject looks or
-  moves. Place the face along a vertical third and leave room on the side they face.
-  ROT makes this simple.[^videomaker-head-lead][^premiumbeat-lead-room]
+### Understanding lead room, nose room, and look space
 
+Lead room (also called nose room or look space) is the horizontal breathing room
+left in front of the direction a subject faces or moves so the composition feels
+balanced and the audience can imagine what lies ahead.[^editmentor-framing][^nofilmschool-nose-room][^wikipedia-lead-room][^premiumbeat-lead-room]
+If someone is looking or running toward the right edge, you usually weight the
+frame so more empty space sits on the right than on the left; doing so prevents
+them from appearing to collide with the border and gives them “somewhere to
+go.”[^editmentor-framing][^wikipedia-lead-room] Painters have leveraged the same
+psychological need for centuries—portraitists often leave extra canvas in front
+of the sitter’s gaze because viewers intuitively expect space for the face to
+inhabit.[^gurney-nose-room]
+
+Starving a subject of look space has the opposite effect. Too little lead room
+compresses a figure against the edge, making them feel boxed in or uneasy, while
+generous space ahead of them signals openness and implies an unseen point of
+interest beyond the frame.[^sphs-headroom][^drhs-composition] The same logic
+governs motion: a moving car framed without space in front looks stalled at the
+edge, whereas a shot with adequate lead room convinces us the vehicle can
+continue accelerating past the camera.[^wikipedia-lead-room]
+
+Look space also guides shot/reverse-shot editing. When two characters are
+framed with matching lead room toward one another, the viewer’s brain stitches
+the shots into a single comfortable conversation; short-siding one of them
+(placing them on the edge they’re facing) instantly introduces tension or
+imbalance.[^neiloseman-lead-room]
+
+### Understanding headroom
+
+Headroom is the vertical space between the top of a subject’s head and the top
+border of the frame.[^editmentor-framing][^videomaker-head-lead] Positioning the eyes around the upper
+third line is a quick way to achieve comfortable headroom—too much empty area
+above causes people to look like they are sinking, while cropping too tightly
+makes a shot feel cramped or draws attention to the chin.[^sphs-headroom][^drhs-composition][^guides-unc-headroom]
+Slightly trimming the very top of the skull is generally less distracting than
+leaving a vast ceiling of blank space, especially in interviews or
+portraits.[^sphs-headroom]
+
+### Emotional effects of spacing (and when to break the rules)
+
+Lead room and headroom are conventions, not iron laws. Deliberately bending them
+lets you encode subtext:
+
+- **Excessive lead room** can make a character seem isolated or dwarfed by what
+  lies ahead, effectively weaponizing negative space.[^neiloseman-lead-room]
+- **Short-siding** (denying look space) produces anxiety or confrontation
+  because the subject appears trapped against the edge; *Mr. Robot* famously
+  uses this framing to underline alienation.[^neiloseman-lead-room]
+- **Centered framing** removes directional bias and can read as formal,
+  symmetrical, or unsettling, depending on context.[^neiloseman-lead-room]
+- **Expansive headroom** pushes a person low in the frame to suggest
+  vulnerability or the weight of an environment bearing down on them, as in the
+  art-house film *Ida* or select shots of *Mr. Robot*.[^cined-headroom]
+- **No headroom** (very tight close-ups) creates claustrophobia or intense
+  intimacy, concentrating all attention on expression.[^cined-headroom]
+
+Use these departures intentionally so viewers feel the emotional cue you’re
+aiming for rather than assuming the framing is accidental.
+
+### Lead room and headroom across media
+
+#### Photography & cinematography
+
+Photographers and cinematographers learn headroom and lead room as day-one
+framing fundamentals because they keep shots readable and editing
+seamless.[^sphs-headroom][^drhs-composition][^neiloseman-lead-room] During
+dialogue, matching look space across angles maintains eyeline continuity; in
+action, leaving room in the direction of travel sells speed and avoids the
+sensation that a subject will slam into the edge.[^wikipedia-lead-room][^neiloseman-lead-room]
+
+#### Animation
+
+Even stylized 2D and 3D animation relies on the same grammar. Storyboards place
+characters with appropriate headroom and look space so the eventual shots feel
+cinematic, and chase scenes leave breathing room ahead of moving figures even
+when backgrounds exaggerate perspective or speed lines push the
+motion.[^neiloseman-lead-room]
+
+#### Illustration & comics
+
+Illustrators and comics artists act as their own camera crew. Giving characters
+space to look into keeps the reader’s eye inside the panel, while withholding
+that space can create mystery or emotional distance (Andrew Wyeth’s short-sided
+portrait in Gurney’s analysis is a classic example).[^gurney-nose-room]
+Sequential art also depends on consistent lead room to carry motion or
+conversations smoothly from panel to panel.[^learncorel-negative-space][^drhs-composition]
+
+### Framing dynamic motion and implied action
+
+1. **Leave lead room in the direction of travel.** Without it, running figures
+   and vehicles appear to hit an invisible wall.[^drhs-composition][^wikipedia-lead-room]
+2. **Use the path of motion to direct the eye.** Include trailing space and
+   emphasize diagonals so viewers feel momentum carrying
+   forward.[^expertphotography-leadroom][^learncorel-negative-space]
+3. **Respect screen direction.** Consistent left/right framing across
+   sequential shots or panels keeps movement legible; flipping lead room signals
+   a deliberate change in direction or tone.[^neiloseman-lead-room]
+4. **Shape implied motion in stills.** Compose gestures so fists, gazes, or
+   leaps aim into open space, letting the audience imagine what they strike or
+   reach.[^expertphotography-leadroom]
+5. **Reinforce speed with supporting cues.** Motion blur, perspective lines, or
+   Dutch angles paired with smart lead room amplify energy.[^expertphotography-leadroom]
+
+### Practice drills for spatial awareness
+
+- **Photo scavenger hunt:** Capture intentionally bad headroom/lead room
+  examples, then reshoot correctly to train your eye.[^sphs-headroom][^drhs-composition]
+- **Thumbnail experiments:** Sketch the same subject with comfortable spacing,
+  excessive headroom, and short-sided framing to catalog the moods each creates.
+- **Panel remix:** Reframe an existing film still or comic panel with altered
+  look space to see how the story tone shifts.[^neiloseman-lead-room]
+- **Motion storyboard:** Plan a mini sequence (kick, flight, catch) ensuring
+  lead room stays consistent as the action crosses the frame.
+- **Crop audit:** Take a portrait and create three crops—too much headroom, too
+  little, and balanced—to feel which one reads best.[^guides-unc-headroom]
+
+### Using digital tools (Clip Studio Paint & Procreate)
+
+- **Show grids:** Enable 3×3 guides in Clip Studio (View → Grid) or Procreate
+  (Actions → Canvas → Drawing Guide) so eyes and look space align with third
+  lines.[^clip-studio-ask][^procreate-guide-overview]
+- **Sketch on separate guide layers:** Draw framing boxes, headroom lines, or
+  nose-room diagonals on their own layer you can toggle while composing.
+- **Test crops non-destructively:** Clip Studio frame folders and Procreate’s
+  Crop & Resize tool let you slide a subject until spacing feels right before
+  committing.[^clip-studio-ask][^procreate-guide-overview]
+- **Leverage animation helpers:** Onion skinning or camera keyframes in Clip
+  Studio keep moving subjects properly spaced from frame to frame.
+- **Flip and compare:** Mirroring the canvas or duplicating layers for
+  alternate framings makes spatial imbalances obvious before final clean-up.
+
+Mastering these spatial cues means you can follow the comfortable defaults when
+clarity matters and bend them deliberately when the story needs friction.
 
 
 ## Chapter 5 — Balance & negative space (calm vs. tension)
@@ -85,11 +211,91 @@ taper weight as the eye travels.[^nng-visual-hierarchy][^nng-visual-video]
 
 ## Chapter 6 — Beyond Thirds: Phi, spirals, and dynamic symmetry (optional tools)
 
-- **Golden Ratio / Phi grid / spiral:** Guides that push focal points slightly closer to
-  center. Some artists prefer the “natural” sweep—test both grids and pick what fits
-  the story.
-- **Dynamic symmetry / armatures:** Root rectangles and diagonal armatures give you
-  richer scaffolds for complex scenes once you’re comfortable with thirds.[^petapixel-golden-ratio][^hsv-dynamic-symmetry]
+### Golden Ratio / Phi grid / spiral
+
+Guides based on φ (≈1.618) nudge focal points a bit nearer to center than the
+rule of thirds. Try both the phi grid (vertical and horizontal splits at 61.8%
+and 38.2%) and Fibonacci spiral overlays to see which reinforces your subject
+and storyline best.[^petapixel-golden-ratio]
+
+### Dynamic symmetry quickstart
+
+Dynamic symmetry expands beyond a single ratio by using root rectangles,
+diagonals, and reciprocals to organize complex scenes with more energy and
+control.[^kitschmeister-dynamic] Instead of four “power points,” you gain a web of
+intersections (the armature’s “eyes”) that can host focal points, gesture lines,
+and supporting rhythms. The baroque diagonal (↗) often reads as uplifting or
+resolved, whereas the sinister diagonal (↘) introduces tension—handy storytelling
+levers when you want a scene to feel calm or dramatic.[^kitschmeister-dynamic]
+
+#### Root rectangles at a glance
+
+- **Definition:** A Root-N rectangle’s long side divided by its short side equals
+  √N (Root-2 ≈ 1.414, Root-3 ≈ 1.732, Root-5 ≈ 2.236).[^kitschmeister-dynamic]
+- **Self-similarity:** Split a Root-N rectangle into N equal parts along the long
+  axis and each slice remains a smaller Root-N, so repeating proportions stay in
+  sync across the frame.[^kitschmeister-dynamic]
+- **Go-to ratios:** Historical work clusters around squares, Root-2, Root-3,
+  double squares (Root-4), Root-5, and golden rectangles—extreme ratios tend to
+  feel awkward.[^kitschmeister-dynamic]
+
+#### Build the harmonic armature
+
+1. Pick your canvas ratio (camera frame, golden rectangle, Root-2, etc.).
+2. Mark the midpoint of each side.
+3. Draw the two major diagonals (baroque and sinister).
+4. From each corner, draw to the midpoints on the opposite sides—these are the
+   reciprocal diagonals that create right-angle intersections.
+5. Optionally add vertical/horizontal lines through key intersections to form
+   smaller reciprocal rectangles or rebated squares.
+6. Identify the intersection “eyes” as likely focal anchors and align major
+   shapes, edges, or gesture paths with the grid. Hide or visualize the guides
+   once placement decisions are set.[^kitschmeister-dynamic]
+
+#### Why trade up from thirds?
+
+- **Directional flow:** Diagonals and reciprocals encourage eye travel through
+  multiple beats instead of hopping between four grid points.[^kitschmeister-dynamic]
+- **Organized complexity:** Aligning clusters of figures, architecture, or value
+  shifts along shared diagonals keeps busy scenes coherent.[^kitschmeister-dynamic]
+- **Confidence to riff:** Many painters (e.g., Michele Byrne) pre-grid canvases,
+  then paint freely knowing the underlying layout already balances weight and
+  movement.[^halbert-dynamic][^oilpainter-dynamic]
+- **Story cues:** Choose the baroque diagonal for an uplifting, left-to-right
+  momentum or the sinister diagonal for a more unsettled beat.[^kitschmeister-dynamic]
+
+#### Dynamic symmetry vs. thirds and φ
+
+- **Thirds → dynamic symmetry:** Start here when you want more diagonal energy or
+  need to choreograph several focal points within one frame.
+- **Golden ratio → dynamic symmetry:** φ-based grids are part of the same family;
+  dynamic symmetry simply widens your options to √2, √3, 2:3, and custom camera
+  ratios.[^kitschmeister-dynamic]
+
+#### Digital workflows
+
+**Clip Studio Paint** — Drag in CSP Asset Library grid materials or draw your own
+lines on a “Guides” layer with the Straight Line tool; convert the layer to a
+ruler if you want snapping.[^kitschmeister-dynamic]
+
+**Procreate** — Import a PNG armature as a low-opacity overlay or draw the grid
+manually with the 2D Drawing Guide for measurements and QuickLine to snap
+straight diagonals.[^kitschmeister-dynamic]
+
+#### Practice prompts
+
+1. Thumbnail compositions on pre-drawn armatures to test focal placements fast.
+2. Overlay grids on master paintings or photographs to reverse engineer how
+   their gestures follow diagonals and reciprocals.
+3. Re-compose a rule-of-thirds shot using a dynamic grid and compare the energy.
+4. Sketch gestures that echo the baroque and sinister diagonals before adding
+   detail.
+5. Practice drawing the armature from memory, then check against a template to
+   sharpen your spatial intuition.[^kitschmeister-dynamic]
+
+> **See also:** The companion deep dive, [*Dynamic Symmetry and Root Rectangles in
+> Composition*](dynamic-symmetry-root-rectangles.md), expands each checklist into
+> full workflows and case studies.
 
 
 ## Chapter 7 — Value first: Notan & tonal design (the secret sauce)
@@ -216,6 +422,18 @@ explain why you’re breaking it.[^petapixel-golden-ratio]
 
 ## References
 
+[^editmentor-framing]: [EditMentor Help Center — Headroom and Lead Room](https://help.editmentor.com/en/articles/4632188-headroom-and-lead-room)
+[^nofilmschool-nose-room]: [No Film School — What Is Nose Room in Photography?](https://nofilmschool.com/what-is-nose-room)
+[^wikipedia-lead-room]: [Wikipedia — Lead Room](https://en.wikipedia.org/wiki/Lead_room)
+[^sphs-headroom]: [Sharyland ISD — Framing Good Shots](https://sphs.sharylandisd.org/apps/pages/index.jsp?uREC_ID=204232&type=d&pREC_ID=447989)
+[^drhs-composition]: [DRHS Photo — Composition in Video](https://drhsphoto.weebly.com/composition-in-video.html)
+[^gurney-nose-room]: [James Gurney — Nose Room](https://gurneyjourney.blogspot.com/2010/08/nose-room.html)
+[^neiloseman-lead-room]: [Neil Oseman — Lead Room, Nose Room or Looking Space?](https://neiloseman.com/lead-room-nose-room-or-looking-space/)
+[^cined-headroom]: [CineD — The Art of Imbalance: Headroom in Storytelling](https://www.cined.com/the-art-of-imbalance-headroom-in-storytelling/)
+[^expertphotography-leadroom]: [ExpertPhotography — Lead Room Principle](https://expertphotography.com/lead-room-principle/)
+[^learncorel-negative-space]: [Corel Discovery Center — Using Negative Space in Photography](https://learn.corel.com/tutorials/negative-space-photography/)
+[^guides-unc-headroom]: [UNC Libraries — Video Best Practices: Shot Framing](https://guides.lib.unc.edu/video/shot-framing#s-lg-box-wrapper-23345970)
+ 
 [^tate-composition]: [Tate — Composition](https://www.tate.org.uk/art/art-terms/c/composition)
 [^nng-visual-hierarchy]: [Nielsen Norman Group — Visual Hierarchy 101](https://www.nngroup.com/articles/visual-hierarchy/)
 [^cambridge-rot]: [Cambridge in Colour — Rule of Thirds](https://www.cambridgeincolour.com/tutorials/rule-of-thirds.htm)
@@ -227,7 +445,9 @@ explain why you’re breaking it.[^petapixel-golden-ratio]
 [^guardian-balance]: [The Guardian — How to Take Better Photos: Balance](https://www.theguardian.com/artanddesign/2015/oct/25/how-to-take-better-photos-balance)
 [^arty-teacher-negative-space]: [The Arty Teacher — What Is Negative Space?](https://theartyteacher.com/what-is-negative-space/)
 [^petapixel-golden-ratio]: [PetaPixel — Golden Ratio Composition Primer](https://petapixel.com/2016/01/26/golden-ratio-composition/)
-[^hsv-dynamic-symmetry]: [HSV Camera Club — Dynamic Symmetry](https://www.hsvcameraclub.com/dynamic-symmetry.html)
+[^kitschmeister-dynamic]: [Kitschmeister — Dynamic Symmetry Explained: The Key to Great Composition](https://www.kitschmeister.com/post/the-key-to-great-composition-dynamic-symmetry-explained)
+[^halbert-dynamic]: [Karen Halbert — 2024 Workshop Weekend with Handell and Halbert Composition Workshop](http://karenhalbert.blogspot.com/2024/11/2024-workshop-weekend-with-handell-and.html)
+[^oilpainter-dynamic]: [Oil Painters of America — Dynamic Symmetry and How I Incorporate It into My Practice](https://www.oilpaintersofamerica.com/2022/03/dynamic-symmetry-and-how-i-incorporate-it-into-my-plein-air-and-studio-and-practice/)
 [^gurney-notan-study]: [James Gurney — Notan Study](https://gurneyjourney.blogspot.com/2008/02/notan.html)
 [^gurney-value-grouping]: [James Gurney — Value Grouping](https://gurneyjourney.blogspot.com/2015/12/value-grouping.html)
 [^will-kemp]: [Will Kemp Art School — How to Use Notan Design](https://willkempartschool.com/how-to-use-notan-design-to-create-compelling-compositions-in-your-paintings/)

--- a/docs/non-ai-research/dynamic-symmetry-root-rectangles.md
+++ b/docs/non-ai-research/dynamic-symmetry-root-rectangles.md
@@ -1,0 +1,323 @@
+---
+title: "Dynamic Symmetry and Root Rectangles in Composition"
+tags: [composition, visual-design, dynamic-symmetry, art]
+project: docs-hub
+updated: 2025-09-17
+---
+
+--8<-- "_snippets/disclaimer.md"
+
+# Dynamic Symmetry and Root Rectangles in Composition
+
+Dynamic symmetry is a compositional design system that uses geometric ratios and
+diagonal grids to organize artwork so it feels harmonious and energetic.[^kitschmeister]
+Jay Hambidge popularized the framework in the early 20th century after studying
+how classical Greek art relied on irrational "dynamic" rectangles (such as the
+√2 or golden rectangles) instead of simple whole-number ratios.[^kitschmeister]
+Rather than relying on a single rule, dynamic symmetry supplies a flexible
+armature of diagonals, reciprocals, and subdivisions that guide placement,
+leading a viewer's eye through the picture with rhythm and movement. The idea is
+not to impose visible grids on finished work, but to lay down an underlying
+structure that keeps complex scenes balanced without feeling static.
+
+## Understanding Root Rectangles
+
+Root rectangles sit at the heart of dynamic symmetry. A root rectangle's long
+side divided by its short side equals √N for some integer N, giving proportions
+such as √2:1 (≈1.414), √3:1 (≈1.732), or √5:1 (≈2.236).[^kitschmeister]
+Constructing them is iterative: start with a square, draw its diagonal, extend
+that diagonal to define the next rectangle, and repeat for higher roots so each
+new armature inherits the previous one’s geometry.[^kitschmeister] Hambidge
+nicknamed Root-2 the *diagon*, Root-3 the *hecton* (or *sixton*), and Root-4 the
+double square; Root-5 ties closely to the golden ratio because its longer side
+can be expressed as 1 + 2 × (1/φ).[^kitschmeister] Beyond Root-5 the rectangles
+become increasingly extreme, which is why historical usage clusters around
+squares, Root-2, Root-3, Root-4, Root-5, and golden rectangles.[^kitschmeister]
+
+### Root rectangle cheat sheet
+
+| Root | Ratio (long : short) | Approx. decimal | Nickname / notes |
+| ---: | -------------------- | --------------- | ---------------- |
+| 1    | 1 : 1                | 1.000           | Square foundation |
+| 2    | √2 : 1               | 1.414           | Diagon; divides into two smaller Root-2s |
+| 3    | √3 : 1               | 1.732           | Hecton/sixton; echoes hexagon geometry |
+| 4    | √4 : 1               | 2.000           | Double square; common in altarpieces |
+| 5    | √5 : 1               | 2.236           | Near-φ proportion; bridges to golden rectangle |
+| 6    | √6 : 1               | 2.449           | Rare in historical work; feels elongated |
+
+### Construction walk-through
+
+1. Start with a square (Root-1) and draw the diagonal.
+2. Swing that diagonal outward to set the length of the next rectangle’s longer
+   side; this creates a Root-2 proportion.
+3. Repeat the swing from each new rectangle to generate Root-3, Root-4, and so
+   on, keeping each new diagonal as the seed of the next proportion.
+4. Divide the long edge into N equal parts to reveal N smaller Root-N
+   rectangles—handy for echoing shapes and spacing visual beats evenly.
+
+### Why root rectangles matter
+
+- **Self-similarity:** Dividing a Root-N rectangle into N equal sections along
+  the long side yields smaller Root-N rectangles, reinforcing unity across the
+  frame.[^kitschmeister]
+- **Natural growth:** Each shape arises from simple geometric operations
+  (swinging diagonals) that mirror growth patterns in nature, making them feel
+  organic rather than contrived.[^kitschmeister]
+- **Historical precedent:** Classical architecture, Renaissance painting, and
+  decorative arts frequently align with these ratios, giving modern artists a
+  proven compositional backbone.[^kitschmeister]
+- **Practical variety:** Having several related rectangles (square through
+  Root-5) lets you match the armature to common canvas, camera, or poster
+  formats without abandoning the system.
+
+## Dynamic Symmetry vs. the Rule of Thirds and Golden Ratio
+
+Dynamic symmetry is often described as the "rule of thirds on steroids": it
+keeps the clarity of a gridded layout but multiplies the number of usable
+intersections and diagonals so compositions feel guided rather than boxed
+in.[^kitschmeister]
+
+### Quick comparison
+
+- **Rule of Thirds → Dynamic Symmetry:** Thirds deliver four power points and a
+  static tic-tac-toe rhythm. Dynamic symmetry adds baroque (bottom-left to
+  upper-right) and sinister (upper-left to lower-right) diagonals plus
+  reciprocals that run corner-to-midpoint, creating energetic triangles and
+  multiple "eyes" for staging focal points.[^kitschmeister]
+- **Golden Ratio → Dynamic Symmetry:** φ-based grids and spirals sit inside the
+  system as one family member. Expanding to √2, √3, Root-5, or 2:3 lets you
+  tailor the grid to your actual canvas or camera aspect ratio without losing
+  the harmonic relationships.[^kitschmeister]
+- **Directional storytelling:** Aligning a gesture along the baroque diagonal
+  tends to feel uplifting and resolved, while the sinister diagonal leans toward
+  tension or instability—handy when you want visual drama.[^kitschmeister]
+
+Reciprocal (diagonal-perpendicular) lines are what make the armature so rich:
+they crisscross the frame at right angles to the main diagonals, carving out
+dynamic triangles—sometimes nicknamed "golden triangles" inside φ rectangles—and
+pointing to nuanced anchor spots beyond the four third-grid intersections.
+
+## Benefits of Geometric Scaffolding
+
+Artists who adopt dynamic symmetry report several compositional advantages:
+
+- **Enhanced movement and flow:** Diagonal pathways lead the eye through
+  multiple focal points so the composition feels active rather than static.
+  Analyses of Caravaggio, Titian, Rembrandt, and El Greco reveal figures,
+  sightlines, and value breaks tracking these diagonals, giving their scenes a
+  cinematic sweep.[^kitschmeister]
+- **Organized complexity:** Intersecting guides let busy scenes stay coherent by
+  aligning clusters of elements along shared diagonals or reciprocals. The armature
+  doubles as a rhythm map so repeated angles feel intentional rather than
+  coincidental.[^kitschmeister]
+- **Reliable balance:** Because the ratios derive from classical geometry, the
+  resulting layouts often feel "right" even when asymmetrical, helping you avoid
+  tangents or awkward placements as you refine a piece.[^kitschmeister]
+- **Guided creative process:** Pre-planned grids free artists to focus on
+  expressive mark-making after major placements are solved. Painter Michele
+  Byrne credits the armature with giving her a solid starting point before she
+  "lets loose" in plein air pieces.[^halbert-workshop]
+- **Consistency and reproducibility:** Reusing the same dynamic grid across
+  multiple works creates a unifying proportional theme—useful for gallery series,
+  illustration packages, or branding systems that must feel related.
+- **Training tool:** Rehearsing with grids teaches your eye to spot harmonious
+  diagonals even when you stop physically drawing them, similar to how practicing
+  perspective eventually lets you visualize vanishing points instinctively.
+
+## Step-by-Step: Building a Dynamic Symmetry Grid
+
+Creating the basic harmonic armature for any rectangle follows a predictable
+workflow:[^kitschmeister]
+
+1. **Choose the base rectangle.** Decide on the aspect ratio (Root-2, Root-3,
+   golden rectangle, 3:2 camera frame, 16:9, etc.) so the armature matches your
+   working surface.
+2. **Mark midpoints.** Find the midpoint of each side with a ruler or software
+   guides; accurate midpoints keep the reciprocals perpendicular.
+3. **Draw the main diagonals.** Connect opposite corners to establish the
+   baroque (↗) and sinister (↘) diagonals—the strongest motion vectors in the
+   grid.
+4. **Add corner-to-midpoint lines.** From each corner, draw to the midpoint of
+   the opposite sides. These reciprocal lines cross the main diagonals at right
+   angles, carving the rectangle into dynamic triangles (the "golden triangles"
+   inside φ rectangles) and revealing multiple intersection "eyes."[^kitschmeister]
+5. **Optional subdivisions.** Drop vertical or horizontal lines through key
+   intersections, or construct rebated squares to echo the frame’s proportions
+   at smaller scales.[^kitschmeister]
+6. **Scan for intersections.** Step back and circle the nodes where diagonals
+   and reciprocals cross—prime spots for focal points, horizon lines, or major
+   gesture turns.
+7. **Use as a guide, not a cage.** Rough in your composition with the grid
+   visible, then lighten, hide, or delete the guides once the big placement
+   decisions are locked.
+
+> **Tip:** Draw the armature lightly in pencil (or on its own digital layer) so
+> it disappears in the finished work while still steering your layout choices.
+
+## Applying the Grid in Clip Studio Paint
+
+Clip Studio Paint (CSP) includes several ways to overlay or construct dynamic
+symmetry guides while keeping your drawing layers clean:[^kitschmeister][^clipstudio]
+
+1. **Overlay a premade material.** Search the CSP Asset Library for "dynamic
+   symmetry" grids, drag the material into your canvas, scale it to match your
+   aspect ratio, set the layer to low opacity, and lock it so you never draw on
+   it accidentally.
+2. **Enable composition guides.** View → *Grid* (and View → *Grid/Ruler
+   Settings*) lets you drop a 3×3 or custom grid on top of the canvas. Pair it
+   with Snap to Grid when you want to align midpoints precisely before drawing
+   diagonals.
+3. **Draw custom guides.** Create a dedicated "Guides" layer, enable the ruler or
+   grid for measurement, and use the Straight Line tool (hold Shift for perfect
+   lines) to add the diagonals and reciprocals. Convert the layer to a ruler if
+   you want strokes on other layers to snap precisely to those guides.
+4. **Crop or mask for reframing.** Keep your scene slightly oversized on lower
+   layers, then use the *Edit → Canvas Properties* crop dialog or a Layer Mask to
+   test different headroom or lead-room trims without redrawing core artwork.
+5. **Leverage animation tools.** In animation folders, onion skinning and camera
+   keyframes help check that moving characters retain nose room across frames;
+   toggle the grid layer while scrubbing the timeline to keep motion aligned to
+   the armature.
+6. **Customize canvas ratios.** Set up canvases at Root-2, Root-3, or φ
+   proportions (File → *New*) so the exported artwork already matches the armature
+   you plan to use.
+7. **Utilize symmetry and perspective rulers.** The Perspective Ruler can mimic
+   baroque or sinister diagonals by parking vanishing points far off canvas, and
+   Parallel Line rulers repeat reciprocals at matching angles when you need
+   echoes of the same energy line.
+8. **Reference and flip.** Import masterworks underneath your grid layer to study
+   alignments, and use *View → Flip Horizontal* to expose any imbalance while the
+   armature is visible.
+9. **Frame Border for comics.** CSP’s Frame Border tool lets you crop or resize
+   panel masks after sketching; resize the mask to reframe a panel along dynamic
+   diagonals without shifting the underlying art.
+
+## Applying the Grid in Procreate
+
+While Procreate lacks a built-in dynamic symmetry overlay, artists can still work
+with the armature effectively by combining templates, guides, and transform
+tools:[^kitschmeister]
+
+1. **Import a reference grid.** Actions → *Add* → *Insert a photo* lets you place
+   a PNG or JPG grid on its own layer. Resize it to the canvas edges, reduce
+   opacity, set the blend mode to Multiply or Screen for contrast, and lock the
+   layer.
+2. **Enable composition guides.** Actions → *Canvas* → *Drawing Guide* displays a
+   configurable 2D grid. Edit the spacing (and grid color/opacity) so thirds or
+   root ratios approximate your armature, giving you quick landmarks for
+   midpoints before you draw diagonals.
+3. **Build the grid manually.** Sketch diagonals with QuickLine (draw and hold to
+   straighten; tap with another finger to snap to 45° increments). Repeat for the
+   corner-to-midpoint reciprocals and any optional subdivisions on a dedicated
+   guide layer.
+4. **Use cropping for reframes.** *Actions → Canvas → Crop & Resize* shows a rule
+   of thirds overlay; adjust the crop to trim headroom or reposition focal points
+   until they hit your preferred dynamic intersection, then accept the crop.
+5. **Leverage assisted drawing.** Set Perspective Guide vanishing points so the
+   assistant lines approximate baroque or sinister diagonals, then toggle
+   Drawing Assist on your guide layer to snap strokes along those directions.
+6. **Plan canvas ratios.** Create custom canvases (e.g., 3000 × 3000 √2-based)
+   that already match your target root rectangle, or duplicate a template file
+   with the grid baked in for consistent series work.
+7. **QuickShape for alignment.** Use QuickShape (draw, hold, and edit the line) to
+   lay down perfectly straight horizon or diagonal references before committing
+   to the full grid.
+8. **Reference and flip.** Import reference art beneath the grid, toggle
+   horizontal flip to spot lopsided spacing, and use the Transform tool with
+   Snapping to align subjects precisely to guide intersections.
+9. **Mind safe zones.** If exporting for varied screens, temporarily reduce the
+   canvas using Crop & Resize or add an inset rectangle to simulate title-safe
+   areas so key focal points do not hug the edge.
+10. **Save reusable templates.** Once a dynamic grid layer is in place, group it
+    with notes and export the file to reuse as a starting point, avoiding
+    repetitive setup.
+11. **Custom guide stamps.** Keep a dedicated layer of reusable thirds/phi grids
+    made with QuickShape, pair it with the vertical/horizontal Symmetry guide to
+    mark centers quickly, or import stamp brushes from the community so you can
+    drop precise overlays without rebuilding them every session.
+
+> **Digital reminder:** Layers, undo history, and transform tools mean you can
+> iterate freely—toggle guide layers on and off as you compose and delete them
+> before final export so the structure remains invisible in the finished art.
+
+## Examples in Practice
+
+Dynamic symmetry appears across mediums, sometimes explicitly and sometimes
+through intuitive alignment:
+
+- **Renaissance and Baroque painting:** Analyses of Caravaggio, Titian, Rembrandt,
+  and El Greco show limbs, gazes, and lighting edges falling on dynamic grid
+  intersections, suggesting training in geometric composition.[^kitschmeister]
+- **Photography:** Henri Cartier-Bresson often framed scenes using golden or
+  dynamic armatures before capturing decisive moments, as seen in his staircase
+  photograph from Hyères, France; modern photographers still overlay phi grids or
+  dynamic triangles in Lightroom to fine-tune crops.[^kitschmeister]
+- **Contemporary painters:** Michele Byrne and Albert Handell share works-in
+  progress that reveal dynamic grids underpinning their award-winning plein air
+  and pastel paintings.[^halbert-workshop]
+- **Illustration and concept art:** Educators like Myron Barnstone and Tavis Leaf
+  Glover teach the system to help artists manage complex scenes while maintaining
+  rhythm, often starting with dynamic thumbnails.[^kitschmeister]
+- **Film and cinematography:** Analysts overlay dynamic symmetry on film frames
+  from directors such as Stanley Kubrick to dissect how diagonal energy guides
+  the viewer through a shot.[^glover-film]
+
+## Practice Exercises
+
+Build intuition by integrating dynamic symmetry into regular drills:[^kitschmeister]
+
+1. **Grid thumbnails:** Sketch a batch of 2–3 inch thumbnails on pre-drawn
+   armatures (Root-2, φ, 3:2) to test focal placement rapidly. Treat them like
+   "thrust maps"—rough geometric masses instead of detail renderings.[^kitschmeister]
+2. **Master overlays:** Print or import masterpieces and overlay the grid to
+   reverse engineer how limbs, gazes, and value breaks ride specific diagonals
+   or reciprocals. Compare your findings with published analyses to sharpen your
+   eye.[^kitschmeister]
+3. **Re-compose studies:** Take a rule-of-thirds photo or sketch, rebuild it on a
+   dynamic grid, and note how diagonal flow or redistributed focal points change
+   the scene’s energy.
+4. **Root rectangle challenges:** Subdivide Root-2 or Root-3 canvases into smaller
+   congruent rectangles, then assign abstract shapes or tonal blocks to each to
+   explore unity through repetition.
+5. **Baroque/sinister gestures:** Begin gesture drawings or plein air sketches by
+   laying in the X of the two main diagonals so figures, tree lines, or shadows
+   echo those energy paths before you add detail.
+6. **Grid memory drills:** Draw the entire harmonic armature from memory, then
+   overlay a precise template to check accuracy; repeat until you can visualize
+   the grid without guides.
+7. **Photographic scavenger hunts:** Go shooting (or look through archives) with
+   the goal of finding real-world diagonals that align with a chosen dynamic
+   rectangle, reinforcing the habit of spotting grids in everyday scenes.
+
+## Further Resources
+
+- Jay Hambidge, *Dynamic Symmetry: The Greek Vase* (1920) – foundational text
+  introducing root rectangles.[^kitschmeister]
+- Jay Hambidge, *The Elements of Dynamic Symmetry* – a concise Dover reprint for
+  artists who want the math in a digestible format.[^kitschmeister]
+- Barnstone Studios lectures – Myron Barnstone’s geometric composition courses
+  with hands-on armature drills.[^barnstone]
+- Clip Studio Tips: "Dynamic Symmetry" – official walkthrough for building the
+  grid inside CSP.[^clipstudio]
+- Tavis Leaf Glover, *Dynamic Symmetry: The Foundation of Masterful Art* – book
+  and companion blog/videos analyzing paintings, photos, and films.[^glover-book][^glover-film]
+- Great Big Photography World: "How to Use Dynamic Symmetry in Composition" –
+  practical advice for photographers working with the grids.[^gbpw]
+- Adam Marelli’s composition breakdowns – bridging classical art lessons and
+  photography through dynamic symmetry demos.[^marelli]
+- Proko community lesson: "How to Use Dynamic Symmetry Grids" – critiques and
+  demonstrations for illustrators learning the system.[^proko]
+- Michele Byrne’s plein air demos – showing dynamic grids penciled on canvases
+  before expressive painting begins.[^halbert-workshop][^oilpainter]
+
+[^kitschmeister]: "Dynamic Symmetry Explained: The Key to Great Composition,"
+    Kitschmeister, accessed 2025, https://www.kitschmeister.com/post/the-key-to-great-composition-dynamic-symmetry-explained.
+[^halbert-workshop]: "2024 Workshop Weekend with Handell and Halbert Composition Workshop," Karen Halbert, November 2024, https://karenhalbert.blogspot.com/2024/11/2024-workshop-weekend-with-handell-and.html.
+[^oilpainter]: Michele Byrne, "Dynamic Symmetry – And how I incorporate it into my plein air and studio practice," Oil Painters of America, March 2022, https://www.oilpaintersofamerica.com/2022/03/dynamic-symmetry-and-how-i-incorporate-it-into-my-plein-air-and-studio-and-practice/.
+[^glover-film]: Tavis Leaf Glover, "Dynamic Symmetry in Cinema," accessed 2025, https://www.tavisleafglover.com/blog/dynamic-symmetry-in-cinema.
+[^barnstone]: Barnstone Studios, "Dynamic Symmetry" course overview, accessed 2025, https://www.barnstonestudios.com/.
+[^glover-book]: Tavis Leaf Glover, *Dynamic Symmetry: The Foundation of Masterful Art*, accessed 2025, https://www.tavisleafglover.com/products/dynamic-symmetry-the-foundation-of-masterful-art.
+[^gbpw]: The Great Big Photography World, "How to Use Dynamic Symmetry in Composition," accessed 2025, https://www.thegreatbigphotographyworld.com/how-to-use-dynamic-symmetry-in-composition/.
+[^clipstudio]: Clip Studio Tips, "Dynamic Symmetry," accessed 2025, https://tips.clip-studio.com/en-us/articles/3920.
+[^marelli]: Adam Marelli, "Dynamic Symmetry," accessed 2025, https://adam-marelli.com/dynamic-symmetry/.
+[^proko]: Proko, "How to Use Dynamic Symmetry Grids," accessed 2025, https://www.proko.com/lesson/how-to-use-dynamic-symmetry-grids/notes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - Notable Figures: non-ai-research/inspiring-figures.md
       - Overview: non-ai-research/index.md
       - Composition 101 — Chaptered Intro: non-ai-research/composition-101-chaptered-intro.md
+      - Dynamic Symmetry and Root Rectangles: non-ai-research/dynamic-symmetry-root-rectangles.md
       - The Metaorganism: non-ai-research/metaorganism.md
   - Productivity:
       - Arduino: arduino/index.md


### PR DESCRIPTION
## Summary
- expand the Clip Studio Paint guidance with grid overlays, cropping and masking options, animation alignment tips, ratio presets, ruler usage, and frame border reframing notes
- broaden the Procreate workflow section with drawing guide configuration, cropping aids, safe-zone planning, reusable templates, symmetry-based stamps, and a reminder about iterating on separate layers
- normalize the Halbert workshop citation to use an https link for consistency

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68caaa7ca0788326bef92b4377918671