### PR TITLE
Add accessible metadata to wave SVG icons

### DIFF
--- a/docs/wave-icons/wave1-foundations.svg
+++ b/docs/wave-icons/wave1-foundations.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave1-foundations"
 >
+  <title id="title-wave1-foundations">Wave 1 foundations icon</title>
   <rect width="16" height="20" x="4" y="2" rx="2" ry="2" />
   <path d="M9 22v-4h6v4" />
   <path d="M8 6h.01" />

--- a/docs/wave-icons/wave10-futures.svg
+++ b/docs/wave-icons/wave10-futures.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave10-futures"
 >
+  <title id="title-wave10-futures">Wave 10 futures icon</title>
   <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
   <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
   <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />

--- a/docs/wave-icons/wave11-cyberpunk-mind.svg
+++ b/docs/wave-icons/wave11-cyberpunk-mind.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave11-cyberpunk-mind"
 >
+  <title id="title-wave11-cyberpunk-mind">Wave 11 cyberpunk mind icon</title>
   <path d="M12 20v2" />
   <path d="M12 2v2" />
   <path d="M17 20v2" />

--- a/docs/wave-icons/wave12-social-engineering.svg
+++ b/docs/wave-icons/wave12-social-engineering.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave12-social-engineering"
 >
+  <title id="title-wave12-social-engineering">Wave 12 social engineering icon</title>
   <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
   <path d="M16 3.128a4 4 0 0 1 0 7.744" />
   <path d="M22 21v-2a4 4 0 0 0-3-3.87" />

--- a/docs/wave-icons/wave2-threat-mapping.svg
+++ b/docs/wave-icons/wave2-threat-mapping.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave2-threat-mapping"
 >
+  <title id="title-wave2-threat-mapping">Wave 2 threat mapping icon</title>
   <path d="M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z" />
   <path d="M15 5.764v15" />
   <path d="M9 3.236v15" />

--- a/docs/wave-icons/wave3-privacy-opsec.svg
+++ b/docs/wave-icons/wave3-privacy-opsec.svg
@@ -8,6 +8,9 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave3-privacy-opsec"
 >
+  <title id="title-wave3-privacy-opsec">Wave 3 privacy and OPSEC icon</title>
   <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
 </svg>

--- a/docs/wave-icons/wave4-legal-countermeasures.svg
+++ b/docs/wave-icons/wave4-legal-countermeasures.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave4-legal-countermeasures"
 >
+  <title id="title-wave4-legal-countermeasures">Wave 4 legal countermeasures icon</title>
   <path d="m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
   <path d="m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
   <path d="M7 21h10" />

--- a/docs/wave-icons/wave5-decentralized-infrastructure.svg
+++ b/docs/wave-icons/wave5-decentralized-infrastructure.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave5-decentralized-infrastructure"
 >
+  <title id="title-wave5-decentralized-infrastructure">Wave 5 decentralized infrastructure icon</title>
   <rect x="16" y="16" width="6" height="6" rx="1" />
   <rect x="2" y="16" width="6" height="6" rx="1" />
   <rect x="9" y="2" width="6" height="6" rx="1" />

--- a/docs/wave-icons/wave6-hands-on-hardening.svg
+++ b/docs/wave-icons/wave6-hands-on-hardening.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave6-hands-on-hardening"
 >
+  <title id="title-wave6-hands-on-hardening">Wave 6 hands-on hardening icon</title>
   <path d="m15 12-9.373 9.373a1 1 0 0 1-3.001-3L12 9" />
   <path d="m18 15 4-4" />
   <path d="m21.5 11.5-1.914-1.914A2 2 0 0 1 19 8.172v-.344a2 2 0 0 0-.586-1.414l-1.657-1.657A6 6 0 0 0 12.516 3H9l1.243 1.243A6 6 0 0 1 12 8.485V10l2 2h1.172a2 2 0 0 1 1.414.586L18.5 14.5" />

--- a/docs/wave-icons/wave7-reconnaissance-osint.svg
+++ b/docs/wave-icons/wave7-reconnaissance-osint.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave7-reconnaissance-osint"
 >
+  <title id="title-wave7-reconnaissance-osint">Wave 7 reconnaissance and OSINT icon</title>
   <path d="m21 21-4.34-4.34" />
   <circle cx="11" cy="11" r="8" />
 </svg>

--- a/docs/wave-icons/wave9-cognitive-security.svg
+++ b/docs/wave-icons/wave9-cognitive-security.svg
@@ -8,7 +8,10 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
+  role="img"
+  aria-labelledby="title-wave9-cognitive-security"
 >
+  <title id="title-wave9-cognitive-security">Wave 9 cognitive security icon</title>
   <path d="M12 18V5" />
   <path d="M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4" />
   <path d="M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5" />


### PR DESCRIPTION
## Summary
- add titles to the wave icon SVGs to provide human-readable descriptions
- apply role and aria-labelledby attributes so assistive technology exposes the new metadata

## Testing
- `npx markdownlint "**/*.md"` *(fails: existing markdown issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd184b97b08326ab8ff8a90cde8509