### PR TITLE
Add Non-AI research nav entries

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,9 @@ nav:
       - High-Level Intelligence Qualia Atlas: non-ai-research/high-level-intelligence-qualia-atlas.md
       - Notable Figures: non-ai-research/inspiring-figures.md
       - Overview: non-ai-research/index.md
+      - "The Anti-Fragile Studio: An Operational Playbook for the Neurodivergent Artist": non-ai-research/anti-fragile-studio.md
+      - "Anti-Fragile Studio Boundary Playbook": non-ai-research/anti-fragile-studio-boundary-playbook.md
+      - "The Artist's Field Guide to Attention & Energy: Navigating Flow, Focus, and Burnout in the Studio": non-ai-research/artists-field-guide-attention-energy.md
       - Composition 101 — Chaptered Intro: non-ai-research/composition-101-chaptered-intro.md
       - Dynamic Symmetry and Root Rectangles: non-ai-research/dynamic-symmetry-root-rectangles.md
       - Painterly Style in Clip Studio Paint: non-ai-research/painterly-style-clip-studio-paint.md


### PR DESCRIPTION
## Summary
- add three Non-AI Research navigation entries for the anti-fragile studio playbooks and attention guide

## Testing
- `mkdocs build` *(fails: ModuleNotFoundError: No module named 'pymdownx.copybutton')*

------
https://chatgpt.com/codex/tasks/task_e_68d2a2408c588326baa1386a6a7c0726