### PR TITLE
Refine GPT-o3 subsystem summary

### DIFF
--- a/docs/ai-research/reverse-engineering-gpt-o3.md
+++ b/docs/ai-research/reverse-engineering-gpt-o3.md
@@ -19,19 +19,13 @@ Date: October 26, 2025
 
 This report presents the complete findings from a reverse-engineering analysis of the "GPT-o3" system, focusing specifically on its multi-turn conversational reasoning capabilities. The analysis concludes that this advanced functionality is not the product of a single, monolithic neural network. Instead, it is an emergent property arising from the sophisticated orchestration of three distinct, yet deeply integrated, subsystems:
 
-A Sparsely-Gated Mixture of Experts (MoE) Transformer: This serves as the foundational generative model. Its architecture enables scaling to trillions of parameters while maintaining manageable inference costs through conditional computation, activating only a fraction of its total weights for any given input token.
-
-A Dynamic Context & State Management Engine: This subsystem acts as the "operating system" for the conversational agent. It is responsible for maintaining state, managing the limited context window across extended dialogues, and ensuring conversational coherence. It employs a hierarchy of techniques including summarization, sliding windows, and vectorized long-term memory.
-
-An Integrated [Retrieval-Augmented Generation (RAG) Pipeline](logical-chunking.md): To ensure factual accuracy and provide up-to-date information, the system dynamically queries an external knowledge base. This RAG pipeline retrieves relevant information from a vector database and injects it into the model's context, grounding its responses in verifiable data.
-
 - **Sparsely-Gated Mixture of Experts (MoE) Transformer**: This serves as the foundational generative model. Its architecture enables scaling to trillions of parameters while maintaining manageable inference costs through conditional computation, activating only a fraction of its total weights for any given input token.
 
 - **Dynamic Context & State Management Engine**: This subsystem acts as the "operating system" for the conversational agent. It is responsible for maintaining state, managing the limited context window across extended dialogues, and ensuring conversational coherence. It employs a hierarchy of techniques including summarization, sliding windows, and vectorized long-term memory.
 
 - **Integrated [Retrieval-Augmented Generation (RAG) Pipeline](logical-chunking.md)**: To ensure factual accuracy and provide up-to-date information, the system dynamically queries an external knowledge base. This RAG pipeline retrieves relevant information from a vector database and injects it into the model's context, grounding its responses in verifiable data.
 
-The interaction between these three components—the MoE model as the computational core, the Context Engine as the state manager, and the RAG pipeline as the knowledge source—is what endows the system with its powerful and coherent multi-turn reasoning abilities.
+Together, these components—the MoE model as the computational core, the Context Engine as the state manager, and the RAG pipeline as the knowledge source—provide the coherent multi-turn reasoning capabilities examined in the visualization and analysis that follow.
 
 The reasoning loop and tool interactions can be visualized as:
 


### PR DESCRIPTION
## Summary
- remove the redundant prose description of the GPT-o3 subsystems
- smooth the transition from the subsystem overview into the subsequent visualization and analysis

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd39d41f3c8326b74466dd0851b85a