### PR TITLE
Add art tags to anti-fragile studio documentation

### DIFF
--- a/docs/non-ai-research/anti-fragile-studio-boundary-playbook.md
+++ b/docs/non-ai-research/anti-fragile-studio-boundary-playbook.md
@@ -1,6 +1,6 @@
 ---
 title: "Anti-Fragile Studio Boundary Playbook"
-tags: [productivity, neurodivergence, operations, research]
+tags: [productivity, art, neurodivergence, operations, research]
 project: docs-hub
 updated: 2025-09-18
 ---

--- a/docs/non-ai-research/anti-fragile-studio.md
+++ b/docs/non-ai-research/anti-fragile-studio.md
@@ -1,6 +1,6 @@
 ---
 title: "The Anti-Fragile Studio: An Operational Playbook for the Neurodivergent Artist"
-tags: [productivity, neurodivergence, operations, research]
+tags: [productivity, art, neurodivergence, operations, research]
 project: docs-hub
 updated: 2025-09-18
 ---

--- a/docs/non-ai-research/artists-field-guide-attention-energy.md
+++ b/docs/non-ai-research/artists-field-guide-attention-energy.md
@@ -1,6 +1,6 @@
 ---
 title: "The Artist's Field Guide to Attention & Energy: Navigating Flow, Focus, and Burnout in the Studio"
-tags: [productivity, neurodivergence, research]
+tags: [productivity, art, neurodivergence, research]
 project: docs-hub
 updated: 2025-09-16
 ---


### PR DESCRIPTION
## Summary
- add the `art` tag to the metadata for the anti-fragile studio and attention guide documents to improve topical categorization

## Testing
- `rg "tags: \[.*art" docs/non-ai-research`


------
https://chatgpt.com/codex/tasks/task_e_68d2a2420f20832698604e660047f9da