### PR TITLE
Add dynamic symmetry diagrams to root rectangle guide

### DIFF
--- a/docs/img/dynamic-symmetry-harmonic-armature.svg
+++ b/docs/img/dynamic-symmetry-harmonic-armature.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 260" role="img" aria-labelledby="title desc">
+  <title id="title">Dynamic symmetry harmonic armature</title>
+  <desc id="desc">Baroque and sinister diagonals with reciprocal lines inside a Root-2 rectangle, labelling key intersections for placing focal points.</desc>
+  <style>
+    :root { color: var(--md-typeset-color, #111827); }
+    text { font-family: "Inter", "Segoe UI", sans-serif; font-size: 13px; fill: var(--md-typeset-color, #111827); }
+    .frame { fill: none; stroke: var(--md-typeset-color, #111827); stroke-width: 2.5; }
+    .baroque { stroke: var(--md-accent-fg-color, #2563eb); stroke-width: 3; }
+    .sinister { stroke: var(--md-warning-fg-color, #f97316); stroke-width: 3; }
+    .reciprocal { stroke: var(--md-default-fg-color--light, #6b7280); stroke-width: 2; stroke-dasharray: 6 6; }
+    circle { fill: var(--md-accent-fg-color, #2563eb); }
+  </style>
+  <rect x="60" y="30" width="283" height="200" class="frame" />
+  <line x1="60" y1="230" x2="343" y2="30" class="baroque" />
+  <line x1="60" y1="30" x2="343" y2="230" class="sinister" />
+  <line x1="60" y1="130" x2="343" y2="130" class="reciprocal" />
+  <line x1="201.5" y1="30" x2="201.5" y2="230" class="reciprocal" />
+  <line x1="60" y1="30" x2="201.5" y2="230" class="reciprocal" />
+  <line x1="343" y1="30" x2="201.5" y2="230" class="reciprocal" stroke-dasharray="4 4" />
+  <circle cx="201.5" cy="130" r="4" />
+  <circle cx="144" cy="166" r="4" />
+  <circle cx="260" cy="94" r="4" />
+  <text x="65" y="24">Root-2 frame</text>
+  <text x="110" y="150" transform="rotate(56 110 150)">Reciprocal to sinister</text>
+  <text x="250" y="70" transform="rotate(-56 250 70)">Reciprocal to baroque</text>
+  <text x="180" y="120">Central eye</text>
+  <text x="280" y="120">Baroque diagonal</text>
+  <text x="95" y="70">Sinister diagonal</text>
+  <text x="210" y="245">Midpoint cross</text>
+</svg>

--- a/docs/img/dynamic-symmetry-root-2.svg
+++ b/docs/img/dynamic-symmetry-root-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 260" role="img" aria-labelledby="title desc">
+  <title id="title">Dynamic symmetry Root-2 construction</title>
+  <desc id="desc">Diagram showing a square with its diagonal swung outward to form a Root-2 rectangle, highlighting the inherited diagonal and reciprocal points.</desc>
+  <style>
+    :root { color: var(--md-typeset-color, #111827); }
+    text { font-family: "Inter", "Segoe UI", sans-serif; font-size: 14px; fill: var(--md-typeset-color, #111827); }
+    .guide { fill: none; stroke: var(--md-typeset-color, #111827); stroke-width: 2; }
+    .accent { stroke: var(--md-accent-fg-color, #2563eb); }
+    .secondary { stroke: var(--md-default-fg-color--light, #6b7280); stroke-dasharray: 6 6; }
+    circle { fill: var(--md-accent-fg-color, #2563eb); }
+  </style>
+  <rect x="60" y="40" width="200" height="200" class="guide" stroke-width="2.5" />
+  <rect x="60" y="40" width="283" height="200" class="guide" stroke-width="2.5" opacity="0.4" />
+  <line x1="60" y1="240" x2="260" y2="40" class="guide accent" stroke-width="3" />
+  <line x1="60" y1="40" x2="343" y2="40" class="secondary" />
+  <line x1="260" y1="40" x2="343" y2="240" class="secondary" />
+  <line x1="260" y1="40" x2="260" y2="240" class="guide" stroke-width="1.5" opacity="0.65" />
+  <circle cx="260" cy="40" r="4" />
+  <circle cx="260" cy="240" r="4" />
+  <circle cx="343" cy="240" r="4" />
+  <text x="65" y="35">Square (1:1)</text>
+  <text x="270" y="35">Diagonal swung</text>
+  <text x="320" y="255">Root-2 corner</text>
+  <text x="170" y="155" transform="rotate(-45 170 155)">Shared diagonal</text>
+  <text x="263" y="130" transform="rotate(90 263 130)">Reciprocal drop</text>
+</svg>

--- a/docs/non-ai-research/dynamic-symmetry-root-rectangles.md
+++ b/docs/non-ai-research/dynamic-symmetry-root-rectangles.md
@@ -34,6 +34,11 @@ can be expressed as 1 + 2 × (1/φ).[^kitschmeister] Beyond Root-5 the recta
 become increasingly extreme, which is why historical usage clusters around
 squares, Root-2, Root-3, Root-4, Root-5, and golden rectangles.[^kitschmeister]
 
+<figure>
+  <img src="../img/dynamic-symmetry-root-2.svg" alt="Square with diagonal swung outward to form a Root-2 rectangle, highlighting the shared diagonal, reciprocal drop, and Root-2 corner." loading="lazy" />
+  <figcaption><strong>Root-2 construction.</strong> The square’s diagonal (accent line) spins outward to locate the Root-2 corner, while the reciprocal drop marks where the inherited diagonal meets the extended frame.</figcaption>
+</figure>
+
 ### Root rectangle cheat sheet
 
 | Root | Ratio (long : short) | Approx. decimal | Nickname / notes |
@@ -128,6 +133,11 @@ Artists who adopt dynamic symmetry report several compositional advantages:
 
 Creating the basic harmonic armature for any rectangle follows a predictable
 workflow:[^kitschmeister]
+
+<figure>
+  <img src="../img/dynamic-symmetry-harmonic-armature.svg" alt="Root-2 frame with baroque and sinister diagonals plus reciprocal lines and central eye intersections for focal placement." loading="lazy" />
+  <figcaption><strong>Harmonic armature highlights.</strong> The baroque (blue) and sinister (orange) diagonals cross through the central eye, while dashed reciprocals pick out secondary anchor points along the midpoint cross.</figcaption>
+</figure>
 
 1. **Choose the base rectangle.** Decide on the aspect ratio (Root-2, Root-3,
    golden rectangle, 3:2 camera frame, 16:9, etc.) so the armature matches your


### PR DESCRIPTION
## Summary
- add theme-aware SVG diagrams for the Root-2 construction and full harmonic armature
- embed the new figures with descriptive captions alongside the root rectangle and grid workflow sections

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd2b1ab0f0832699f6f910c76536c7