### PR TITLE
Add printable attention checkpoint card and guide link

### DIFF
--- a/docs/non-ai-research/artists-field-guide-attention-energy.md
+++ b/docs/non-ai-research/artists-field-guide-attention-energy.md
@@ -85,6 +85,9 @@ Abruptly stopping a monotropic brain can feel destabilizing. Use this three-part
 | 2. Physical Reset | Stand up, stretch, hydrate, and take three deep breaths away from the desk. | 60–120 seconds | Reconnects interoceptive signals and breaks the physical posture tied to overfocus. |
 | 3. Conscious Decision | Choose one:<br>• Resume with a fresh 20–25 minute timer.<br>• Switch to a 15-minute bridge task (layer cleanup, filling flats).<br>• Log progress on the scorecard and stop fully if depletion is high. | 2–3 minutes | Puts attention back under voluntary control and protects energy reserves. |
 
+!!! info "Need a printable version?"
+    Keep a hard copy beside your desk with the [Attention Checkpoint Card](templates/attention-checklist-card.md) quick reference. Print at 100% scale for a half-sheet card that fits on clipboards or desktop stands.
+
 ## Diagram Blueprint: Attention Tunnel ↔ Flow Channel
 
 <figure>

--- a/docs/non-ai-research/templates/attention-checklist-card.md
+++ b/docs/non-ai-research/templates/attention-checklist-card.md
@@ -1,0 +1,26 @@
+---
+title: "Attention Checkpoint Card"
+---
+
+# Attention Checkpoint Card
+
+Use this one-page card to stay in the flow lane, monitor hyperfocus flags, and deploy the Exit Ramp before energy crashes. Print it on cardstock, laminate it, and keep a dry-erase marker nearby.
+
+## Flow vs. Hyperfocus Checkpoints
+
+| ☐ | Flow Signal | Hyperfocus Flag | Quick Action |
+| --- | --- | --- | --- |
+| ☐ | **Goal Clarity**<br><span style="font-size:1.1em;">I can say the next 15-minute goal aloud.</span> | I hesitate, ramble, or draw a blank. | Pause, define the goal in one sentence, and write it down. |
+| ☐ | **Challenge ↔ Skill Fit**<br><span style="font-size:1.1em;">Task feels engagingly difficult but doable.</span> | Task feels dull *or* panic-inducing. | Raise or lower difficulty by ~10% to return to the flow channel. |
+| ☐ | **Sense of Control**<br><span style="font-size:1.1em;">I can pause voluntarily without dread.</span> | Attention feels sticky or compulsive. | Take one deep breath, reset timer, prep Exit Ramp. |
+| ☐ | **Body Awareness**<br><span style="font-size:1.1em;">I notice hunger, thirst, pain, and time cues.</span> | I've ignored bodily signals for 60 minutes. | Launch the Exit Ramp protocol immediately. |
+
+## Exit Ramp Protocol
+
+| ☐ | Step | What to Do | Why It Protects Energy |
+| --- | --- | --- | --- |
+| ☐ | **Hard Stop Cue** | Trigger a loud alarm, save work, capture a screenshot, and write “Next, I will…” with the very next step. | Externalizes working memory and interrupts the hyperfocus loop. |
+| ☐ | **Physical Reset** | Stand, stretch, hydrate, and take three deep breaths away from the desk (60–120 seconds). | Reconnects interoceptive signals and resets posture. |
+| ☐ | **Conscious Decision** | Choose: resume with a 20–25 minute timer, switch to a 15-minute bridge task, or log out for full recovery. | Puts attention back under voluntary control and protects reserves. |
+
+**Reminder:** Run the checkpoint timer every 45–60 minutes. If two hyperfocus flags appear back-to-back, schedule a longer recovery block before resuming deep work.


### PR DESCRIPTION
## Summary
- create a printable attention checkpoint card template that consolidates flow vs. hyperfocus checks and the exit ramp protocol
- add a callout in the artist attention and energy field guide pointing to the new quick-reference card for easy printing

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd2b1803548326a336240486a119ed