### PR TITLE
Add anti-fragile studio playbook research doc

### DIFF
--- a/docs/non-ai-research/anti-fragile-studio.md
+++ b/docs/non-ai-research/anti-fragile-studio.md
@@ -1,0 +1,340 @@
+---
+title: "The Anti-Fragile Studio: An Operational Playbook for the Neurodivergent Artist"
+tags: [productivity, neurodivergence, operations, research]
+project: docs-hub
+updated: 2025-09-17
+---
+
+--8<-- "_snippets/disclaimer.md"
+
+{{ toc }}
+
+# The Anti-Fragile Studio: An Operational Playbook for the Neurodivergent Artist
+
+## Introduction: The Principles of the Anti-Fragile Studio
+
+This playbook documents a full operational system for running a freelance
+art commission pipeline without sacrificing cognitive health. It extends
+beyond coping strategies: the goal is to design a studio that gains
+stability and momentum from well-defined routines. By engineering
+processes that favour predictability and guardrails, the artist becomes
+insulated from chaos, last-minute fire drills, and the slow drain toward
+burnout. The result is a business that leverages structure so that the
+artist can concentrate on delivering craft, not firefighting logistics.
+
+## Defining Anti-Fragility for the Neurodivergent Creative
+
+For solo artists with ADHD or monotropic focus patterns, the greatest
+threats are rarely creative ability. Instead, the bottlenecks are
+executive dysfunction, emotional dysregulation, and attention
+fragmentation. An anti-fragile studio anticipates these failure points in
+advance. It establishes the guardrails that absorb stressors such as
+scope creep, compulsory task-switching, or the emotional storms triggered
+by Rejection Sensitive Dysphoria (RSD). Boundaries and protocols are not
+extras—they form the essential infrastructure of the business.
+
+### Your Core Assets: Focus, Energy, and Flow
+
+The studio treats the artist’s cognitive and emotional resources as
+finite capital. Protecting them is the central objective.
+
+- **Executive function** supplies planning, prioritisation, and task
+  initiation.
+- **Emotional regulation** moderates intense reactions during moments of
+  feedback or perceived rejection.
+- **Monotropic flow** produces the highest quality work when attention is
+  allowed to remain in a single tunnel long enough to reach depth.
+
+Every template, script, and dashboard in this playbook preserves these
+assets so that they are spent on the highest-value creative work instead
+of on preventable friction.
+
+### The Three Pillars of Protection: Structure, Simplification, and Scaffolding
+
+1. **Structure** introduces predictable, repeatable paths for each
+   project. Contracts, templates, and milestone schedules remove the
+   cognitive burden of reinventing process.
+2. **Simplification** eliminates unnecessary choices. Fewer decision
+   points translate to reduced decision fatigue and higher-quality
+   judgments.
+3. **Scaffolding** supplies external supports—checklists, scripts, and
+   dashboards—that substitute for unreliable internal executive
+   functions when stress is high.
+
+These pillars underpin the five-part operating system detailed below.
+
+## Section 1: The Commission Lifecycle Map — Your Studio Operating System
+
+The client experience can be mapped into a linear, predictable sequence.
+Maintaining this single map keeps the entire pipeline out of working
+memory, alleviating an ADHD brain’s tendency to juggle every step at
+once. Each project repeats the same five stages, with documented
+checkpoints and boundaries.
+
+### Visualising the Full Client Journey
+
+A one-page lifecycle map visualises the complete journey from inquiry to
+archive. It functions as a master checklist that guarantees each step is
+completed before moving forward. Keep it in clear view within the studio
+so that the process is always externalised.
+
+!!! info "Deliverable"
+    Provide the lifecycle map as a single-page flowchart or infographic
+    that lists the five stages and their neuroprotective checkpoints.
+
+### Stage 1: Intake — The Automated Gatekeeper
+
+- **Protocol:** Route all new inquiries through a mandatory form hosted
+  on tools such as Google Forms, Typeform, or a portfolio site. Collect
+  contact details, project description, deliverables, timelines, and the
+  client’s budget range before engaging further.
+- **Neuro-protection:** The form removes the anxiety of unstructured
+  emails and gathers critical details without requiring on-the-spot
+  improvisation. The budget field screens out non-viable clients before
+  emotional energy is invested.
+
+### Stage 2: Scoping & Pricing — The Clarity Contract
+
+- **Protocol:** Use the intake data to generate a proposal based on the
+  AIGA Standard Form of Agreement or similar legal templates. Require a
+  signature and deposit before work begins. Define scope, deliverables,
+  revision rounds, milestones, payment schedule, and the communication
+  cadence.
+- **Neuro-protection:** The contract becomes the external authority for
+  boundaries. Enforcing scope is no longer a personal confrontation; it
+  is a joint commitment referenced in the signed agreement.
+
+### Stage 3: Production — The Focus Funnel
+
+- **Protocol:** During production, the dashboard designates a single
+  “Active Focus” project. Batch non-urgent communication and provide
+  updates only on the schedule defined in the contract.
+- **Neuro-protection:** The focus bubble shields the monotropic brain
+  from costly context switches and unscheduled interruptions, preserving
+  flow and energy.
+
+### Stage 4: Feedback & Revisions — The De-risked Dialogue
+
+- **Protocol:** Collect feedback exclusively through the Structured
+  Feedback Protocol outlined in Section 4. Limit revisions to the number
+  specified in the contract; anything extra triggers a new proposal.
+- **Neuro-protection:** Structured, actionable feedback neutralises RSD
+  triggers by removing ambiguity. Collaboration becomes procedural rather
+  than emotional.
+
+### Stage 5: Delivery & Off-boarding — The Clean Closure
+
+- **Protocol:** Follow a completion checklist: send the final invoice,
+  deliver files through a single organised link, and issue a templated
+  wrap-up email that confirms next steps.
+- **Neuro-protection:** Clear closure prevents lingering mental load and
+  provides a satisfying conclusion before attention shifts to the next
+  project.
+
+## Section 2: Pricing for Your Brain — The Cognitive Overhead Calculator
+
+Hourly billing misrepresents the value of a neurodivergent artist’s work.
+An hour in flow is not equivalent to an hour spent wrestling with task
+initiation or switching costs. A value-based pricing model captures the
+full cognitive and emotional investment of a project.
+
+### Moving Beyond Hours: Pricing Outcomes, Not Time
+
+Clients purchase outcomes—solutions, clarity, or relief—not raw hours.
+Value-based pricing decouples income from time-tracking and anchors fees
+in the results delivered. For neurodivergent artists, it also recognises
+that cognitive intensity fluctuates, making strict hourly estimates
+unreliable.
+
+### Quantifying the Invisible Load
+
+- **Task initiation and planning:** Overcoming inertia and sequencing a
+  project consumes measurable energy long before drawing begins.
+- **Switching costs:** Research indicates an average of 23 minutes to
+  regain focus after an interruption. For monotropic attention, forced
+  switching can halve productivity and induce overwhelm.
+- **Decision fatigue and communication load:** Every email, meeting, and
+  revision request spends a finite reserve of high-quality decision-making
+  capacity.
+
+### Building the Pricing Formula
+
+Use a cognitive overhead multiplier to factor these hidden costs into
+project estimates. The basic formula is:
+
+```
+(Estimated Production Hours × Base Hourly Rate) × Project Complexity Multiplier = Project Fee
+```
+
+- **Base hourly rate:** Covers expertise, software, tools, and desired
+  profit margins.
+- **Estimated production hours:** The time spent in true creative flow.
+- **Project complexity multiplier:** Starts at 1.0 and increases with
+  identifiable cognitive drains.
+
+### Table 1: Cognitive Overhead Cost Factors
+
+| Factor | Low Load (+0.0) | Medium Load (+0.2) | High Load (+0.4) |
+| ---------------------- | ----------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------- |
+| Number of stakeholders | Single decision-maker | Two to three stakeholders needing consensus | Committee review across multiple departments |
+| Revision rounds | One round of minor revisions | Two rounds of revisions | Three or more rounds or undefined feedback cycles |
+| Meeting frequency | Asynchronous communication only | One scheduled call per week | Multiple or unscheduled calls and urgent meetings |
+| Client organisation | All materials provided upfront and well-organised | Materials drip-fed during the project | Disorganised client; assets incomplete or constantly changing |
+| Timeline urgency | Flexible timeline with generous buffer | Firm but reasonable deadline | Rush project with aggressive turnarounds |
+
+**Example:** A project with a single stakeholder (+0.0), two revision
+rounds (+0.2), asynchronous communication (+0.0), disorganised client
+materials (+0.4), and a rush timeline (+0.4) results in a multiplier of
+1.0 + 0.0 + 0.2 + 0.0 + 0.4 + 0.4 = 2.0. The base fee doubles to cover
+cognitive overhead.
+
+!!! tip "Deliverable"
+    Provide a spreadsheet or calculator template that applies the
+    formula and table to produce consistent project quotes.
+
+## Section 3: Defending Your Focus — The Boundary-Setting Playbook
+
+Strong structures matter only if they can be enforced. Pre-written scripts
+act as social scaffolding, giving the artist ready-to-deploy responses
+when executive resources are low or emotions run hot.
+
+### Why Boundaries Matter for Neurodivergent Brains
+
+Challenging client conversations often trigger RSD. By referencing the
+contract or established processes, the artist redirects the exchange from
+personal confrontation to collaborative adherence. Scripts make the
+contract the enforcer so that the artist does not have to rely on in-the-moment
+willpower.
+
+### The Art of the Graceful “No”
+
+- **Budget mismatch:**
+  “Thank you so much for reaching out and for your interest in my work.
+  Based on the scope you’ve described, this project falls outside my
+  current budget range. I wish you the best of luck finding the right
+  artist.”
+- **Timeline mismatch:**
+  “Thank you for this detailed inquiry. I’m currently booked and wouldn’t
+  be able to give this project the focused attention it deserves within
+  your timeframe. My next availability for a project of this scale begins
+  on [date].”
+
+### Enforcing Scope: Responding to “Just One More Thing”
+
+“That's an interesting idea. It falls outside the scope defined in our
+signed agreement. I’m happy to scope it as a new phase once we complete
+our current goals. Shall I prepare a separate proposal for that work?”
+
+### Managing Deadlines and Delays
+
+“I’m checking in on the feedback for [deliverable], which was due on
+[date]. Our timeline depends on receiving notes by the agreed dates. A
+feedback delay will shift the final delivery accordingly. Let me know
+when to expect your notes so I can update the schedule.”
+
+### Navigating Difficult Conversations
+
+- **Vague dissatisfaction:** Request the client complete the Structured
+  Feedback Form so their concerns become actionable.
+- **Invoice questions:** Reference the signed proposal and point to the
+  relevant clause or phase before inviting specific questions.
+
+!!! info "Deliverable"
+    Compile all scripts into a single boundary-playbook document, sorted
+    by scenario for fast reference during client communication.
+
+## Section 4: De-risking Feedback — The Structured Feedback Protocol
+
+Feedback is frequently the most emotionally volatile stage for
+neurodivergent creatives. The antidote is to force clarity and to frame
+critique as a collaborative problem-solving exercise.
+
+### Understanding the RSD Trigger
+
+Ambiguous comments such as “I’m not feeling it” leave space for the brain
+to interpret worst-case scenarios. By insisting on structured feedback,
+subjective reactions are translated into specific instructions, reducing
+pain and protecting momentum.
+
+### The Three-Part Feedback Structure
+
+1. **What’s working?** Clients identify elements they want preserved.
+2. **What are the specific problems?** Issues are described concretely.
+3. **What are your proposed solutions or next steps?** Clients suggest
+   potential directions so the conversation shifts toward collaboration.
+
+### Implementing the Protocol
+
+Send each draft with an email that embeds the template:
+
+> Hi [Client Name],
+>
+> Please find the first draft of [Project Name] attached for your review.
+> To ensure I can incorporate your feedback accurately, please provide
+> your notes using the format below. It clarifies what’s working, what
+> needs adjustment, and how you’d like to proceed.
+>
+> **Feedback Template**
+>
+> 1. What’s Working? (List one to three specific things you like about
+>    this draft.)
+> 2. What Are the Specific Problems? (Describe the issues that need to be
+>    addressed.)
+> 3. What Are Your Proposed Solutions or Next Steps? (Suggest any
+>    directions you’d like to explore.)
+>
+> Looking forward to your thoughts.
+>
+> Best,
+> [Artist Name]
+
+!!! tip "Deliverable"
+    Host the template in a shared document or form so clients can
+    complete it without friction. Attach it to draft deliveries by
+    default.
+
+## Section 5: Taming the Pipeline — The Monotropic-Aware Dashboard
+
+Managing multiple projects is difficult for a brain designed for deep,
+single-focus work. A minimalist dashboard prevents overload by
+visualising commitments and enforcing limits on active attention.
+
+### Designing for Monotropism
+
+Use a three-column board in Trello, Notion, or an equivalent tool:
+
+1. **Active Focus (limit: one project):** Only one project enters the
+   attention tunnel at a time. All other notifications are muted.
+2. **On Deck (limit: one to two projects):** Contracts signed and deposits
+   received, ready to start once the active project wraps.
+3. **Simmering (variable limit):** Inquiries, proposals awaiting signatures,
+   or projects paused while waiting for client feedback.
+
+### Visualising Workload to Prevent Overwhelm
+
+Keeping the dashboard visible delivers a constant reminder of current
+capacity. When the temptation to start something new arises, the empty
+slot in “Active Focus” becomes the deciding factor. This external
+constraint replaces unreliable internal gating, keeping commitments
+aligned with actual cognitive bandwidth.
+
+!!! info "Deliverable"
+    Share a template board with instructions for weekly review and admin
+    blocks dedicated to maintaining it.
+
+## Conclusion: Sustaining the System
+
+These five components operate as an integrated shield for the artist’s
+focus.
+
+1. The lifecycle map defines the predictable path for every client.
+2. The cognitive overhead calculator prices in the real cost of
+   protection.
+3. The boundary scripts enforce agreements without emotional fallout.
+4. The structured feedback protocol transforms critique into collaboration.
+5. The pipeline dashboard governs attention and prevents overload.
+
+An anti-fragile studio is not rigid—it is resilient. Externalising
+executive functions, depersonalising boundary enforcement, and aligning
+workflows with a neurodivergent brain’s strengths liberates the artist to
+pursue a long, profitable, creatively fulfilling career.

--- a/docs/non-ai-research/index.md
+++ b/docs/non-ai-research/index.md
@@ -2,7 +2,7 @@
 title: "Non-AI Research"
 tags: [research, docs]
 project: "non-ai-research"
-updated: 2025-09-16
+updated: 2025-09-17
 ---
 
 --8<-- "_snippets/disclaimer.md"
@@ -25,6 +25,7 @@ Short, actionable approaches for personal efficiency and time management.
   with insights from [Productivity](../productivity/index.md) and
   [Terminal Workflow](../terminal-workflow/index.md).
 - [The Artist's Field Guide to Attention & Energy](artists-field-guide-attention-energy.md) maps ADHD-aware session design that channels flow while preventing burnout.
+- [The Anti-Fragile Studio](anti-fragile-studio.md) operationalises contracts, pricing, and dashboards so neurodivergent artists can run commission pipelines without burnout.
 
 
 ## Corporate Studies


### PR DESCRIPTION
## Summary
- add The Anti-Fragile Studio research document outlining a neurodivergent-aware commission pipeline
- include detailed sections on lifecycle mapping, cognitive pricing, boundary scripts, feedback protocols, and a pipeline dashboard
- update the Non-AI Research index to reference the new playbook

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d14a445f448326b34dcf7a01d89974