### PR TITLE
Convert scorecard tip to Material admonition

### DIFF
--- a/docs/non-ai-research/artists-field-guide-attention-energy.md
+++ b/docs/non-ai-research/artists-field-guide-attention-energy.md
@@ -163,10 +163,10 @@ Redefine a "good day" by process adherence, not output volume.
 
 ### Using the Scorecard
 
-> [!TIP]
-> - Track leading indicators such as boundary breaks and recovery actions, not just flow minutes.
-> - Treat entries as neutral data. Low-flow days with strong recovery still count as wins against burnout.
-> - Prioritize Metric 5. Writing the next session's first step lowers initiation friction for ADHD and monotropic brains.
+!!! tip
+    - Track leading indicators such as boundary breaks and recovery actions, not just flow minutes.
+    - Treat entries as neutral data. Low-flow days with strong recovery still count as wins against burnout.
+    - Prioritize Metric 5. Writing the next session's first step lowers initiation friction for ADHD and monotropic brains.
 
 ## Recovery Toolkit: Refueling Creative Capacity
 


### PR DESCRIPTION
## Summary
- convert the scorecard tip callout to Material for MkDocs admonition syntax so it renders with the themed styling

## Testing
- mkdocs build *(fails: ModuleNotFoundError: No module named 'pymdownx.copybutton')*

------
https://chatgpt.com/codex/tasks/task_e_68dd20bb60f88326a2fde5b7a9e6336b