### PR TITLE
Add accessible metadata to SVG diagrams

### DIFF
--- a/docs/ai-research/context-windows-design-matrix.svg
+++ b/docs/ai-research/context-windows-design-matrix.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="432pt" viewBox="0 0 720 432" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="432pt" viewBox="0 0 720 432" xmlns="http://www.w3.org/2000/svg" version="1.1" role="img" aria-labelledby="context-windows-design-matrix-title context-windows-design-matrix-desc">
+ <title id="context-windows-design-matrix-title">Context windows design matrix</title>
+ <desc id="context-windows-design-matrix-desc">Matrix chart showing context window methods on the x-axis against their typical maximum effective length in tokens on the y-axis, matching the data from the accompanying design matrix table.</desc>
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>

--- a/docs/ai-research/grok4-heavy-arch.svg
+++ b/docs/ai-research/grok4-heavy-arch.svg
@@ -1,4 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 260">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 260" role="img" aria-labelledby="grok4-heavy-arch-title grok4-heavy-arch-desc">
+  <title id="grok4-heavy-arch-title">Grok 4 Heavy multi-agent architecture</title>
+  <desc id="grok4-heavy-arch-desc">High-level architecture diagram showing the user connected to an orchestrator that routes tasks to Agent A and Agent B, both of which interface with shared tools, outputs, and memory stores.</desc>
   <defs>
     <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto">
       <path d="M0,0 L10,5 L0,10 z" fill="#333" />

--- a/docs/ai-research/kv-cache-chart.svg
+++ b/docs/ai-research/kv-cache-chart.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="432pt" viewBox="0 0 720 432" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="432pt" viewBox="0 0 720 432" xmlns="http://www.w3.org/2000/svg" version="1.1" role="img" aria-labelledby="kv-cache-chart-title kv-cache-chart-desc">
+ <title id="kv-cache-chart-title">KV cache memory requirements by token count</title>
+ <desc id="kv-cache-chart-desc">Bar chart showing token count on the x-axis and KV cache memory in GiB on the y-axis, illustrating that memory usage climbs almost linearly so larger models and longer sequences demand substantially more capacity.</desc>
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>

--- a/docs/arduino/img/blink_wiring.svg
+++ b/docs/arduino/img/blink_wiring.svg
@@ -1,4 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120" viewBox="0 0 200 120">
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120" viewBox="0 0 200 120" role="img" aria-labelledby="blink-wiring-title blink-wiring-desc">
+  <title id="blink-wiring-title">LED blink wiring</title>
+  <desc id="blink-wiring-desc">Schematic showing an Arduino connected from pin 13 through a resistor to an LED, with a return path to ground.</desc>
   <rect x="10" y="10" width="80" height="100" fill="#b3cde0" stroke="#000"/>
   <text x="50" y="25" font-size="10" text-anchor="middle">Arduino</text>
   <circle cx="150" cy="40" r="10" fill="red" stroke="#000"/>


### PR DESCRIPTION
## Summary
- add title and description metadata with aria attributes to the AI research SVG charts
- align the new descriptions with the existing markdown captions to keep figure references consistent
- annotate the Arduino blink wiring schematic with matching accessibility metadata

## Testing
- N/A (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd1853a6448326a38e60e74765931e