### PR TITLE
Add composition diagrams for rule of thirds and lead room

### DIFF
--- a/docs/img/composition-lead-room.svg
+++ b/docs/img/composition-lead-room.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Lead Room and Headroom Examples</title>
+  <desc id="desc">Four mini frames compare balanced look space and headroom against cramped or excessive spacing. The first frame shows a subject on the left third facing open space. The second short-sides the subject against the frame edge. The third keeps the eyes near the top third for comfortable headroom, and the fourth leaves excessive headroom above the subject.</desc>
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+    <style>
+      text {
+        font-family: "Inter", "Segoe UI", sans-serif;
+        fill: #0f172a;
+      }
+    </style>
+    <marker id="arrow-head" orient="auto" markerWidth="10" markerHeight="10" refX="5" refY="5">
+      <path d="M0,0 L10,5 L0,10 z" fill="#0f172a" />
+    </marker>
+  </defs>
+  <rect x="30" y="30" width="900" height="480" fill="url(#panel)" stroke="#1e293b" stroke-width="2" rx="16" />
+  <g font-size="26" font-weight="600" text-anchor="middle">
+    <text x="240" y="72">Comfortable look space</text>
+    <text x="720" y="72">Short-sided look space</text>
+    <text x="240" y="312">Balanced headroom</text>
+    <text x="720" y="312">Excessive headroom</text>
+  </g>
+  <!-- Comfortable look space frame -->
+  <g transform="translate(80 90)">
+    <rect width="360" height="180" fill="#f1f5f9" stroke="#1e293b" stroke-width="2" rx="12" />
+    <g stroke="#334155" stroke-width="1.5" stroke-dasharray="6 8" opacity="0.8">
+      <line x1="120" y1="0" x2="120" y2="180" />
+      <line x1="240" y1="0" x2="240" y2="180" />
+      <line x1="0" y1="60" x2="360" y2="60" />
+      <line x1="0" y1="120" x2="360" y2="120" />
+    </g>
+    <g stroke="#0f172a" stroke-width="4" fill="none" marker-end="url(#arrow-head)">
+      <line x1="150" y1="90" x2="300" y2="90" />
+    </g>
+    <g stroke="#0e7490" stroke-width="5" stroke-linecap="round">
+      <circle cx="120" cy="80" r="28" fill="#bae6fd" stroke="#0e7490" />
+      <line x1="120" y1="108" x2="120" y2="150" />
+      <line x1="120" y1="120" x2="156" y2="140" />
+      <line x1="120" y1="120" x2="84" y2="140" />
+    </g>
+    <text x="180" y="170" font-size="18" text-anchor="middle">Lead room lets the gaze travel</text>
+  </g>
+  <!-- Short-sided frame -->
+  <g transform="translate(560 90)">
+    <rect width="360" height="180" fill="#f1f5f9" stroke="#1e293b" stroke-width="2" rx="12" />
+    <g stroke="#334155" stroke-width="1.5" stroke-dasharray="6 8" opacity="0.8">
+      <line x1="120" y1="0" x2="120" y2="180" />
+      <line x1="240" y1="0" x2="240" y2="180" />
+      <line x1="0" y1="60" x2="360" y2="60" />
+      <line x1="0" y1="120" x2="360" y2="120" />
+    </g>
+    <g stroke="#0f172a" stroke-width="4" fill="none" marker-end="url(#arrow-head)">
+      <line x1="260" y1="90" x2="320" y2="90" />
+    </g>
+    <g stroke="#be123c" stroke-width="5" stroke-linecap="round">
+      <circle cx="300" cy="80" r="28" fill="#fecdd3" stroke="#be123c" />
+      <line x1="300" y1="108" x2="300" y2="150" />
+      <line x1="300" y1="120" x2="336" y2="140" />
+      <line x1="300" y1="120" x2="264" y2="140" />
+    </g>
+    <text x="180" y="170" font-size="18" text-anchor="middle">Short-sided: no space to look into</text>
+  </g>
+  <!-- Balanced headroom -->
+  <g transform="translate(80 330)">
+    <rect width="360" height="180" fill="#f1f5f9" stroke="#1e293b" stroke-width="2" rx="12" />
+    <g stroke="#334155" stroke-width="1.5" stroke-dasharray="6 8" opacity="0.8">
+      <line x1="0" y1="60" x2="360" y2="60" />
+    </g>
+    <line x1="60" y1="40" x2="300" y2="40" stroke="#0f172a" stroke-width="4" stroke-linecap="round" />
+    <g stroke="#0e7490" stroke-width="5" stroke-linecap="round">
+      <circle cx="180" cy="80" r="28" fill="#bae6fd" stroke="#0e7490" />
+      <line x1="180" y1="108" x2="180" y2="150" />
+      <line x1="180" y1="120" x2="210" y2="146" />
+      <line x1="180" y1="120" x2="150" y2="146" />
+    </g>
+    <text x="180" y="170" font-size="18" text-anchor="middle">Eyes hover near the top third</text>
+    <text x="180" y="24" font-size="18" text-anchor="middle">Comfortable headroom</text>
+  </g>
+  <!-- Excessive headroom -->
+  <g transform="translate(560 330)">
+    <rect width="360" height="180" fill="#f1f5f9" stroke="#1e293b" stroke-width="2" rx="12" />
+    <g stroke="#334155" stroke-width="1.5" stroke-dasharray="6 8" opacity="0.8">
+      <line x1="0" y1="60" x2="360" y2="60" />
+    </g>
+    <line x1="40" y1="20" x2="320" y2="20" stroke="#be123c" stroke-width="4" stroke-linecap="round" stroke-dasharray="8 10" />
+    <g stroke="#be123c" stroke-width="5" stroke-linecap="round">
+      <circle cx="180" cy="120" r="28" fill="#fecdd3" stroke="#be123c" />
+      <line x1="180" y1="148" x2="180" y2="170" />
+      <line x1="180" y1="136" x2="210" y2="162" />
+      <line x1="180" y1="136" x2="150" y2="162" />
+    </g>
+    <text x="180" y="170" font-size="18" text-anchor="middle">Too much headroom pulls attention upward</text>
+    <text x="180" y="36" font-size="18" text-anchor="middle">Unused space dominates</text>
+  </g>
+</svg>

--- a/docs/img/composition-rule-of-thirds.svg
+++ b/docs/img/composition-rule-of-thirds.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Rule of Thirds Grid with Power Points</title>
+  <desc id="desc">A neutral frame with a 3 by 3 grid overlay. The four intersections are highlighted to show the rule of thirds power points with labels for horizon placement, subject placement, and supporting elements.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+    <marker id="arrow" orient="auto" markerWidth="12" markerHeight="12" refX="6" refY="6">
+      <path d="M0,0 L12,6 L0,12 z" fill="#0f172a" />
+    </marker>
+    <style>
+      text {
+        font-family: "Inter", "Segoe UI", sans-serif;
+        fill: #0f172a;
+      }
+    </style>
+  </defs>
+  <rect x="40" y="40" width="880" height="460" fill="url(#bg)" stroke="#1e293b" stroke-width="2" rx="12" />
+  <!-- Grid lines -->
+  <g stroke="#334155" stroke-width="2" stroke-dasharray="6 8" opacity="0.85">
+    <line x1="333.33" y1="40" x2="333.33" y2="500" />
+    <line x1="626.67" y1="40" x2="626.67" y2="500" />
+    <line x1="40" y1="193.33" x2="920" y2="193.33" />
+    <line x1="40" y1="346.67" x2="920" y2="346.67" />
+  </g>
+  <!-- Power point markers -->
+  <g fill="#ef4444" stroke="#fff" stroke-width="4">
+    <circle cx="333.33" cy="193.33" r="18" />
+    <circle cx="333.33" cy="346.67" r="18" />
+    <circle cx="626.67" cy="193.33" r="18" />
+    <circle cx="626.67" cy="346.67" r="18" />
+  </g>
+  <g fill="#ef4444" font-size="22" font-weight="600" text-anchor="middle">
+    <text x="333.33" y="176">Power</text>
+    <text x="333.33" y="204">point</text>
+    <text x="626.67" y="176">Power</text>
+    <text x="626.67" y="204">point</text>
+    <text x="333.33" y="329">Power</text>
+    <text x="333.33" y="357">point</text>
+    <text x="626.67" y="329">Power</text>
+    <text x="626.67" y="357">point</text>
+  </g>
+  <!-- Subject suggestion -->
+  <circle cx="626.67" cy="193.33" r="48" fill="rgba(14,116,144,0.15)" stroke="#0e7490" stroke-width="4" />
+  <path d="M626.67 110 L626.67 142" stroke="#0e7490" stroke-width="6" stroke-linecap="round" />
+  <path d="M626.67 244 L626.67 316" stroke="#0e7490" stroke-width="6" stroke-linecap="round" />
+  <path d="M626.67 193.33 L686.67 233.33" stroke="#0e7490" stroke-width="6" stroke-linecap="round" />
+  <path d="M626.67 193.33 L566.67 233.33" stroke="#0e7490" stroke-width="6" stroke-linecap="round" />
+  <text x="626.67" y="96" text-anchor="middle" font-size="22" font-weight="600">Subject on a power point</text>
+  <!-- Horizon annotation -->
+  <path d="M80 193.33 L300 193.33" stroke="#0f172a" stroke-width="6" stroke-linecap="round" />
+  <text x="172" y="170" font-size="22" font-weight="600">Horizon on top third</text>
+  <text x="190" y="382" font-size="22" font-weight="600">Foreground hugs lower third</text>
+  <path d="M80 346.67 L300 346.67" stroke="#0f172a" stroke-width="6" stroke-linecap="round" />
+  <!-- Annotation arrow -->
+  <path d="M220 320 Q220 250 320 210" fill="none" stroke="#0f172a" stroke-width="3" marker-end="url(#arrow)" />
+</svg>

--- a/docs/non-ai-research/composition-101-chaptered-intro.md
+++ b/docs/non-ai-research/composition-101-chaptered-intro.md
@@ -37,6 +37,11 @@ Imagine a tic-tac-toe grid over your frame; place key elements along those lines
 at the four intersections (“power points”). It’s popular because it’s fast, readable,
 and avoids dead-center stagnation.[^cambridge-rot][^studiobinder-rot][^wikipedia-rot]
 
+<figure>
+  <img src="../img/composition-rule-of-thirds.svg" alt="Rule of thirds grid overlay highlighting the four power points, a horizon on the upper third, and a subject aligned to the right intersection." style="width: min(100%, 720px); height: auto;" />
+  <figcaption><em>Figure 1. The thirds grid keeps horizons, focal points, and supporting elements on predictable lines so the eye travels with intention.</em></figcaption>
+</figure>
+
 ### How to use (quick recipes)
 
 - **Horizon:** Drop it on the top or bottom third, not dead center, to avoid a static
@@ -88,6 +93,11 @@ interest beyond the frame.[^sphs-headroom][^drhs-composition] The same logic
 governs motion: a moving car framed without space in front looks stalled at the
 edge, whereas a shot with adequate lead room convinces us the vehicle can
 continue accelerating past the camera.[^wikipedia-lead-room]
+
+<figure>
+  <img src="../img/composition-lead-room.svg" alt="Four small frames comparing balanced lead room, short-sided framing, comfortable headroom, and excessive headroom using thirds guides." style="width: min(100%, 760px); height: auto;" />
+  <figcaption><em>Figure 2. Lead room and headroom overlays show how generous look space and eyes-on-the-third placements feel stable, while short-siding or excessive headroom throws the frame off balance.</em></figcaption>
+</figure>
 
 Look space also guides shot/reverse-shot editing. When two characters are
 framed with matching lead room toward one another, the viewer’s brain stitches


### PR DESCRIPTION
## Summary
- add SVG overlays that illustrate the rule of thirds grid and lead/head room spacing
- embed the new figures in the Composition 101 primer with descriptive captions and alt text

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dd2b191f348326b1da8d17e872c51d