### PR TITLE
Expand erotic composition chapter formatting

### DIFF
--- a/docs/non-ai-research/composition-101-chaptered-intro.md
+++ b/docs/non-ai-research/composition-101-chaptered-intro.md
@@ -539,6 +539,256 @@ explain why you’re breaking it.[^petapixel-golden-ratio]
 - **Procreate:** Actions → Canvas → Drawing Guide → Edit → 2D Grid. Enter exact pixel
   values so gridlines fall on thirds (the guide defaults to squares).[^procreate-guide-overview]
 
+## Chapter 12 — Erotic figure composition: shaping desire, tension, and flow
+
+Erotic figure composition arranges bodies, props, and framing so the image
+communicates desire and emotional charge rather than anatomy drills
+alone.[^stmarys-erotic] Every pose, gesture, and cropping choice should serve
+that mood—guiding the viewer’s gaze, balancing tension, and suggesting an
+intimate story that resonates beyond simple nudity.[^stmarys-erotic] In this
+chapter you’ll unpack how gesture, asymmetry, framing, focal planning, and
+digital workflows shape desire, tension, and flow—and you’ll finish with drills
+to keep those instincts sharp.[^stmarys-erotic]
+
+### Why erotic composition differs from general figure drawing
+
+- **Emotional emphasis:** Erotic scenes spotlight vulnerability, invitation,
+  or power exchange so viewers sense relationship dynamics, whereas neutral
+  figure studies can remain purely anatomical.[^stmarys-erotic]
+- **Gesture selection:** Small cues—arched backs, tilted necks, deliberate hand
+  placement—are chosen for sensual resonance rather than comfort or symmetry.[^stmarys-erotic]
+- **Viewer engagement:** Subjects may return the gaze or completely ignore the
+  audience so we either feel addressed or voyeuristic by design.[^stmarys-erotic]
+- **Compositional support:** Lighting, focal points, and framing heighten erotic
+  tension the way chiaroscuro emphasizes a curve or a cropped frame forces us
+  into the scene.[^stmarys-erotic]
+- **Balancing explicitness:** Successful erotic work implies more than it shows,
+  sustaining elegance while remaining undeniably charged.[^stmarys-erotic]
+
+### Gesture, line of action, and body rhythm
+
+#### Line of action and the S-curve
+
+Start every figure with a fluid line of action. S-curves—Hogarth’s famed “line
+of beauty”—naturally energize the body and read as sensual because the eye
+rides that undulating spine instead of a stiff column.[^wikipedia-line-of-beauty]
+Psychology research even links a gentle lumbar curve with perceived
+attractiveness, so emphasizing that flow pays off in erotic imagery.[^psychologytoday-curves]
+When you sketch the first pass, overstate that line—even beyond anatomical
+accuracy—then dial it back so the final pose keeps that sensual sweep.[^stmarys-erotic]
+
+#### Body rhythm and flowing repetition
+
+Look for repeating curves and echoing angles that let hips, shoulders, and limbs
+“dance” together; uninterrupted rhythms keep the viewer’s eye gliding across the
+figure and make the pose feel alive.[^lovelifedrawing-flow] Track how one curve
+echoes another (hip to shoulder to wrist) and ensure negative spaces between
+limbs reinforce the same tempo.[^stmarys-erotic] Any limb that juts out awkwardly
+or breaks the rhythm can snap the mood, so redesign silhouettes until the flow
+feels intentional.[^stmarys-erotic]
+
+#### Expressive exaggeration
+
+Treat gesture drawing like body language—label thumbnails with verbs (“reaching,”
+“yielding,” “teasing”) and exaggerate the pose to communicate that feeling.
+Pushing the arc of a spine, the angle of a knee, or the tilt of the neck during
+the rough stage adds sensual energy you can refine later.[^clipstudiotips-pose]
+Avoid mannequin stances; even standing figures can adopt a flirty weight shift
+or playful tilt to stay engaging.[^lovelifedrawing-mistakes]
+
+#### Harmonizing multiple figures
+
+When composing couples or groups, design an overall gesture that links bodies—an
+S-curve enveloping both, an “X” created by crossing limbs, or a loop that keeps
+the eye circling.[^stmarys-erotic] Complementary or contrasting lines of action
+signal whether the relationship feels harmonious or push-pull
+tense.[^stmarys-erotic] Sketch combined gesture lines to see if the pair forms a
+cohesive megashape; if not, adjust until their silhouettes interlock without
+confusion.[^stmarys-erotic]
+
+### Asymmetry, weight distribution, and counterbalance
+
+Stiff symmetry drains sensuality. Contrapposto (weight settled on one leg so
+hips and shoulders tilt opposite) naturally sculpts S-curves, highlights the
+waist-to-hip rhythm, and reliably boosts perceived
+attractiveness.[^psychologytoday-contrapposto] Purposeful asymmetry distributes
+visual weight unevenly so the pose feels alive while still balanced—think of it
+as a teeter-totter where one area’s activity is countered
+elsewhere.[^innovature-asymmetry]
+
+Counterbalance adds implied motion and trust: a leaning torso finds support in a
+reaching arm, or one partner dips another so their shared axes keep the pair
+upright.[^studiobinder-asymmetry] Tilt shoulders and hips in opposite directions to
+maintain that energy; parallel axes flatten the figure instantly.[^clipstudiotips-pose]
+Push and pull limbs to show weight transfer—pressed hands leave indentations,
+supporting legs flex, and trailing limbs soften to balance the composition.[^stmarys-erotic]
+
+Whenever both sides mirror each other exactly, the result reads static, so break
+symmetry with varied limb angles, staggered heights, or offset props.[^creativebloq-balance]
+Intentionally short-side or tilt the camera to echo that imbalance and raise the
+viewer’s heart rate.[^studiobinder-asymmetry]
+
+### Framing techniques for intimacy
+
+#### Selective cropping and proximity
+
+Crop decisively to focus on bodies and their contact points. Tight framing pulls
+the viewer into private space, while trimming at clean locations (mid-thigh,
+mid-torso) leaves the rest to imagination and keeps emphasis on the emotional
+core.[^photo-stack-cropping] Avoid chopping at joints unless you mean to shock;
+instead, let curves lead out of frame so the viewer imagines what continues just
+beyond the border.[^stmarys-erotic]
+
+#### Lead room and look space
+
+Give eyes and gestures room to travel when you want a relaxed tone; starving a
+gaze of space increases claustrophobia and erotic tension because the subjects
+appear pressed against the frame.[^photo-stack-cropping] That same short-sided
+framing can feel voyeuristic, like the viewer is eavesdropping inches from the
+scene—use it intentionally when you want discomfort or intensity.[^stmarys-erotic]
+
+#### Negative space and spatial balance
+
+Use empty areas to spotlight silhouettes or the charged gaps between near-touching
+hands. Asymmetrically balancing dense figure clusters against calm voids keeps
+the scene dynamic without clutter and creates little “tension pockets” where
+contact almost happens.[^toyphotographers-negative-space][^innovature-asymmetry]
+
+#### Camera distance and angle
+
+Decide whether the audience should feel like a participant or voyeur: close-ups
+linger on expressions, goosebumps, or gripping hands, whereas wider shots let us
+watch from a doorway.[^stmarys-erotic] Eye-level framing feels personal, low
+angles empower dominant figures, and high angles emphasize
+vulnerability.[^stmarys-erotic] Switching distance across a sequence—wide to
+close—can mirror characters moving from flirtation to intimacy.
+
+#### Managing tangents and clean silhouettes
+
+Audit edges so limbs, hair, and props don’t merge into confusing tangents; shift
+elements or adjust cropping to keep silhouettes legible and the viewer focused on
+the sensual narrative.[^clipstudiotips-pose] Leave a sliver of space between key
+contours and the frame so focal points don’t accidentally stick to the border.
+
+### Focal points: guiding desire with face, core, hands, and gaze
+
+Design a hierarchy of focal points so the viewer’s eye follows an intentional
+path through the scene.[^numberanalytics-focal] Faces often anchor emotion—direct
+eye contact invites the audience, closed eyes broadcast bliss, and characters
+staring at each other cue us to study their connection.[^stmarys-erotic] Support
+that focus with value or color contrast so the expression becomes the brightest
+or sharpest zone on the page.[^drawpaint-saturation]
+
+Center bodies through the hips and waist; accentuating the waist-to-hip ratio or
+the junction where two figures meet spotlights sexual
+chemistry.[^psychologytoday-curves] Props like belts, garters, or wrinkled sheets
+can frame that region without explicit detail, letting implication do the heavy
+lifting.[^stmarys-erotic]
+
+Hands become action cues: fingers pressing into skin, tangling in hair, or
+clutching sheets are micro-stories worth elevating as secondary focal
+points.[^stmarys-erotic-manga] Render subtle pressure marks or fabric pulls to
+sell the sensation.[^stmarys-erotic]
+
+Leverage sightlines as invisible arrows—if a lover glances toward a touch, we
+instinctively follow the gaze.[^numberanalytics-focal] Arrange primary, secondary,
+and tertiary focal beats so the eye loops smoothly rather than ping-ponging
+between competing hotspots; asymmetry and controlled contrast prevent stagnant
+compositions.[^creativebloq-balance] Think of it like choreography: face → core →
+hands → back to face creates a satisfying “tour” for the viewer.
+
+### Common mistakes in erotic compositions
+
+- **Stiff symmetry:** Perfectly mirrored limbs or evenly weighted poses feel
+  clinical; introduce contrapposto, twists, or asymmetrical props to restore
+  life.[^lovelifedrawing-mistakes] Even tiny changes—a dropped shoulder or
+  staggered knees—reintroduce motion.
+- **Unclear gesture or silhouette:** Overlapping limbs without negative-space
+  planning muddle intent—adjust spacing and avoid tangents so the action reads at
+  a glance.[^clipstudiotips-pose] If you can’t identify the pose in flat
+  silhouette, rework it before rendering.
+- **Overcrowded scenes:** Too many props or figures dilute intimacy; simplify the
+  environment so the focal relationship dominates.[^stmarys-erotic] Reserve dense
+  detail for focal zones and let backgrounds breathe.
+- **Missing tension zones:** Include at least one area of strain or
+  anticipation—a gripping hand, arched back, or hovering touch—to keep desire
+  palpable.[^stmarys-erotic-manga] Visual tension is the hook that makes viewers
+  linger.
+- **Anatomy drift:** Extreme exaggeration without structural awareness breaks
+  immersion; keep studying real bodies and weight distribution so stylization
+  stays intentional.[^artgym-posing] Show weight pressing into surfaces so the
+  scene feels tangible.
+
+### Real-world reference points
+
+Study masters to reverse engineer their decisions. Gustav Klimt’s *The Kiss*
+wraps lovers in a gold cocoon so our eyes land on their tilted heads and joined
+hands, with curling toes adding precarious tension.[^artsper-klimt] Egon Schiele’s
+contorted nudes prove how aggressive diagonals and empty space can broadcast raw
+urgency.[^stmarys-erotic] Mid-century pin-up illustrators and erotic comic artist
+Milo Manara choreograph diagonals, props, and exaggerated gestures to invite the
+viewer while keeping compositions tasteful and
+legible.[^stmarys-erotic-manga]
+
+Film offers framing lessons too—Wong Kar-Wai’s *In the Mood for Love* uses
+doorways, close crops, and red accents to make longing sizzle without explicit
+imagery.[^medium-wong-kar-wai] Consider other cinematic touchstones: the pottery
+sequence in *Ghost* turns hands and clay into a stand-in for touch; Kubrick’s
+*Barry Lyndon* stages candlelit seductions where warm light isolates faces; *Carol*
+lingers in shallow focus to center emotional experience; and *Black Swan* leverages
+mirrors to double bodies and heighten psychological charge. Each scene is a
+masterclass in framing desire without needing explicit content.
+
+### Practice drills for sensual flow and framing
+
+1. **Timed gesture bursts:** Do 30–120 second sketches focused on S-curves, then
+   exaggerate each pass to feel how much curve sells the mood before settling on a
+   final version.[^clipstudiotips-pose]
+2. **Rhythm overlays:** Trace lines of action and repeating curves on references,
+   then build new poses from those rhythms to internalize how one body part cues
+   the next.[^lovelifedrawing-flow]
+3. **Tension studies:** Draw relaxed versus high-tension versions of the same
+   pose to catalog the visual cues (arched backs, clenched hands, pointed toes)
+   that raise the heat.[^stmarys-erotic]
+4. **Framing thumbnails:** Test wide, medium, close, and unusual angles of one
+   scenario to see which crop best delivers intimacy, and note how viewer POV
+   shifts the emotional read.[^photo-stack-cropping]
+5. **Focal-point mapping:** Diagram primary and secondary beats on favorite
+   artworks, sketch arrows for the eye path, and plan your own hierarchy before
+   rendering.[^numberanalytics-focal]
+6. **Timed “finish the story” sketches:** Expand a suggestive pose into a quick
+   narrative scene—add props, lighting cues, or implied partners within a 10-minute
+   limit to stretch storytelling instincts.[^stmarys-erotic-manga]
+7. **Resource sessions:** Use Croquis Café or similar timed-model libraries for
+   varied body types, and revisit Love Life Drawing or Art Gym lessons to correct
+   gesture pitfalls while keeping poses lively.[^croquis-cafe][^lovelifedrawing-mistakes][^artgym-posing]
+
+### Digital workflows (Clip Studio Paint & Procreate)
+
+- **Layered planning:** Rough gestures, grids, silhouettes, and refined line art
+  on separate layers so you can tweak flow without redrawing the entire
+  figure.[^clipstudiotips-pose]
+- **Guides and overlays:** Import thirds or custom grids in Clip Studio Paint or
+  enable Procreate’s Drawing Guide to align focal points intentionally.[^wildlifeartstore-grid]
+- **Canvas flips and crops:** Mirror, scale, or reposition figures
+  non-destructively until asymmetry and negative space feel right; duplicate the
+  canvas to compare alternate framings side by side.[^clipstudiotips-pose]
+- **Selective adjustments:** Use lasso transforms to refine limb placement, fix
+  tangents, or tighten silhouettes after checking the composition at thumbnail
+  size.[^clipstudiotips-pose]
+- **Lighting and color accents:** Add glow or multiply layers to spotlight focal
+  zones, vignette the edges for intimacy, or glaze warm tones where skin
+  touches.[^drawpaint-saturation]
+- **Reference panels:** Keep inspirational art or 3D mannequins in Clip Studio’s
+  Sub View or Procreate’s Reference window so you can compare rhythm and focal
+  planning without leaving the canvas.
+- **Perspective and shape assists:** Drop perspective rulers in Clip Studio or use
+  Procreate’s QuickShape/Drawing Assist to frame doorways, beds, or mirrors cleanly
+  around figures.[^clipstudiotips-pose]
+- **Iteration safety nets:** Save versions often or duplicate layers so you can
+  experiment with bold edits—different crops, color grades, or focal priorities—
+  without fear of losing the original idea.[^clipstudiotips-pose]
+
 ## References
 
 [^editmentor-framing]: [EditMentor Help Center — Headroom and Lead Room](https://help.editmentor.com/en/articles/4632188-headroom-and-lead-room)
@@ -595,16 +845,36 @@ explain why you’re breaking it.[^petapixel-golden-ratio]
 [^muddycolors]: [Muddy Colors — Composition Basics: Value Structure](https://www.muddycolors.com/2012/08/composition-basics-value-structure/)
 [^clip-studio-ask]: [CLIP STUDIO ASK — Search: Straight Ruler Equal Division](https://ask.clip-studio.com/en-us/?search=Straight%20Ruler%20Equal%20Division)
 [^procreate-guide-overview]: [Procreate Handbook — Drawing Guide Overview](https://procreate.com/handbook)
+[^stmarys-erotic]: [St. Mary’s College of California Archives — *Erotic Art of the Masters* (PDF)](https://archive.stmarys-ca.edu/archive-ga-23-1k-2-13/erotic-art-of-the-masters.pdf)
+[^wikipedia-line-of-beauty]: [Wikipedia — Line of Beauty](https://en.wikipedia.org/wiki/Line_of_beauty)
+[^psychologytoday-curves]: [Psychology Today — Body Language Poses to Highlight Body Curves](https://www.psychologytoday.com/us/blog/what-others-are-not-saying/202504/body-language-poses-to-highlight-body-curves)
+[^lovelifedrawing-flow]: [Love Life Drawing — The Secret of Gestural “Flowing” Curves](https://www.lovelifedrawing.com/gesturedrawinglevel2/)
+[^clipstudiotips-pose]: [CLIP STUDIO TIPS — Character Pose Design by BarbaraBrutti](https://tips.clip-studio.com/en-us/articles/5388)
+[^lovelifedrawing-mistakes]: [Love Life Drawing — Top 5 Gesture Mistakes](https://www.lovelifedrawing.com/top-5-gesture-mistakes/)
+[^stmarys-erotic-manga]: [St. Mary’s College of California Archives — *How to Draw Erotic Manga* (PDF)](https://archive.stmarys-ca.edu/archive-ga-23-1k-2-60/how-to-draw-erotic-manga.pdf)
+[^psychologytoday-contrapposto]: [Psychology Today — Body Language of the Contrapposto Pose](https://www.psychologytoday.com/us/blog/what-others-are-not-saying/202411/body-language-of-the-contrapposto-pose)
+[^innovature-asymmetry]: [Innovature — Asymmetrical Balance Photography](https://pps.innovatureinc.com/asymmetrical-balance-photography/)
+[^studiobinder-asymmetry]: [StudioBinder — What Is Asymmetrical Balance in Art](https://www.studiobinder.com/blog/what-is-asymmetrical-balance-in-art/)
+[^creativebloq-balance]: [Creative Bloq — How to Use the Rule of Thirds in Art](https://www.creativebloq.com/art/how-use-rule-thirds-art-21619159)
+[^photo-stack-cropping]: [Photography Stack Exchange — When Does “Fill the Frame” Become Too Tightly Framed?](https://photo.stackexchange.com/questions/62101/when-does-fill-the-frame-become-too-tightly-framed)
+[^toyphotographers-negative-space]: [Toy Photographers — Composing for Negative Space](https://toyphotographers.com/2024/10/07/composing-for-negative-space/)
+[^numberanalytics-focal]: [Number Analytics — Ultimate Guide to Focal Point in Figure Drawing](https://www.numberanalytics.com/blog/ultimate-guide-to-focal-point-in-figure-drawing)
+[^artsper-klimt]: [Artsper Magazine — Art Analysis: *The Kiss* by Klimt](https://blog.artsper.com/en/a-closer-look/art-analysis-the-kiss-by-klimt/)
+[^medium-wong-kar-wai]: [Nik Frances — The Secret Is in Red: Wong Kar-Wai’s *In the Mood for Love*](https://nikfrances.medium.com/the-secret-is-in-red-how-color-plays-a-vital-role-in-wong-kar-wais-in-the-mood-for-love-8a5a3140ad46)
+[^croquis-cafe]: [Croquis Café — Art Model Reference Photos and Videos](https://croquis.cafe/)
+[^wildlifeartstore-grid]: [Wildlife Art Store — How to Add a Grid in Procreate](https://www.wildlifeartstore.com/how-to-add-a-grid-in-procreate/)
+[^artgym-posing]: [Art Gym — The 10 Mistakes People Make When Posing Characters](https://artgym.substack.com/p/mistakes-people-make-when-posing?utm_medium=web)
 
 
 ## Conclusion & Suggested Next Steps
 
-Across eleven chapters you mapped the foundations of composition—from defining
+Across twelve chapters you mapped the foundations of composition—from defining
 the core principles (Chapter 1) to practicing rule-of-thirds frameworks
 (Chapters 2 and 3), managing space and balance (Chapters 4 and 5), experimenting
 with advanced grids (Chapter 6), building value and color mastery (Chapters 7
-and 8), and leaning into intentional exceptions, practice loops, and digital
-supports (Chapters 9–11). Treat the sequence as a toolkit: start each project by
+and 8), and leaning into intentional exceptions, practice loops, digital
+supports, and sensual storytelling (Chapters 9–12). Treat the sequence as a
+toolkit: start each project by
 clarifying your subject, pick the grid, value, and color plan that supports the
 story, and review the chapter-specific checklists before locking in details.
 


### PR DESCRIPTION
## Summary
- expand Chapter 12 so the erotic figure composition guidance retains the full discussion on gesture, asymmetry, framing, focal planning, and digital workflows
- restore detailed coverage of focal point hierarchies, common mistakes, cinematic examples, practice drills, and tool tips so the GitHub-formatted chapter preserves all original information

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cadc93526c8326a68a5a3b956f884a