### PR TITLE
Add SVG diagrams for painterly brush guide

### DIFF
--- a/docs/non-ai-research/img/active-color-mix.svg
+++ b/docs/non-ai-research/img/active-color-mix.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Active color mixing swatches</title>
+  <desc id="desc">Circular swatches mixing into one another to demonstrate active color mixing with Clip Studio Paint brushes.</desc>
+  <defs>
+    <marker id="arrow" markerUnits="strokeWidth" markerWidth="12" markerHeight="12" viewBox="0 0 10 10" refX="8" refY="5" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" fill="#3c9c8f" />
+    </marker>
+  </defs>
+  <rect width="640" height="360" fill="#f8fbfa" />
+  <g transform="translate(140,120)">
+    <circle cx="80" cy="60" r="60" fill="#f26f63" opacity="0.85" />
+    <circle cx="200" cy="60" r="60" fill="#f2c75e" opacity="0.8" />
+    <circle cx="140" cy="140" r="60" fill="#4fb4a7" opacity="0.8" />
+    <circle cx="80" cy="60" r="40" fill="#f7a689" opacity="0.8" />
+    <circle cx="200" cy="60" r="40" fill="#f5d58c" opacity="0.8" />
+    <circle cx="140" cy="140" r="40" fill="#7ad3c4" opacity="0.85" />
+    <circle cx="140" cy="90" r="46" fill="#f5b65b" opacity="0.8" />
+    <circle cx="140" cy="90" r="26" fill="#f5d9a5" opacity="0.9" />
+  </g>
+  <path d="M360 150 C420 110 470 110 520 140" fill="none" stroke="#3c9c8f" stroke-width="6" stroke-linecap="round" marker-end="url(#arrow)" opacity="0.7" />
+  <g font-family="'Segoe UI',sans-serif" fill="#2f3235" font-size="18">
+    <text x="320" y="48" text-anchor="middle">Brush picks up and deposits surrounding pigment</text>
+    <text x="140" y="310">sample mix</text>
+    <text x="500" y="178">picked hue</text>
+  </g>
+</svg>

--- a/docs/non-ai-research/img/cats-tongue-taper.svg
+++ b/docs/non-ai-research/img/cats-tongue-taper.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Cat's Tongue brush pressure taper study</title>
+  <desc id="desc">Diagonal strokes that taper at each end to show how a Cat's Tongue brush reacts to pressure in Clip Studio Paint.</desc>
+  <rect width="640" height="360" fill="#fbf8f2" />
+  <g stroke-linecap="round" fill="none" transform="translate(80,70)">
+    <path d="M0 40 Q180 0 360 40" stroke="#f05b5b" stroke-width="28" stroke-opacity="0.7" />
+    <path d="M20 40 Q200 70 360 10" stroke="#f9a857" stroke-width="24" stroke-opacity="0.75" />
+    <path d="M-10 120 Q160 60 360 120" stroke="#3fa6d9" stroke-width="26" stroke-opacity="0.65" />
+    <path d="M30 200 Q220 260 360 180" stroke="#50bfa0" stroke-width="22" stroke-opacity="0.7" />
+  </g>
+  <g fill="#2f2f33" font-family="'Segoe UI',sans-serif" font-size="16">
+    <text x="320" y="36" text-anchor="middle">Pressure-controlled taper</text>
+    <text x="110" y="110">light press</text>
+    <text x="470" y="90" text-anchor="end">heavy press</text>
+  </g>
+</svg>

--- a/docs/non-ai-research/img/flat-ribbon-blocks.svg
+++ b/docs/non-ai-research/img/flat-ribbon-blocks.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Flat Ribbon brush block-in strokes</title>
+  <desc id="desc">Angular palette-knife swatches stacked to show how the Flat Ribbon brush carves blocky shapes.</desc>
+  <rect width="640" height="360" fill="#f8f5f1" />
+  <g transform="translate(70,70)">
+    <rect x="0" y="0" width="180" height="80" fill="#2f4f77" rx="12" />
+    <rect x="120" y="20" width="220" height="90" fill="#6c92be" rx="14" />
+    <rect x="60" y="100" width="260" height="80" fill="#f6a13d" rx="18" />
+    <rect x="220" y="40" width="180" height="70" fill="#20324f" rx="16" opacity="0.75" />
+    <rect x="260" y="130" width="140" height="90" fill="#f4c678" rx="18" />
+    <rect x="120" y="180" width="180" height="70" fill="#c04a34" rx="16" opacity="0.8" />
+  </g>
+  <text x="320" y="42" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#2f2f33">Chiseled knife marks in opposing angles</text>
+</svg>

--- a/docs/non-ai-research/img/flat-ribbon-soft-random.svg
+++ b/docs/non-ai-research/img/flat-ribbon-soft-random.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Flat Ribbon Soft randomized textures</title>
+  <desc id="desc">Scattered brush tips with varied opacity illustrating the Flat Ribbon Soft brush's unpredictable textures.</desc>
+  <rect width="640" height="360" fill="#fefcf6" />
+  <g transform="translate(70,60)">
+    <ellipse cx="80" cy="80" rx="70" ry="40" fill="#f09050" opacity="0.6" />
+    <ellipse cx="200" cy="90" rx="60" ry="38" fill="#e85d7a" opacity="0.45" />
+    <ellipse cx="140" cy="170" rx="85" ry="48" fill="#71c1b5" opacity="0.55" />
+    <ellipse cx="280" cy="160" rx="68" ry="42" fill="#4a7ab3" opacity="0.5" />
+    <ellipse cx="230" cy="40" rx="56" ry="32" fill="#f3c873" opacity="0.45" />
+    <ellipse cx="340" cy="90" rx="48" ry="28" fill="#2d4d6d" opacity="0.4" />
+    <ellipse cx="360" cy="200" rx="70" ry="38" fill="#a369d6" opacity="0.5" />
+    <ellipse cx="150" cy="230" rx="60" ry="34" fill="#f07443" opacity="0.42" />
+    <ellipse cx="300" cy="250" rx="90" ry="48" fill="#3b8574" opacity="0.38" />
+  </g>
+  <text x="320" y="40" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#2d2d31">Random texture cycling per stroke</text>
+</svg>

--- a/docs/non-ai-research/img/hard-edge-demo.svg
+++ b/docs/non-ai-research/img/hard-edge-demo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Hard edge separation demo</title>
+  <desc id="desc">Rectangular shapes with crisp borders illustrating how hard edges separate planes.</desc>
+  <rect width="640" height="360" fill="#f8f8fb" />
+  <g transform="translate(120,70)">
+    <rect x="0" y="20" width="160" height="200" fill="#374f7d" />
+    <rect x="160" y="20" width="160" height="200" fill="#f5a24f" />
+    <rect x="320" y="20" width="120" height="200" fill="#f2d480" />
+    <line x1="160" y1="20" x2="160" y2="220" stroke="#1f2f4d" stroke-width="8" />
+    <line x1="320" y1="20" x2="320" y2="220" stroke="#c7772c" stroke-width="8" />
+  </g>
+  <text x="320" y="48" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#2d2d34">Hard edge divides value and hue families</text>
+</svg>

--- a/docs/non-ai-research/img/hoarse-oil-pressure.svg
+++ b/docs/non-ai-research/img/hoarse-oil-pressure.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Hoarse Oil brush pressure response</title>
+  <desc id="desc">A set of strokes thickening from feather-light to bold to demonstrate the Hoarse Oil brush pressure curve.</desc>
+  <rect width="640" height="360" fill="#f9f6f3" />
+  <g transform="translate(60,60)" fill="none" stroke-linecap="round">
+    <path d="M0 40 C140 10 220 10 360 40" stroke="#3f4f5c" stroke-width="6" opacity="0.4" />
+    <path d="M0 100 C160 70 220 70 360 110" stroke="#3f4f5c" stroke-width="16" opacity="0.7" />
+    <path d="M0 160 C160 190 220 190 360 150" stroke="#3f4f5c" stroke-width="26" opacity="0.85" />
+    <path d="M0 220 C160 240 230 240 360 220" stroke="#2d3b46" stroke-width="32" opacity="0.9" />
+  </g>
+  <g font-family="'Segoe UI',sans-serif" fill="#2d2d31" font-size="16">
+    <text x="320" y="36" text-anchor="middle">Pressure gain from soft to firm</text>
+    <text x="80" y="90">feather</text>
+    <text x="520" y="225" text-anchor="end">full press</text>
+  </g>
+</svg>

--- a/docs/non-ai-research/img/ink-tapered-raw-texture.svg
+++ b/docs/non-ai-research/img/ink-tapered-raw-texture.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Ink Tapered Raw dry texture map</title>
+  <desc id="desc">Three overlapping dry brush strokes that reveal tapering texture and lifted fibers along the stroke tails.</desc>
+  <rect width="640" height="360" fill="#fdfcf8" />
+  <g transform="translate(70,70)">
+    <path d="M0 40 C130 20 220 20 360 0" fill="#1a3655" opacity="0.15" />
+    <path d="M10 40 C140 30 230 16 360 8" stroke="#1a3655" stroke-width="32" stroke-linecap="round" stroke-linejoin="round" opacity="0.6" />
+    <path d="M0 120 C140 110 230 140 360 120" stroke="#203b63" stroke-width="28" stroke-linecap="round" opacity="0.5" />
+    <path d="M0 200 C120 190 210 220 360 200" stroke="#203b63" stroke-width="26" stroke-linecap="round" opacity="0.4" stroke-dasharray="2 8" />
+  </g>
+  <g font-family="'Segoe UI',sans-serif" fill="#2b2c34" font-size="15">
+    <text x="320" y="42" text-anchor="middle">Dry-brush breakup toward stroke ends</text>
+    <text x="120" y="130">grain lift</text>
+    <text x="490" y="210" text-anchor="end">ragged taper</text>
+  </g>
+</svg>

--- a/docs/non-ai-research/img/oil-paint-flat-blend.svg
+++ b/docs/non-ai-research/img/oil-paint-flat-blend.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Oil Paint Flat brush blending chart</title>
+  <desc id="desc">Three horizontal color strokes demonstrating gradual blending from orange to teal using overlapping bands.</desc>
+  <defs>
+    <linearGradient id="warmBlend" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#ef8b40" />
+      <stop offset="50%" stop-color="#f6c77d" />
+      <stop offset="100%" stop-color="#8ed1c1" />
+    </linearGradient>
+    <linearGradient id="coolBlend" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#4f7ac2" />
+      <stop offset="50%" stop-color="#6db5d9" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#c9e9e2" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="#f6f4f0" />
+  <g transform="translate(60,80)">
+    <rect width="520" height="40" rx="20" fill="url(#warmBlend)" />
+    <rect y="70" width="520" height="40" rx="20" fill="url(#coolBlend)" />
+    <rect y="140" width="520" height="32" rx="16" fill="#c6d7cf" />
+    <rect y="140" width="320" height="32" rx="16" fill="#6c9c89" opacity="0.75" />
+    <rect y="140" x="240" width="180" height="32" rx="16" fill="#f6bf63" opacity="0.6" />
+  </g>
+  <text x="320" y="45" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="20" fill="#2f2f33">Blended transitions with the Oil Paint Flat brush</text>
+</svg>

--- a/docs/non-ai-research/img/post-process-blend.svg
+++ b/docs/non-ai-research/img/post-process-blend.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Post-process blend comparison</title>
+  <desc id="desc">Side-by-side comparison showing a smudged gradient versus the original to explain Clip Studio Paint blend tools.</desc>
+  <defs>
+    <linearGradient id="gradLeft" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#faebd7" />
+      <stop offset="50%" stop-color="#f4b15a" />
+      <stop offset="100%" stop-color="#f4766d" />
+    </linearGradient>
+    <linearGradient id="gradRight" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#faebd7" />
+      <stop offset="50%" stop-color="#f4b15a" />
+      <stop offset="100%" stop-color="#f4766d" stop-opacity="0.7" />
+    </linearGradient>
+    <filter id="smudge" x="-0.2" y="-0.2" width="1.4" height="1.4">
+      <feGaussianBlur stdDeviation="12" />
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="#f7f7f9" />
+  <rect x="70" y="80" width="200" height="200" rx="20" fill="#f4b15a" filter="url(#smudge)" opacity="0.8" />
+  <rect x="70" y="80" width="200" height="200" rx="20" fill="url(#gradLeft)" />
+  <rect x="370" y="80" width="200" height="200" rx="20" fill="url(#gradRight)" />
+  <rect x="370" y="80" width="200" height="200" rx="20" fill="#f4b15a" opacity="0.35" />
+  <text x="170" y="310" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#2d2d33">Blend tool smudge</text>
+  <text x="470" y="310" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#2d2d33">Unaltered paint</text>
+  <text x="320" y="46" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="20" fill="#2d2d33">Post-process blurring vs original strokes</text>
+</svg>

--- a/docs/non-ai-research/img/soft-edge-demo.svg
+++ b/docs/non-ai-research/img/soft-edge-demo.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Soft edge gradient demo</title>
+  <desc id="desc">Circular forms gently blending into the background to show a soft edge transition.</desc>
+  <defs>
+    <radialGradient id="softSphere" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f7dca6" />
+      <stop offset="60%" stop-color="#f3a96c" />
+      <stop offset="100%" stop-color="#f37c5c" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="640" height="360" fill="#f6f7fb" />
+  <circle cx="220" cy="180" r="120" fill="url(#softSphere)" />
+  <circle cx="420" cy="180" r="100" fill="url(#softSphere)" transform="scale(0.9 1) translate(46 0)" opacity="0.9" />
+  <text x="320" y="320" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#2f2f34">Feathered falloff without visible seams</text>
+</svg>

--- a/docs/non-ai-research/img/su-cream-pencil-sketch.svg
+++ b/docs/non-ai-research/img/su-cream-pencil-sketch.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">SU-Cream Pencil sketch texture</title>
+  <desc id="desc">Loose construction lines with crosshatching demonstrating the SU-Cream Pencil grain.</desc>
+  <rect width="640" height="360" fill="#faf7f2" />
+  <g stroke="#43362e" stroke-linecap="round" stroke-width="3" fill="none" transform="translate(120,70)">
+    <path d="M0 120 C40 20 200 20 240 120" opacity="0.45" />
+    <path d="M30 80 C90 140 150 140 210 80" opacity="0.7" />
+    <path d="M20 150 Q120 220 220 150" opacity="0.35" />
+    <path d="M70 40 L170 40" opacity="0.2" />
+    <path d="M70 40 L110 10" opacity="0.25" />
+    <path d="M170 40 L200 10" opacity="0.25" />
+    <path d="M60 120 L200 120" opacity="0.3" />
+    <path d="M80 110 L120 150" opacity="0.3" />
+    <path d="M160 110 L120 150" opacity="0.25" />
+    <path d="M130 70 Q140 100 130 130" opacity="0.5" />
+  </g>
+  <g stroke="#43362e" stroke-width="2" opacity="0.3" transform="translate(120,70)">
+    <line x1="30" y1="200" x2="210" y2="200" />
+    <line x1="30" y1="200" x2="60" y2="230" />
+    <line x1="60" y1="230" x2="210" y2="230" />
+    <line x1="110" y1="250" x2="170" y2="250" />
+  </g>
+  <text x="320" y="40" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#403832">Loose graphite-like scaffolding</text>
+</svg>

--- a/docs/non-ai-research/img/textured-edge-demo.svg
+++ b/docs/non-ai-research/img/textured-edge-demo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Textured lost edge demo</title>
+  <desc id="desc">Brush marks dissolving into background noise to illustrate a textured lost edge transition.</desc>
+  <defs>
+    <pattern id="grain" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <circle cx="4" cy="6" r="1.4" fill="#4e5a56" />
+      <circle cx="14" cy="10" r="1.2" fill="#4e5a56" />
+      <circle cx="8" cy="16" r="1.1" fill="#4e5a56" />
+    </pattern>
+  </defs>
+  <rect width="640" height="360" fill="#f8f5f4" />
+  <g transform="translate(120,90)">
+    <path d="M0 120 C80 40 220 40 300 120" fill="#f17f57" opacity="0.7" />
+    <path d="M40 90 C110 30 210 30 260 110" fill="#f5b77a" opacity="0.6" />
+    <path d="M20 150 C120 200 240 200 320 150" fill="#a2cfc4" opacity="0.5" />
+  </g>
+  <g transform="translate(120,90)" fill="#5a675f" opacity="0.25">
+    <circle cx="220" cy="130" r="8" />
+    <circle cx="240" cy="140" r="6" />
+    <circle cx="260" cy="150" r="5" />
+    <circle cx="280" cy="160" r="6" />
+    <circle cx="300" cy="170" r="8" />
+    <circle cx="320" cy="150" r="7" />
+    <circle cx="340" cy="140" r="6" />
+    <circle cx="360" cy="160" r="7" />
+    <circle cx="330" cy="120" r="5" />
+  </g>
+  <rect x="120" y="90" width="200" height="160" fill="url(#grain)" opacity="0.2" />
+  <text x="320" y="48" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#2e2d2c">Textured edge dissolving into background</text>
+</svg>

--- a/docs/non-ai-research/img/textured-thick-lineart-grit.svg
+++ b/docs/non-ai-research/img/textured-thick-lineart-grit.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Textured Thick Lineart grit example</title>
+  <desc id="desc">Angular contour lines with stippled shading highlighting the gritty quality of the Textured Thick Lineart brush.</desc>
+  <rect width="640" height="360" fill="#fdfbf7" />
+  <g transform="translate(110,60)" fill="none" stroke="#2e2a2b" stroke-width="5" stroke-linejoin="round" stroke-linecap="round" opacity="0.7">
+    <path d="M0 160 Q90 0 220 80 Q300 130 320 220" />
+    <path d="M40 120 Q140 60 220 120" />
+    <path d="M80 200 Q160 140 260 200" />
+  </g>
+  <g transform="translate(110,60)" stroke="#2e2a2b" stroke-width="3" stroke-linecap="round" opacity="0.3">
+    <line x1="60" y1="220" x2="180" y2="260" />
+    <line x1="180" y1="260" x2="260" y2="240" />
+  </g>
+  <g transform="translate(110,60)" fill="#2e2a2b" opacity="0.18">
+    <circle cx="90" cy="180" r="6" />
+    <circle cx="120" cy="190" r="5" />
+    <circle cx="150" cy="210" r="4" />
+    <circle cx="200" cy="180" r="5" />
+    <circle cx="240" cy="210" r="4" />
+    <circle cx="260" cy="150" r="5" />
+    <circle cx="210" cy="110" r="4" />
+    <circle cx="180" cy="140" r="5" />
+  </g>
+  <text x="320" y="40" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#2f2b2c">Gritty contour with stippled edge</text>
+</svg>

--- a/docs/non-ai-research/img/thick-paints-impasto.svg
+++ b/docs/non-ai-research/img/thick-paints-impasto.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Thick Paints impasto swatches</title>
+  <desc id="desc">Layered blobs of color with highlights to visualize impasto buildup created with thick paint brushes.</desc>
+  <rect width="640" height="360" fill="#f9f6f1" />
+  <g transform="translate(100,80)">
+    <path d="M0 80 C60 20 160 20 220 80 C160 140 60 140 0 80" fill="#f57c4a" opacity="0.85" />
+    <path d="M40 40 C110 -10 190 0 240 60 C170 120 90 120 40 40" fill="#f4b761" opacity="0.75" />
+    <path d="M120 120 C200 70 270 70 320 120 C260 170 180 170 120 120" fill="#7bbbc2" opacity="0.75" />
+    <path d="M90 150 C150 200 230 210 280 170" stroke="#fff" stroke-width="10" stroke-linecap="round" opacity="0.4" />
+    <path d="M40 70 C80 50 130 50 170 80" stroke="#fff8ee" stroke-width="12" stroke-linecap="round" opacity="0.5" />
+    <path d="M200 100 C240 80 270 90 300 120" stroke="#fff8f2" stroke-width="9" stroke-linecap="round" opacity="0.4" />
+  </g>
+  <text x="320" y="44" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="18" fill="#3b3430">Impasto ridges catching light</text>
+</svg>

--- a/docs/non-ai-research/painterly-style-clip-studio-paint.md
+++ b/docs/non-ai-research/painterly-style-clip-studio-paint.md
@@ -9,7 +9,7 @@ updated: 2025-09-08
 
 [[toc]]
 
-> **Contributor note:** Keep image callouts as HTML comments formatted like `<!-- image: docs/non-ai-research/img/filename.png -->` until the actual asset is committed. Replace the comment with the real image path when adding binaries.
+> **Contributor note:** Lightweight SVG diagrams now live in `docs/non-ai-research/img/` and the guide embeds them with `<figure>` elements. To swap in your own PNG captures later, replace the `<img src="…">` reference with your filename (and optionally retain a `<!-- image: … -->` comment for clarity).
 
 # A Comprehensive Guide to the Painterly Style in Clip Studio Paint
 
@@ -22,29 +22,32 @@ updated: 2025-09-08
 
 ## Image Placeholder Checklist (Add Your Examples Later)
 
-To keep this repository binary-free, every figure callout in the guide is a placeholder that points
-to a PNG inside `docs/non-ai-research/img/`. Drop your own captures into that folder using the
-filenames below and they will slot directly into place. The `img/README.md` file in the same
-directory expands on recommended capture settings if you need extra guidance.
+To keep this repository binary-free, every figure callout currently uses a lightweight SVG diagram
+stored in `docs/non-ai-research/img/`. When you have real screen captures, drop them into that
+folder and update the `<img src="…">` path in the relevant `<figure>` element. If you want to keep a
+breadcrumb for future replacements, you can also add a `<!-- image: … -->` comment alongside the
+figure. The `img/README.md` file in the same directory expands on recommended capture settings if
+you need extra guidance.
 
-| File name | Appears in | Depicts |
-| --- | --- | --- |
-| `oil-paint-flat-blend.png` | Section 1 – Default workhorse brush | Oil Paint Flat blending sample |
-| `cats-tongue-taper.png` | Section 1 – Cat's Tongue customization | Pressure-based taper strokes |
-| `ink-tapered-raw-texture.png` | Section 1 – Organic texture | Ink Tapered Raw dry-brush finish |
-| `flat-ribbon-blocks.png` | Section 1 – Palette knife emulation | Flat Ribbon block-in strokes |
-| `flat-ribbon-soft-random.png` | Section 1 – Spontaneous edges | Flat Ribbon Soft texture variety |
-| `hoarse-oil-pressure.png` | Section 1 – Brush notes | Hoarse Oil pressure response |
-| `su-cream-pencil-sketch.png` | Section 1 – Brush notes | SU-Cream Pencil grain |
-| `thick-paints-impasto.png` | Section 1 – Brush notes | Thick Paints impasto swatches |
-| `textured-thick-lineart-grit.png` | Section 1 – Brush notes | Textured Thick Lineart grit |
-| `post-process-blend.png` | Section 4 – Blending overview | Post-process Blend tool comparison |
-| `active-color-mix.png` | Section 4 – Blending overview | Active color mixing strokes |
-| `hard-edge-demo.png` | Section 4 – Edge handling | Hard edge separation |
-| `soft-edge-demo.png` | Section 4 – Edge handling | Soft edge gradient |
-| `textured-edge-demo.png` | Section 4 – Edge handling | Textured lost edge transition |
+| File name | Appears in | Depicts | Current asset |
+| --- | --- | --- | --- |
+| `oil-paint-flat-blend.*` | Section 1 – Default workhorse brush | Oil Paint Flat blending sample | `img/oil-paint-flat-blend.svg` |
+| `cats-tongue-taper.*` | Section 1 – Cat's Tongue customization | Pressure-based taper strokes | `img/cats-tongue-taper.svg` |
+| `ink-tapered-raw-texture.*` | Section 1 – Organic texture | Ink Tapered Raw dry-brush finish | `img/ink-tapered-raw-texture.svg` |
+| `flat-ribbon-blocks.*` | Section 1 – Palette knife emulation | Flat Ribbon block-in strokes | `img/flat-ribbon-blocks.svg` |
+| `flat-ribbon-soft-random.*` | Section 1 – Spontaneous edges | Flat Ribbon Soft texture variety | `img/flat-ribbon-soft-random.svg` |
+| `hoarse-oil-pressure.*` | Section 1 – Brush notes | Hoarse Oil pressure response | `img/hoarse-oil-pressure.svg` |
+| `su-cream-pencil-sketch.*` | Section 1 – Brush notes | SU-Cream Pencil grain | `img/su-cream-pencil-sketch.svg` |
+| `thick-paints-impasto.*` | Section 1 – Brush notes | Thick Paints impasto swatches | `img/thick-paints-impasto.svg` |
+| `textured-thick-lineart-grit.*` | Section 1 – Brush notes | Textured Thick Lineart grit | `img/textured-thick-lineart-grit.svg` |
+| `post-process-blend.*` | Section 4 – Blending overview | Post-process Blend tool comparison | `img/post-process-blend.svg` |
+| `active-color-mix.*` | Section 4 – Blending overview | Active color mixing strokes | `img/active-color-mix.svg` |
+| `hard-edge-demo.*` | Section 4 – Edge handling | Hard edge separation | `img/hard-edge-demo.svg` |
+| `soft-edge-demo.*` | Section 4 – Edge handling | Soft edge gradient | `img/soft-edge-demo.svg` |
+| `textured-edge-demo.*` | Section 4 – Edge handling | Textured lost edge transition | `img/textured-edge-demo.svg` |
 
-Until those captures exist, each section includes a blockquoted placeholder note (following the `<!-- image: … -->` comment) that describes the required content and target file. After you drop the finished asset into `docs/non-ai-research/img/`, replace the note with a standard Markdown image tag pointing to that path.
+These diagrams hold the place of future PNG captures, so swapping in new assets is as simple as
+replacing the SVG path with your preferred raster image.
 
 ## Introduction: The Philosophy of Painterly Digital Art
 
@@ -109,9 +112,10 @@ starting point. It is designed to blend colors smoothly right out of the box. Us
 reduced opacity, around 90%, allows for the creation of beautiful mid-tone transitions as new
 strokes are laid down, making it excellent for achieving both hard and soft edges.
 
-<!-- image: docs/non-ai-research/img/oil-paint-flat-blend.png -->
-
-> _Image placeholder:_ Save `docs/non-ai-research/img/oil-paint-flat-blend.png` showing the Oil Paint Flat blend sample, then replace this note with an embedded image once the asset is ready.
+<figure>
+  <img src="img/oil-paint-flat-blend.svg" alt="Three horizontal painterly strokes blending from warm orange to cool teal with overlapping bands." />
+  <figcaption>Oil Paint Flat brush strokes blend smoothly from warm to cool hues.</figcaption>
+</figure>
 
 **Customization for Control:** Simple modifications to default brushes can unlock new possibilities.
 By duplicating the Oil Paint Flat Brush and adjusting its "brush size dynamics" to respond to pen
@@ -119,9 +123,10 @@ pressure, an artist can create a Cat's Tongue Brush. This tapered brush provides
 control, allowing for strokes that swell and thin with pressure, mimicking the behavior of a
 traditional filbert brush.
 
-<!-- image: docs/non-ai-research/img/cats-tongue-taper.png -->
-
-> _Image placeholder:_ Save `docs/non-ai-research/img/cats-tongue-taper.png` illustrating the Cat's Tongue taper strokes, then swap this callout for the finished image embed.
+<figure>
+  <img src="img/cats-tongue-taper.svg" alt="Diagonal tapered brush marks that thin out toward each end to illustrate pressure control." />
+  <figcaption>Cat's Tongue customization delivers tapered pressure-sensitive strokes.</figcaption>
+</figure>
 
 **Introducing Organic Texture:** To break away from digital sterility, brushes that incorporate
 scanned natural media are invaluable. The Ink Tapered Raw brush from DAUB Brushes is a prime
@@ -130,9 +135,10 @@ texture at the end of strokes, adding a layer of organic realism. This highlight
 the name of a brush should not limit its application. An "ink" brush can be a perfect "painting"
 brush if its texture and behavior serve the artist's goal.
 
-<!-- image: docs/non-ai-research/img/ink-tapered-raw-texture.png -->
-
-> _Image placeholder:_ Save `docs/non-ai-research/img/ink-tapered-raw-texture.png` capturing the Ink Tapered Raw dry-brush finish before restoring the Markdown image tag.
+<figure>
+  <img src="img/ink-tapered-raw-texture.svg" alt="Dark blue strokes that fray into dry texture at their ends." />
+  <figcaption>Ink Tapered Raw showcases dry, organic breakup at the tail of each stroke.</figcaption>
+</figure>
 
 **Palette Knife Emulation:** For blocking in large shapes and creating crisp, hard edges, brushes
 that mimic a palette knife are essential. A custom-made Flat Ribbon Vertical brush, which has a
@@ -140,9 +146,10 @@ vertical chisel tip that does not follow the stroke's direction, creates a disru
 Variations where the tip follows the direction of the line (Flat Ribbon) or has a horizontal
 orientation (Flat Ribbon Horizontal) provide a full range of palette knife effects.
 
-<!-- image: docs/non-ai-research/img/flat-ribbon-blocks.png -->
-
-> _Image placeholder:_ Save `docs/non-ai-research/img/flat-ribbon-blocks.png` depicting palette-knife style marks from the Flat Ribbon brush, then replace this note with the live image embed.
+<figure>
+  <img src="img/flat-ribbon-blocks.svg" alt="Stacked rectangular swatches in staggered angles showing palette-knife block-ins." />
+  <figcaption>Flat Ribbon brush variants stack chunky palette-knife style blocks.</figcaption>
+</figure>
 
 **Achieving Spontaneous Edges:** The most elusive quality of traditional media is often its
 unpredictability. The Flat Ribbon Soft brush is designed to replicate this. By loading it with
@@ -151,9 +158,10 @@ apply a different texture with each click or stroke. This creates interesting an
 shapes and dry-brush effects that would be difficult to paint deliberately, perfectly embodying the
 principle of "controlled chaos."
 
-<!-- image: docs/non-ai-research/img/flat-ribbon-soft-random.png -->
-
-> _Image placeholder:_ Save `docs/non-ai-research/img/flat-ribbon-soft-random.png` demonstrating randomized textures from Flat Ribbon Soft, then reinstate the image element here.
+<figure>
+  <img src="img/flat-ribbon-soft-random.svg" alt="Soft oval daubs overlapping with varied opacity to indicate random texture cycling." />
+  <figcaption>Flat Ribbon Soft rotates textures to keep edge terminations unpredictable.</figcaption>
+</figure>
 
 ### Table 1: The Essential Painterly Brush Toolkit
 
@@ -172,41 +180,50 @@ principle of "controlled chaos."
 #### Brush Notes
 
 - **Oil Paint Flat Brush:** Clip Studio Paint's default oil brush blends colors smoothly out of the box, and dropping its opacity to around 90% encourages soft transitions while still allowing assertive, hard-edged strokes when needed.  
-  <!-- image: docs/non-ai-research/img/oil-paint-flat-blend.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/oil-paint-flat-blend.png` showing brush stroke behavior, then restore an embedded image when the asset is produced.
+  <figure>
+    <img src="img/oil-paint-flat-blend.svg" alt="Orange and teal strokes blending together to display the Oil Paint Flat response." />
+    <figcaption>Oil Paint Flat transitions smoothly with minimal effort.</figcaption>
+  </figure>
 - **Cat's Tongue Brush:** Duplicating the Oil Paint Flat Brush and tying brush size dynamics to pen pressure yields a tapered stroke that mimics a traditional filbert brush, offering expressive control during blends and calligraphic marks.  
-  <!-- image: docs/non-ai-research/img/cats-tongue-taper.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/cats-tongue-taper.png` demonstrating the taper example before reintroducing the Markdown image.
+  <figure>
+    <img src="img/cats-tongue-taper.svg" alt="Pressure-based tapered strokes in warm and cool colors." />
+    <figcaption>Cat's Tongue tapering mimics a filbert brush profile.</figcaption>
+  </figure>
 - **Hoarse Oil:** This asset brush excels at both sketching and painting by delivering gentle blends under light pressure and snapping into harder edges with firm pressure so you can block forms without swapping tools.  
-  <!-- image: docs/non-ai-research/img/hoarse-oil-pressure.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/hoarse-oil-pressure.png` documenting the Hoarse Oil pressure response, then swap this reminder for the finished figure.
+  <figure>
+    <img src="img/hoarse-oil-pressure.svg" alt="Sequential strokes growing thicker to demonstrate pressure response." />
+    <figcaption>Hoarse Oil ramps from feather-light strokes to dense coverage as pressure increases.</figcaption>
+  </figure>
 - **Ink Tapered Raw:** Sourced from DAUB Brushes, this tool uses scans of natural media to add subtle dry-brush textures at stroke ends, making it ideal for breaking up digital passages while keeping color mixing clean.  
-  <!-- image: docs/non-ai-research/img/ink-tapered-raw-texture.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/ink-tapered-raw-texture.png` capturing the brush's dry texture before reinstating an image embed.
+  <figure>
+    <img src="img/ink-tapered-raw-texture.svg" alt="Indigo brush passes that fray into dry texture at the tail." />
+    <figcaption>Ink Tapered Raw ends with textured, paper-emulated breakup.</figcaption>
+  </figure>
 - **Flat Ribbon (Vertical/Horizontal):** These custom palette-knife simulations use vertical and horizontal chisel options to carve crisp edges or lay down chunky shapes that keep brushwork energetic.  
-  <!-- image: docs/non-ai-research/img/flat-ribbon-blocks.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/flat-ribbon-blocks.png` illustrating palette knife strokes, then replace this note with the finished image.
+  <figure>
+    <img src="img/flat-ribbon-blocks.svg" alt="Overlapping chiseled blocks demonstrating palette-knife stroke variety." />
+    <figcaption>Flat Ribbon chisel tips carve confident geometric masses.</figcaption>
+  </figure>
 - **Flat Ribbon Soft:** Loading this custom brush with multiple Clip Studio texture patterns and random rotation makes each stamp generate unpredictable termini that deliver the controlled chaos of traditional dry media.  
-  <!-- image: docs/non-ai-research/img/flat-ribbon-soft-random.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/flat-ribbon-soft-random.png` showing the randomized textures once you are ready to embed the image.
+  <figure>
+    <img src="img/flat-ribbon-soft-random.svg" alt="Clustered soft daubs in multiple hues illustrating random texture shifts." />
+    <figcaption>Flat Ribbon Soft introduces controlled chaos through rotating textures.</figcaption>
+  </figure>
 - **SU-Cream Pencil:** Its delicate grain makes this pencil brush a reliable sketching tool for both clean construction lines and loose gesture marks before paint application.  
-  <!-- image: docs/non-ai-research/img/su-cream-pencil-sketch.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/su-cream-pencil-sketch.png` highlighting the sketch grain, then reinstate the figure when available.
+  <figure>
+    <img src="img/su-cream-pencil-sketch.svg" alt="Loose pencil scaffolding with crosshatching that shows paper grain." />
+    <figcaption>SU-Cream Pencil lays in gentle tooth for construction lines.</figcaption>
+  </figure>
 - **Thick Paints Set:** Reach for this asset collection when you need rich impasto-like coverage, with built-in color jitter injecting natural variance so repeated strokes never feel mechanical.  
-  <!-- image: docs/non-ai-research/img/thick-paints-impasto.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/thick-paints-impasto.png` showing the impasto swatches before reintroducing the image embed.
+  <figure>
+    <img src="img/thick-paints-impasto.svg" alt="Layered paint blobs with highlights representing impasto build-up." />
+    <figcaption>Thick Paints brushes stack tactile impasto ridges.</figcaption>
+  </figure>
 - **Textured Thick Lineart:** Leverage this pencil-like grit to define forms or reinforce edges, laying it down before painting to establish structure or afterward to reintroduce tactile line work.  
-  <!-- image: docs/non-ai-research/img/textured-thick-lineart-grit.png -->
-
-  > _Image placeholder:_ Add `docs/non-ai-research/img/textured-thick-lineart-grit.png` capturing the gritty line work, then replace this note with the final visual.
+  <figure>
+    <img src="img/textured-thick-lineart-grit.svg" alt="Bold contour lines with stippled accents showing gritty lineart." />
+    <figcaption>Textured Thick Lineart reintroduces gritty edge definition.</figcaption>
+  </figure>
 
 ## Section 2: The Grisaille Foundation: Mastering Value with the Grayscale-to-Color Method
 
@@ -349,9 +366,10 @@ blurring them together. This is a corrective or softening action, performed afte
 applied. It is ideal for creating very smooth, gradual transitions, such as those in an out-of-focus
 background or for gently softening the blush on a character's cheek.
 
-<!-- image: docs/non-ai-research/img/post-process-blend.png -->
-
-> _Image placeholder:_ Add `docs/non-ai-research/img/post-process-blend.png` comparing post-process blending, then convert this reminder back into a figure when the asset exists.
+<figure>
+  <img src="img/post-process-blend.svg" alt="Two side-by-side squares comparing a blurred gradient to a crisp original." />
+  <figcaption>Post-process Blend tools smudge existing pixels without adding new paint.</figcaption>
+</figure>
 
 **Active Blending (Color Mixing Brushes):** This is a more direct and organic method of blending
 that more closely mimics traditional wet-on-wet painting. Any painting brush (like the Oil Paint or
@@ -362,9 +380,10 @@ Amount of paint and Color stretch control this behavior. This is an active, addi
 creates textured, organic transitions and is perfect for rendering focal points like skin, hair, and
 fabric, where visible brushwork is desired.
 
-<!-- image: docs/non-ai-research/img/active-color-mix.png -->
-
-> _Image placeholder:_ Add `docs/non-ai-research/img/active-color-mix.png` showing the active color mixing swatches and restore an image embed later.
+<figure>
+  <img src="img/active-color-mix.svg" alt="Overlapping color circles with an arrow indicating pigment pickup." />
+  <figcaption>Active color mixing brushes blend pigment as they lay down new strokes.</figcaption>
+</figure>
 
 ### Mastering Lost-and-Found Edges
 
@@ -375,17 +394,19 @@ an object casts a shadow onto another, or where there is an abrupt change in a f
 create these crisp edges, the artist should use opaque, non-blending brushes like the default G-pen
 or a custom brush like the Flat Ribbon Horizontal.
 
-<!-- image: docs/non-ai-research/img/hard-edge-demo.png -->
-
-> _Image placeholder:_ Add `docs/non-ai-research/img/hard-edge-demo.png` illustrating the hard edge separation before reinstating the image.
+<figure>
+  <img src="img/hard-edge-demo.svg" alt="Three vertical panels with crisp dividers showing hard edge separation." />
+  <figcaption>Hard edges enforce clear boundaries between adjacent shapes.</figcaption>
+</figure>
 
 **Soft Edges:** A soft edge indicates a gradual turning of a form away from the light source, such
 as the rounded edge of a sphere or a cheekbone. These smooth transitions are best created using the
 Soft Airbrush or by gently using one of the tools from the Blend palette.
 
-<!-- image: docs/non-ai-research/img/soft-edge-demo.png -->
-
-> _Image placeholder:_ Add `docs/non-ai-research/img/soft-edge-demo.png` capturing the soft edge gradient and replace this text with the final figure when ready.
+<figure>
+  <img src="img/soft-edge-demo.svg" alt="Glowing circular gradients fading into the background." />
+  <figcaption>Soft edges gently transition values to turn forms.</figcaption>
+</figure>
 
 **Textured (Lost) Edges:** The most characteristic painterly edge is the "lost" edge, where a form
 seems to subtly dissolve into its surroundings. This effect is achieved by using brushes that have
@@ -393,9 +414,10 @@ both texture and Color Mixing enabled. As the brush moves from one color area to
 and mixes the pigments, creating a broken, textured transition that is neither perfectly hard nor
 perfectly soft.
 
-<!-- image: docs/non-ai-research/img/textured-edge-demo.png -->
-
-> _Image placeholder:_ Add `docs/non-ai-research/img/textured-edge-demo.png` demonstrating the textured lost edge transition, then restore the Markdown image later.
+<figure>
+  <img src="img/textured-edge-demo.svg" alt="Layered brush passes dissolving into speckled texture on one side." />
+  <figcaption>Textured edges dissolve into the background for lost-and-found transitions.</figcaption>
+</figure>
 
 ### Applying Global Textures for Unification
 


### PR DESCRIPTION
## Summary
- add fourteen lightweight SVG diagrams illustrating brush behavior, blending tools, and edge handling in the painterly Clip Studio Paint guide
- replace placeholder callouts with accessible figure markup and document how to swap the new SVGs for future PNG captures

## Testing
- `mkdocs serve --no-livereload --watch-theme`


------
https://chatgpt.com/codex/tasks/task_e_68de868e0bb083269d1badd6849a36e6