### PR TITLE
Add printable artist attention scorecard template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ site/
 docs/non-ai-research/img/*.png
 docs/non-ai-research/img/*.jpg
 docs/non-ai-research/img/*.jpeg
+docs/non-ai-research/templates/*.xlsx
 

--- a/docs/non-ai-research/artists-field-guide-attention-energy.md
+++ b/docs/non-ai-research/artists-field-guide-attention-energy.md
@@ -153,13 +153,16 @@ Redefine a "good day" by process adherence, not output volume.
 
 ### Scorecard Template
 
-| Metric | Entry | Why It Matters |
+!!! info "Download the scorecard"
+    Save or print the [Artist Attention Scorecard Template](templates/artist-attention-scorecard.md) for ready-to-fill columns, or duplicate it into a spreadsheet for longer-term tracking.
+
+| Metric | What to Log | Why It Matters |
 | --- | --- | --- |
-| Estimated Flow Minutes | _________ | Tracks sustainable focus minutes rather than raw hours. |
-| Micro-Goals Hit | _________ | Measures session structure and follow-through. |
-| Boundary Breaks Taken | _________ | Rewards the breaks that prevent burnout. |
-| Recovery Action Done? (Y/N) | _________ | Confirms that recovery is treated as part of the job. |
-| Next Session's First Goal Written? (Y/N) | _________ | Lowers initiation friction for the next work block. |
+| Estimated Flow Minutes | Record the total number of minutes spent in sustainable flow. | Tracks sustainable focus minutes rather than raw hours. |
+| Micro-Goals Hit | Count how many micro-goals you completed during the session. | Measures session structure and follow-through. |
+| Boundary Breaks Taken | Log every deliberate break that protected your attention tunnel. | Rewards the breaks that prevent burnout. |
+| Recovery Action Done? (Y/N) | Mark `Y` when you complete a recovery ritual before closing the session. | Confirms that recovery is treated as part of the job. |
+| Next Session's First Goal Written? (Y/N) | Mark `Y` once you've written the first action for the next session. | Lowers initiation friction for the next work block. |
 
 ### Using the Scorecard
 

--- a/docs/non-ai-research/templates/artist-attention-scorecard.md
+++ b/docs/non-ai-research/templates/artist-attention-scorecard.md
@@ -1,0 +1,33 @@
+# Artist Attention Scorecard Template
+
+Use this printable sheet to record the leading indicators described in the field guide without needing to reformat the table every session. Print the table directly from MkDocs or copy it into the note-taking app of your choice for digital tracking.
+
+## How to Use
+
+1. Start a new session by writing the date in the first column and logging each metric as you go.
+2. Treat the "Why it matters" notes as a quick prompt to stay focused on sustainability rather than perfectionism.
+3. Duplicate the table into a spreadsheet if you prefer running totals; saving a copy as `.xlsx` keeps the running history while this Markdown file stays clean.
+
+| Session Date | Estimated Flow Minutes | Micro-Goals Hit | Boundary Breaks Taken | Recovery Action Done? (Y/N) | Next Session's First Goal Written? (Y/N) | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |
+
+## Metric Reference
+
+| Metric | Tracking Prompt | Why It Matters |
+| --- | --- | --- |
+| Estimated Flow Minutes | Log the total number of minutes that felt like voluntary, sustainable focus. | Tracks sustainable focus minutes rather than raw hours. |
+| Micro-Goals Hit | Count how many 15–25 minute micro-goals you completed. | Measures session structure and follow-through. |
+| Boundary Breaks Taken | Note how many deliberate breaks protected your attention tunnel. | Rewards the breaks that prevent burnout. |
+| Recovery Action Done? | Mark `Y` or `N` after completing a recovery ritual before ending the session. | Confirms that recovery is treated as part of the job. |
+| Next Session's First Goal Written? | Record whether you wrote the first action for the next session. | Lowers initiation friction for the next work block. |
+


### PR DESCRIPTION
## Summary
- add a dedicated artist attention scorecard template with ready-to-print columns and usage guidance
- link the field guide’s scorecard section to the downloadable template and replace placeholder underscores with actionable prompts
- ignore optional spreadsheet exports alongside the new template

## Testing
- `mkdocs build` *(fails: missing pymdownx.copybutton extension in the environment; requires MkDocs dependencies to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2b173840832696c3504686f45727