### PR TITLE
Add metadata front matter to non-AI research templates

### DIFF
--- a/docs/non-ai-research/img/README.md
+++ b/docs/non-ai-research/img/README.md
@@ -1,3 +1,13 @@
+---
+title: "Painterly Brush Effect Image Checklist"
+tags:
+  - asset-guide
+  - art
+  - workflow
+project: docs-hub
+updated: 2025-10-02
+---
+
 # Painterly Brush Effect Image Checklist
 
 The **painterly-style-clip-studio-paint.md** guide references PNG assets that live beside this

--- a/docs/non-ai-research/templates/anti-fragile-studio-dashboard.md
+++ b/docs/non-ai-research/templates/anti-fragile-studio-dashboard.md
@@ -1,3 +1,13 @@
+---
+title: "Anti-Fragile Studio Dashboard Template"
+tags:
+  - template
+  - workflow
+  - studio-management
+project: docs-hub
+updated: 2025-10-02
+---
+
 # Anti-Fragile Studio Dashboard Template
 
 Use this board to externalise your commission pipeline and keep weekly maintenance lightweight. The structure below mirrors the workflow described in the playbook and can be recreated in any kanban-capable tool.

--- a/docs/non-ai-research/templates/artist-attention-scorecard.md
+++ b/docs/non-ai-research/templates/artist-attention-scorecard.md
@@ -1,3 +1,13 @@
+---
+title: "Artist Attention Scorecard Template"
+tags:
+  - template
+  - art
+  - attention
+project: docs-hub
+updated: 2025-10-02
+---
+
 # Artist Attention Scorecard Template
 
 Use this printable sheet to record the leading indicators described in the field guide without needing to reformat the table every session. Print the table directly from MkDocs or copy it into the note-taking app of your choice for digital tracking.

--- a/docs/non-ai-research/templates/attention-checklist-card.md
+++ b/docs/non-ai-research/templates/attention-checklist-card.md
@@ -1,5 +1,11 @@
 ---
 title: "Attention Checkpoint Card"
+tags:
+  - template
+  - attention
+  - workflow
+project: docs-hub
+updated: 2025-10-02
 ---
 
 # Attention Checkpoint Card


### PR DESCRIPTION
## Summary
- add YAML front matter to artist attention scorecard, studio dashboard, and image checklist docs
- extend the attention checklist card metadata to include tags, project, and updated date

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68de913bebb88326aa4462dcbfb3093c