### PR TITLE
Update security docs to embed privacy opsec icon

### DIFF
--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -21,4 +21,4 @@ Resources related to security practices and research.
 
 ## Further Reading
 
-- [Privacy & OpSec Icon](../wave-icons/wave3-privacy-opsec.svg)
+- ![Privacy and operational security icon](../wave-icons/wave3-privacy-opsec.svg) — Use this icon to highlight privacy and operational security guidance within related documentation.


### PR DESCRIPTION
## Summary
- embed the privacy and operational security icon directly in the security docs
- add context on when to use the icon while preserving list formatting

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68dd1862ef188326869d195a52b6ee33