### PR TITLE
Fix disclaimer include path

### DIFF
--- a/docs/non-ai-research/painterly-style-clip-studio-paint.md
+++ b/docs/non-ai-research/painterly-style-clip-studio-paint.md
@@ -5,7 +5,7 @@ project: docs-hub
 updated: 2025-09-08
 ---
 
---8<-- "\_snippets/disclaimer.md"
+--8<-- "_snippets/disclaimer.md"
 
 {{ toc }}
 


### PR DESCRIPTION
## Summary
- point the painterly style guide disclaimer include to the existing `_snippets` directory

## Testing
- python scripts/expand_snippets.py docs/non-ai-research/painterly-style-clip-studio-paint.md

------
https://chatgpt.com/codex/tasks/task_e_68cac7f5ef44832698b28cfcd9c96966