### PR TITLE
Add nav entry for Roses of Heliogabalus study

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - From Qualia to Simulacra: non-ai-research/from-qualia-to-simulacra.md
       - High-Level Intelligence Qualia Atlas: non-ai-research/high-level-intelligence-qualia-atlas.md
       - Notable Figures: non-ai-research/inspiring-figures.md
+      - Roses of Heliogabalus Study: non-ai-research/roses-of-heliogabalus-art-historical-study.md
       - Overview: non-ai-research/index.md
       - "The Anti-Fragile Studio: An Operational Playbook for the Neurodivergent Artist": non-ai-research/anti-fragile-studio.md
       - "Anti-Fragile Studio Boundary Playbook": non-ai-research/anti-fragile-studio-boundary-playbook.md


### PR DESCRIPTION
## Summary
- add the "Roses of Heliogabalus Study" page to the Non-AI Research navigation section

## Testing
- mkdocs build *(fails: ModuleNotFoundError: No module named 'pymdownx.copybutton')*

------
https://chatgpt.com/codex/tasks/task_e_68de913caea883269d25fbe3c547c0e8