### PR TITLE
Replace liquid toc with MkDocs directive

### DIFF
--- a/docs/ai-research/index.md
+++ b/docs/ai-research/index.md
@@ -11,7 +11,7 @@ This index collects documents exploring context windows, reverse engineering, an
 
 ![KV cache chart](kv-cache-chart.svg)
 
-{{ toc }}
+[[toc]]
 
 ## Context Windows
 - [Context Windows Deep Dive](context-windows-deep-dive.md) — Analyzes long LLM context scaling

--- a/docs/ai-research/reverse-engineering-tribe.md
+++ b/docs/ai-research/reverse-engineering-tribe.md
@@ -9,7 +9,7 @@ updated: 2025-08-14
 
 # Reverse-Engineering Design Report: facebookresearch/algonauts-2025 (TRIBE)
 
-{{ toc }}
+[[toc]]
 
 1.0 Executive Summary
 1.1 Project Mandate and Findings

--- a/docs/non-ai-research/anti-fragile-studio.md
+++ b/docs/non-ai-research/anti-fragile-studio.md
@@ -7,7 +7,7 @@ updated: 2025-09-18
 
 --8<-- "_snippets/disclaimer.md"
 
-{{ toc }}
+[[toc]]
 
 # The Anti-Fragile Studio: An Operational Playbook for the Neurodivergent Artist
 

--- a/docs/non-ai-research/artists-field-guide-attention-energy.md
+++ b/docs/non-ai-research/artists-field-guide-attention-energy.md
@@ -7,7 +7,7 @@ updated: 2025-09-16
 
 --8<-- "_snippets/disclaimer.md"
 
-{{ toc }}
+[[toc]]
 
 # The Artist's Field Guide to Attention & Energy: Navigating Flow, Focus, and Burnout in the Studio
 

--- a/docs/non-ai-research/composition-101-chaptered-intro.md
+++ b/docs/non-ai-research/composition-101-chaptered-intro.md
@@ -7,7 +7,7 @@ updated: 2025-09-17
 
 --8<-- "_snippets/disclaimer.md"
 
-{{ toc }}
+[[toc]]
 
 # Composition 101 — Chaptered Intro (with Links)
 

--- a/docs/non-ai-research/index.md
+++ b/docs/non-ai-research/index.md
@@ -13,7 +13,7 @@ This collection surveys productivity methods, corporate dynamics, and
 interdisciplinary ideas beyond AI. These studies link diverse research to
 broaden and complement AI-focused work.
 
-{{ toc }}
+[[toc]]
 
 ## Productivity
 

--- a/docs/non-ai-research/neuropsychology-of-fandom-affinity.md
+++ b/docs/non-ai-research/neuropsychology-of-fandom-affinity.md
@@ -7,7 +7,7 @@ updated: 2025-09-02
 
 --8<-- "_snippets/disclaimer.md"
 
-{{ toc }}
+[[toc]]
 
 # The Neuropsychology of Fandom Affinity: An Integrative Analysis of Furry Art, Identity, and Belonging
 

--- a/docs/non-ai-research/painterly-style-clip-studio-paint.md
+++ b/docs/non-ai-research/painterly-style-clip-studio-paint.md
@@ -7,7 +7,7 @@ updated: 2025-09-08
 
 --8<-- "_snippets/disclaimer.md"
 
-{{ toc }}
+[[toc]]
 
 > **Contributor note:** Keep image callouts as HTML comments formatted like `<!-- image: docs/non-ai-research/img/filename.png -->` until the actual asset is committed. Replace the comment with the real image path when adding binaries.
 


### PR DESCRIPTION
## Summary
- replace deprecated liquid-style toc directive with MkDocs-native [[toc]] in AI and non-AI research docs

## Testing
- mkdocs build *(fails: Config value 'markdown_extensions': Failed to load extension 'pymdownx.copybutton')*

------
https://chatgpt.com/codex/tasks/task_e_68dd39ca3d6c8326a1ab0a0fb55a7566