### PR TITLE
Add TOC directive to Composition 101 intro

### DIFF
--- a/docs/non-ai-research/composition-101-chaptered-intro.md
+++ b/docs/non-ai-research/composition-101-chaptered-intro.md
@@ -7,6 +7,8 @@ updated: 2025-09-17
 
 --8<-- "_snippets/disclaimer.md"
 
+{{ toc }}
+
 # Composition 101 — Chaptered Intro (with Links)
 
 This primer distills essential composition frameworks into a chaptered guide. Each


### PR DESCRIPTION
## Summary
- insert the MkDocs `{{ toc }}` directive right after the shared disclaimer include so the composition guide renders an on-page table of contents

## Testing
- mkdocs build -f /tmp/mkdocs-nositemap.yml -d /tmp/site

------
https://chatgpt.com/codex/tasks/task_e_68d2a233efd0832691042b493b98df12