### PR TITLE
Add painterly style doc to Non-AI Research navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
       - Overview: non-ai-research/index.md
       - Composition 101 — Chaptered Intro: non-ai-research/composition-101-chaptered-intro.md
       - Dynamic Symmetry and Root Rectangles: non-ai-research/dynamic-symmetry-root-rectangles.md
+      - Painterly Style in Clip Studio Paint: non-ai-research/painterly-style-clip-studio-paint.md
       - The Metaorganism: non-ai-research/metaorganism.md
   - Productivity:
       - Arduino: arduino/index.md


### PR DESCRIPTION
## Summary
- add the Painterly Style in Clip Studio Paint article to the Non-AI Research navigation section of the docs

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68cd7814017c8326b6f571290ef2523b