### PR TITLE
Format Elagabalus banquet briefing for GitHub

### DIFF
--- a/docs/non-ai-research/flower-suffocation-banquet-of-emperor-elagabalus.md
+++ b/docs/non-ai-research/flower-suffocation-banquet-of-emperor-elagabalus.md
@@ -1,0 +1,135 @@
+---
+title: "The Flower-Suffocation Banquet of Emperor Elagabalus"
+tags: [roman-history, decadence, research]
+project: docs-hub
+updated: 2025-10-07
+---
+
+--8<-- "_snippets/disclaimer.md"
+
+[[toc]]
+
+# Abstract
+
+The _Historia Augusta_ preserves a lurid anecdote in which the Roman emperor
+Elagabalus smothers banquet guests beneath a manufactured storm of flower
+petals. This briefing assembles the literary evidence behind the story,
+compares it with near-contemporary accounts from Cassius Dio and Herodian, and
+traces the motif's later migration into Victorian art—especially Lawrence
+Alma-Tadema's celebrated _The Roses of Heliogabalus_. While the episode's
+historicity remains doubtful, its narrative power illustrates how Roman authors
+and later interpreters weaponised luxury to critique political and moral
+excess.
+
+# Source Overview and Reliability
+
+| Source                                          | Date            | Characterisation of Elagabalus                                                  | Notes                                                                                              |
+| ----------------------------------------------- | --------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| _Historia Augusta_, _Vita Heliogabali_ 21.5     | Late 4th c. CE  | Murderous prankster deploying mechanical ceilings to drown sycophants in petals | Written centuries after the reign; notorious for satire, forged documents, and invented anecdotes. |
+| Cassius Dio, _Roman History_ 80                 | Early 3rd c. CE | First-hand senatorial witness describing sexual excess, sacrilege, and cruelty  | Contemporary but fragmentary; moralising tone shaped by aristocratic outrage.                      |
+| Herodian, _History of the Empire_ 5.6–5.8       | Mid-3rd c. CE   | Emphasises religious extravagance, public spectacles that turned lethal         | Offers independent confirmation of fatal "generosity" without mentioning the petal episode.        |
+| Petronius, _Satyricon_ 60; Suetonius, _Nero_ 31 | 1st–2nd c. CE   | Precedent for banquet ceilings that release perfumes and flowers                | Demonstrates the literary motif the _Historia Augusta_ reworks into a deadly joke.                 |
+
+The _Historia Augusta_ author signals an intent to entertain as much as to
+inform, explicitly curating salacious tales to illustrate the emperor's
+"search after pleasures." Modern scholarship therefore treats the petal
+massacre as possible fiction, albeit one that reflects genuine anxieties about
+imperial decadence. Cassius Dio and Herodian corroborate the broader portrait of
+Elagabalus as dangerously extravagant even if they omit the flower prank itself.
+
+# The _Historia Augusta_'s Violet Avalanche
+
+The key passage (HA 21.5) situates the banquet among a catalogue of decadent
+practical jokes: Elagabalus, exploiting a reversible ceiling, releases such a
+volume of violets and assorted blooms that certain parasites—flatterers feeding
+off imperial favor—suffocate before they can claw to the surface. The author's
+choice of victims underscores the moral lesson: even sycophancy cannot guarantee
+safety in a court governed by whim. The scene reads like a grotesque farce,
+invoking earlier literary ceilings but pushing their delights into lethal
+excess.
+
+## Literary Signals of Invention
+
+- **Parasitic victims.** The Greek loanword _parasitoi_ frames the guests as
+  professional flatterers whose comeuppance will amuse readers familiar with
+  comic tropes.
+- **Catalogue structure.** The story follows menus dyed unnatural colours,
+  legumes studded with gold, and similar tall tales, highlighting its role as a
+  satirical crescendo rather than a sober report.
+- **Intertextual footnotes.** Later commentators—and even HA marginalia—point to
+  Nero's revolving dining rooms and Trimalchio's trick ceiling, signalling that
+  the author is riffing on an established topos of luxury architecture.
+
+# Cassius Dio: Excess Without Petals
+
+Cassius Dio's senatorial chronicle never mentions suffocating flowers, yet it
+unflinchingly documents Elagabalus' appetite for sensational pleasures. Dio
+casts the emperor as "living most licentiously from first to last," staging
+public brothel performances within the palace and boasting about earnings from
+sex work. The historian's focus on taboo-breaking sexuality and religious
+profanation—marrying a Vestal Virgin, elevating the Syrian sun-god Elagabal above
+Jupiter—reinforces the message that indulgence becomes dangerous when wielded by
+an autocrat.
+
+Dio also records moments of personal cruelty, such as the emperor murdering his
+own advisor Gannys and executing critics. These episodes lend plausibility to
+tales of lethal banquets even if Dio never heard (or believed) the flower
+anecdote itself.
+
+# Herodian: Religious Spectacle Turned Deadly
+
+Herodian, writing in Greek a generation later, provides a complementary view. He
+focuses on Elagabalus' theatrical religious processions, where the emperor
+showered crowds with lavish gifts hurled from towering platforms. The resulting
+stampedes left spectators impaled on soldiers' spears or crushed underfoot—an
+ominous parallel to guests buried beneath petals. Herodian's account affirms the
+core pattern: imperial generosity staged as performance can rapidly become
+mortal peril for subjects trapped within the spectacle.
+
+# Earlier Flower Ceilings: Petronius and Nero
+
+Petronius' _Satyricon_ satirises the freedman Trimalchio, whose dining room
+ceiling parts to lower scented garlands and gifts, while Suetonius credits Nero's
+Golden House with revolving panels that dust diners in blossoms and perfume. The
+_Historia Augusta_ thus adapts an existing symbol of indulgent hospitality and
+weaponises it. By transforming decorative petals into a suffocating deluge, the
+late antique author literalises the fear that uncontrolled luxury smothers the
+body politic.
+
+# Victorian Reception and Alma-Tadema's Roses
+
+Victorian writers and artists revived the anecdote as a parable of decadent
+collapse. Lawrence Alma-Tadema's 1888 canvas _The Roses of Heliogabalus_ swaps
+the HA's violets for pink roses associated in Victorian floriography with sensual
+lust. The painting's meticulous realism—achieved by importing weekly shipments
+of Riviera roses in winter—juxtaposes intoxicating beauty with visible terror on
+its suffocating guests. Figures like the pomegranate-clutching woman at the
+foreground stare directly at viewers, implicating them in the pleasures and
+perils of watching decadence unfold.
+
+This reinterpretation cemented the anecdote in the modern imagination, even as
+historians continued to question its factual basis. Alma-Tadema's image
+popularised the idea that beauty itself, when engineered for spectacle, can
+become a lethal weapon—a motif that originates with the _Historia Augusta's_
+dark punchline.
+
+# Assessment: Legend, Motif, or Memory?
+
+The convergence of late antique satire, contemporary moral invective, and later
+artistic elaboration suggests the flower banquet functions more as cultural
+symbol than archival fact. Yet the tale persistently refracts genuine concerns:
+mechanised ceilings advertised an emperor's engineering might, while massed
+petals (or coins, or animals) falling from above dramatise how unchecked power
+turns pleasures deadly. Whether the episode occurred is ultimately less
+important than the way successive generations mobilised it to critique tyranny,
+hedonism, and the fragility of social hierarchies under spectacle.
+
+# Further Reading
+
+- _Historia Augusta_, _Vita Heliogabali_ 21.5.
+- Cassius Dio, _Roman History_ 80.
+- Herodian, _History of the Empire_ 5.6–5.8.
+- Petronius, _Satyricon_ 60.
+- Suetonius, _Nero_ 31.
+- Lawrence Alma-Tadema, _The Roses of Heliogabalus_ (1888) and modern analyses
+  by Naura Nadhira (2022) and Annikka Olsen (2025).

--- a/docs/non-ai-research/index.md
+++ b/docs/non-ai-research/index.md
@@ -27,7 +27,6 @@ Short, actionable approaches for personal efficiency and time management.
 - [The Artist's Field Guide to Attention & Energy](artists-field-guide-attention-energy.md) maps ADHD-aware session design that channels flow while preventing burnout.
 - [The Anti-Fragile Studio](anti-fragile-studio.md) operationalises contracts, pricing, and dashboards so neurodivergent artists can run commission pipelines without burnout.
 
-
 ## Corporate Studies
 
 Insights into organizational behavior, power, and corporate evolution.
@@ -80,10 +79,14 @@ Interdisciplinary explorations across science, philosophy, and culture.
 - [Painterly Style in Clip Studio Paint](painterly-style-clip-studio-paint.md)
   focuses on painterly brush workflows for Clip Studio users and outlines
   expressive digital painting techniques.
-- [An Art-Historical Study of Lawrence Alma-Tadema's *The Roses of
-  Heliogabalus*](roses-of-heliogabalus-art-historical-study.md) examines how
+- [An Art-Historical Study of Lawrence Alma-Tadema's _The Roses of
+  Heliogabalus_](roses-of-heliogabalus-art-historical-study.md) examines how
   Victorian academic painting weaponized beauty, traces the work's reception,
   and extracts lessons for contemporary digital artists.
+- [The Flower-Suffocation Banquet of Emperor Elagabalus](flower-suffocation-
+  banquet-of-emperor-elagabalus.md) surveys the anecdote's late antique sources,
+  contemporary historiography, and Victorian reinterpretations to map how a
+  lethal cascade of petals became a symbol of imperial decadence.
 - [Composition 101 — Chaptered Intro](composition-101-chaptered-intro.md)
   offers a guided path through scene-building fundamentals and distills
   classical and modern composition frameworks into linked chapters for fast


### PR DESCRIPTION
## Summary
- run Prettier on the Elagabalus flower-banquet briefing to normalize italics, tables, and spacing for GitHub rendering
- reformat the non-AI research index entry so the new study link wraps cleanly with consistent typography

## Testing
- no tests were run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dfddd81608832688d04088ad8231b1